### PR TITLE
bugfix: doRemoveWorkload isn't for rollback of deploy

### DIFF
--- a/cluster/calcium/create.go
+++ b/cluster/calcium/create.go
@@ -357,7 +357,7 @@ func (c *Calcium) doDeployOneWorkload(
 			if workload.ID == "" {
 				return nil
 			}
-			return c.doRemoveWorkload(ctx, workload, true)
+			return workload.Remove(ctx, true)
 		},
 		c.config.GlobalTimeout,
 	)

--- a/cluster/calcium/create_test.go
+++ b/cluster/calcium/create_test.go
@@ -232,7 +232,6 @@ func TestCreateWorkloadTxn(t *testing.T) {
 	engine.On("ImageRemoteDigest", mock.Anything, mock.Anything).Return("", nil)
 	engine.On("VirtualizationCreate", mock.Anything, mock.Anything).Return(nil, errors.Wrap(context.DeadlineExceeded, "VirtualizationCreate")).Twice()
 	engine.On("VirtualizationRemove", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-	store.On("RemoveWorkload", mock.Anything, mock.Anything).Return(nil)
 	store.On("ListNodeWorkloads", mock.Anything, mock.Anything, mock.Anything).Return(nil, types.ErrNoETCD)
 	walCommitted = false
 	ch, err = c.CreateWorkload(ctx, opts)


### PR DESCRIPTION
When it comes to rollback phase of deploy, the metadata doesn't exist, leaving it not suitable for doRemoveWorkload