### PR TITLE
improve scheduler getFullResult

### DIFF
--- a/scheduler/complex/cpu_test.go
+++ b/scheduler/complex/cpu_test.go
@@ -235,3 +235,28 @@ func TestCPUReallocWithPriorPlan(t *testing.T) {
 	_, _, _, err = po.ReselectCPUNodes(scheduleInfo, CPU, 2, 0)
 	assert.EqualError(t, err, "not enough resource")
 }
+
+func TestGetFullResult(t *testing.T) {
+	h := host{share: 100}
+	res := h.getFullResult(2, []resourceInfo{
+		{
+			id:     "0",
+			pieces: 400,
+		},
+		{
+			id:     "1",
+			pieces: 200,
+		},
+		{
+			id:     "2",
+			pieces: 400,
+		},
+	})
+	assert.EqualValues(t, 4, len(res))
+	assert.ElementsMatch(t, res, []types.ResourceMap{
+		{"0": 100, "1": 100},
+		{"0": 100, "1": 100},
+		{"0": 100, "2": 100},
+		{"0": 100, "2": 100},
+	})
+}

--- a/scheduler/complex/resource.go
+++ b/scheduler/complex/resource.go
@@ -183,7 +183,7 @@ func (h *host) getFragmentsResult(resources []resourceInfo, fragments ...int64) 
 
 func (h *host) getFullResult(full int, resources []resourceInfo) []types.ResourceMap {
 	result := []types.ResourceMap{}
-	count := len(resources) / full
+	count, rem := len(resources)/full, len(resources)%full
 	newResources := []resourceInfo{}
 	for i := 0; i < count; i++ {
 		plan := types.ResourceMap{}
@@ -198,6 +198,7 @@ func (h *host) getFullResult(full int, resources []resourceInfo) []types.Resourc
 		result = append(result, plan)
 	}
 
+	newResources = append(newResources, resources[len(resources)-rem:]...)
 	if len(newResources)/full > 0 {
 		return append(result, h.getFullResult(full, newResources)...)
 	}


### PR DESCRIPTION
1. recursive -> loop
2. 更好的核分配

第二点的 test case 补充在测试里, 3 cpus 选 2 完整核, 之前的算法忽视了第三个 cpu, 小小的改进了一下, 把 `len(resources) % full` 的部分也加到下一轮的计算中.