### PR TITLE
bugfix: rollback node resource on failure of creating container

### DIFF
--- a/cluster/calcium/create.go
+++ b/cluster/calcium/create.go
@@ -188,7 +188,7 @@ func (c *Calcium) doCreateAndStartContainer(
 		createContainerMessage.Error = err
 		if err != nil && container.ID != "" {
 			if err := c.doRemoveContainer(context.Background(), container, true); err != nil {
-				log.Errorf("[doCreateAndStartContainer] create and start container failed, and remove it failed also %v", err)
+				log.Errorf("[doCreateAndStartContainer] create and start container failed, and remove it failed also, %s, %v", container.ID, err)
 				return
 			}
 			createContainerMessage.ContainerID = ""
@@ -208,7 +208,6 @@ func (c *Calcium) doCreateAndStartContainer(
 		return createContainerMessage
 	}
 	container.ID = containerCreated.ID
-	createContainerMessage.ContainerID = containerCreated.ID
 
 	// Copy data to container
 	if len(opts.Data) > 0 {
@@ -256,6 +255,8 @@ func (c *Calcium) doCreateAndStartContainer(
 	if err = c.store.AddContainer(ctx, container); err != nil {
 		return createContainerMessage
 	}
+	// non-empty message.ContainerID signals that "core saves metadata of this container"
+	createContainerMessage.ContainerID = containerCreated.ID
 
 	return createContainerMessage
 }


### PR DESCRIPTION
这个 bug 还是比较难主动发现的.

复现步骤: 

1. `doCreateAndStartContainer` 的最后一步 `c.store.AddContainer(ctx, container)` 让 ctx 超时
2. `doCreateAndStartContainer` 的 defer 里让 `c.doRemoveContainer(ctx, container)` 超时

原因:

上面两步失败后, 返回的 createContainerMessage.ContainerID 是非空的, 上层拿到 message 后不会调用 updateNodeResource 去 reset node resource, 然而这是不对的.

`createContainerMessage.ContainerID` 非空的语义应该是指 `core 保存有这个 ID 的元数据`, 所以才不 reset node resource, 但是在这种场景下, 虽然 `removeContainer` 失败导致 Message.ContainerID 非空, 但是 core 从一开始就没保存元数据, 因为一开始 AddContainer 就失败了, 这时候上层不 reset node resource 就会出现不一致.

我感觉还是需要把所有的情况测一下, 在不同的地方 ctx 超时会出现不一样的问题, 肉眼真的不好查