### PR TITLE
fix unittest

### DIFF
--- a/scheduler/complex/potassium_test.go
+++ b/scheduler/complex/potassium_test.go
@@ -1243,8 +1243,6 @@ func TestSelectVolumeNodesNonAuto(t *testing.T) {
 		"/data0:/data:rw",
 		"/data0:/data",
 	}
-	_, _, err := SelectVolumeNodes(k, nodes, []string{"AUTO:/tmp:rw:abc"}, 2, true)
-	assert.Error(t, err)
 	res, changed, err := SelectVolumeNodes(k, nodes, volumes, 2, true)
 	assert.NoError(t, err)
 	assert.Equal(t, len(res["0"]), 2)


### PR DESCRIPTION
错误格式的 volume string 在 rpc 层做转化的时候直接报错返回了, 所以不可能在 schedule 发生这种事情.. 删掉测试

https://github.com/projecteru2/core/blob/master/rpc/transform.go#L246