### PR TITLE
introduce ReaderManager to address race condition in smaller critical

### DIFF
--- a/cluster/calcium/replace.go
+++ b/cluster/calcium/replace.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"sync"
 
 	"github.com/projecteru2/core/store"
@@ -121,11 +120,9 @@ func (c *Calcium) doReplaceContainer(
 		if err != nil {
 			return nil, removeMessage, err
 		}
-		bs, err := ioutil.ReadAll(stream)
-		if err != nil {
+		if opts.DeployOptions.Data[dst], err = types.NewReaderManager(stream); err != nil {
 			return nil, removeMessage, err
 		}
-		opts.DeployOptions.Data[dst] = bytes.NewReader(bs)
 	}
 
 	createMessage := &types.CreateContainerMessage{}

--- a/cluster/calcium/replace_test.go
+++ b/cluster/calcium/replace_test.go
@@ -119,7 +119,7 @@ func TestReplaceContainer(t *testing.T) {
 		assert.False(t, r.Remove.Success)
 	}
 	engine.On("VirtualizationCopyFrom", mock.Anything, mock.Anything, mock.Anything).Return(ioutil.NopCloser(bytes.NewReader([]byte{})), "", nil)
-	opts.DeployOptions.Data = map[string]*bytes.Reader{}
+	opts.DeployOptions.Data = map[string]types.ReaderManager{}
 	// failed by Stop
 	engine.On("VirtualizationStop", mock.Anything, mock.Anything).Return(types.ErrCannotGetEngine).Once()
 	engine.On("VirtualizationStart", mock.Anything, mock.Anything).Return(types.ErrCannotGetEngine).Once()

--- a/rpc/transform.go
+++ b/rpc/transform.go
@@ -262,9 +262,11 @@ func toCoreDeployOptions(d *pb.DeployOptions) (*types.DeployOptions, error) {
 		return nil, err
 	}
 
-	data := map[string]*bytes.Reader{}
+	data := map[string]types.ReaderManager{}
 	for filename, bs := range d.Data {
-		data[filename] = bytes.NewReader(bs)
+		if data[filename], err = types.NewReaderManager(bytes.NewBuffer(bs)); err != nil {
+			return nil, err
+		}
 	}
 
 	return &types.DeployOptions{


### PR DESCRIPTION
解决了三点:

1. 可以对 DeployOptions 进行浅拷贝, mutex 在 DeployOptions 的 map 的值里, 值是一个 interface, map 和 interface 都是引用类型, 浅拷贝传递引用
2. 临界区 (critical section) 更小, 上一个 PR 里一个 mutex 管理所有 send file, 这是不准确的做法, 应该是一个 file 一个 mutex
3. mutex 被封装在 ReaderManager 里了, 不暴露 mutex 是更好的