### PR TITLE
Revert "workload id will be returned as the first message (#364)"

### DIFF
--- a/cluster/calcium/lambda.go
+++ b/cluster/calcium/lambda.go
@@ -54,13 +54,6 @@ func (c *Calcium) RunAndWait(ctx context.Context, opts *types.DeployOptions, inC
 			continue
 		}
 
-		// first message to indicate the workload id
-		runMsgCh <- &types.AttachWorkloadMessage{
-			WorkloadID:    message.WorkloadID,
-			Data:          []byte(""),
-			StdStreamType: types.Stdout,
-		}
-
 		lambda := func(message *types.CreateWorkloadMessage) {
 			defer func() {
 				if err := c.doRemoveWorkloadSync(context.Background(), []string{message.WorkloadID}); err != nil {


### PR DESCRIPTION
This reverts commit f87a4b0388d8f69956229d741fd1ecf23c404788.

will block since no one is reading