### PR TITLE
emit a final BuildImageMessage that indicates build success

### DIFF
--- a/cluster/calcium/build_image.go
+++ b/cluster/calcium/build_image.go
@@ -217,7 +217,7 @@ func (c *calcium) BuildImage(ctx context.Context, opts *types.BuildOptions) (cha
 			}
 		}()
 
-		ch <- &types.BuildImageMessage{Stream: fmt.Sprintf("finished %s\n", tag)}
+		ch <- &types.BuildImageMessage{Stream: fmt.Sprintf("finished %s\n", tag), Status: "finished", Progress: tag}
 	}()
 
 	return ch, nil


### PR DESCRIPTION
以前 build 结束是可以通过 build message 的 status 字段确定的, 然后约定这条信息的 progress 字段就是 image tag, 有这样一个约定总比去解析 "finished [image tag]" 要更安全.

因此希望恢复这个传统.