### PR TITLE
improve resource managements on replace and realloc

### DIFF
--- a/cluster/calcium/realloc_test.go
+++ b/cluster/calcium/realloc_test.go
@@ -2,8 +2,9 @@ package calcium
 
 import (
 	"context"
-	complexscheduler "github.com/projecteru2/core/scheduler/complex"
 	"testing"
+
+	complexscheduler "github.com/projecteru2/core/scheduler/complex"
 
 	"github.com/stretchr/testify/assert"
 
@@ -135,6 +136,7 @@ func TestRealloc(t *testing.T) {
 	simpleMockScheduler.On("SelectCPUNodes", mock.Anything, mock.Anything, mock.Anything).Return(nil, nodeCPUPlans, 2, nil).Times(5)
 	// failed by apply resource
 	engine.On("VirtualizationUpdateResource", mock.Anything, mock.Anything, mock.Anything).Return(types.ErrBadContainerID).Twice()
+	store.On("UpdateContainer", mock.Anything, mock.Anything).Return(nil).Twice()
 	// update node failed
 	store.On("UpdateNode", mock.Anything, mock.Anything).Return(types.ErrNoETCD).Once()
 	// reset node

--- a/cluster/calcium/replace.go
+++ b/cluster/calcium/replace.go
@@ -156,9 +156,9 @@ func (c *Calcium) doReplaceContainer(
 				},
 				// rollback
 				func(ctx context.Context) (err error) {
-					if createMessage.ContainerID != "" {
+					if createMessage.Error != nil && createMessage.ContainerID != "" {
 						log.Warnf("[doReplaceContainer] Create container failed and metadata remained: %+v", createMessage.Error)
-					} else {
+					} else if createMessage.Error != nil && createMessage.ContainerID == "" {
 						log.Warnf("[doReplaceContainer] Create container failed and metadata cleaned, reset node resource: %+v", createMessage.Error)
 						if err = c.withNodeLocked(ctx, node.Name, func(node *types.Node) error {
 							return c.store.UpdateNodeResource(ctx, node, createMessage.CPU, createMessage.Quota, createMessage.Memory, createMessage.Storage, createMessage.VolumePlan.IntoVolumeMap(), store.ActionIncr)

--- a/cluster/calcium/replace_test.go
+++ b/cluster/calcium/replace_test.go
@@ -134,6 +134,7 @@ func TestReplaceContainer(t *testing.T) {
 	// failed by VirtualizationCreate
 	engine.On("VirtualizationCreate", mock.Anything, mock.Anything).Return(nil, types.ErrCannotGetEngine).Once()
 	engine.On("VirtualizationStart", mock.Anything, mock.Anything).Return(types.ErrCannotGetEngine).Once()
+	store.On("UpdateNodeResource", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 	ch, err = c.ReplaceContainer(ctx, opts)
 	assert.NoError(t, err)
 	for r := range ch {


### PR DESCRIPTION
1. 正确回滚 doCreateAndStartContainer: `msg.Err != nil && msg.ContainerID == ""` 的时候需要 reset node resource
2. UpdateContainerResource 失败的时候依然进行内存计算