### PR TITLE
bugfix: pull image context cancelled

### DIFF
--- a/cluster/calcium/helper.go
+++ b/cluster/calcium/helper.go
@@ -98,9 +98,13 @@ func pullImage(ctx context.Context, node *types.Node, image string) error {
 	}
 
 	log.Info("[pullImage] Image not cached, pulling")
-	if _, err = node.Engine.ImagePull(ctx, image, false); err != nil {
+	ch, err := node.Engine.ImagePull(ctx, image, false)
+	if err != nil {
 		log.Errorf("[pullImage] Error during pulling image %s: %v", image, err)
 		return err
+	}
+	// waiting for pull completion
+	for range ch {
 	}
 	log.Infof("[pullImage] Done pulling image %s", image)
 	return nil

--- a/engine/docker/helper.go
+++ b/engine/docker/helper.go
@@ -279,10 +279,15 @@ func dumpFromString(ca, cert, key *os.File, caStr, certStr, keyStr string) error
 }
 
 func parseDockerImageMessages(reader io.ReadCloser) chan *enginetypes.ImageMessage {
+	if reader == nil {
+		return nil
+	}
 	ch := make(chan *enginetypes.ImageMessage)
 	go func() {
 		defer func() {
-			_, _ = io.Copy(ioutil.Discard, reader)
+			if _, err := io.Copy(ioutil.Discard, reader); err != nil {
+				log.Errorf("[parseDockerImageMessages] io.Copy image stream failed: %+v", err)
+			}
 			reader.Close()
 			close(ch)
 		}()


### PR DESCRIPTION
其实有三个 bug:

1. decorator 返回就把 context cancel 了
2. calcium 调用 ImagePull 之后没有等带 pull 完成
3. reader 在 pull 失败的时候为 nil, 之前没处理会导致 panic