### PR TITLE
you can't remove a node with associated workloads now

### DIFF
--- a/cluster/calcium/node.go
+++ b/cluster/calcium/node.go
@@ -17,6 +17,13 @@ func (c *Calcium) AddNode(ctx context.Context, opts *types.AddNodeOptions) (*typ
 // RemoveNode remove a node
 func (c *Calcium) RemoveNode(ctx context.Context, nodename string) error {
 	return c.withNodeLocked(ctx, nodename, func(node *types.Node) error {
+		ws, err := c.ListNodeWorkloads(ctx, node.Name, nil)
+		if err != nil {
+			return err
+		}
+		if len(ws) > 0 {
+			return types.ErrNodeNotEmpty
+		}
 		return c.store.RemoveNode(ctx, node)
 	})
 }

--- a/types/errors.go
+++ b/types/errors.go
@@ -23,8 +23,9 @@ var (
 
 	ErrZeroNodes = errors.New("no nodes provide to choose some")
 
-	ErrNodeFormat = errors.New("bad endpoint name")
-	ErrNodeExist  = errors.New("node already exists")
+	ErrNodeFormat   = errors.New("bad endpoint name")
+	ErrNodeExist    = errors.New("node already exists")
+	ErrNodeNotEmpty = errors.New("node not empty, still has workloads associated")
 
 	ErrKeyIsDir    = errors.New("key is a directory")
 	ErrKeyIsNotDir = errors.New("key is not a directory")


### PR DESCRIPTION
`store` will not do this check since store is only in charge of storage, check should be handled by `cluster`