### PR TITLE
avoid concurrent map writes

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -26,33 +26,38 @@ func SetupLog(l string) error {
 	return nil
 }
 
-// Fields is identical to logrus.Fields
-type Fields log.Fields
+// Fields is a wrapper for logrus.Entry
+// we need to insert some sentry captures here
+type Fields struct {
+	e *log.Entry
+}
 
 // WithField .
 func (f Fields) WithField(key string, value interface{}) Fields {
-	f[key] = value
-	return f
+	e := f.e.WithField(key, value)
+	return Fields{e: e}
 }
 
 // Errorf sends sentry message
 func (f Fields) Errorf(format string, args ...interface{}) {
 	sentry.CaptureMessage(fmt.Sprintf(format, args...))
-	log.WithFields(log.Fields(f)).Errorf(format, args...)
+	f.e.Errorf(format, args...)
 }
 
 // Err is a decorator returning the argument
 func (f Fields) Err(err error) error {
 	if err != nil {
 		sentry.CaptureMessage(fmt.Sprintf("%+v", err))
-		log.WithFields(log.Fields(f)).Errorf("%+v", err)
+		f.e.Errorf("%+v", err)
 	}
 	return err
 }
 
 // WithField add kv into log entry
 func WithField(key string, value interface{}) Fields {
-	return Fields{key: value}
+	return Fields{
+		e: log.WithField(key, value),
+	}
 }
 
 // Error forwards to sentry


### PR DESCRIPTION
This `Fields` thing will be used in multiple goroutines, which may end up concurrent map writes, so why don't we just use `logrus.Entry`?

easily reproduce by

```
package main

import (
	"sync"

	"github.com/sirupsen/logrus"
)

type Fields logrus.Fields

// WithField .
func (f Fields) WithField(key string, value interface{}) Fields {
	f[key] = value
	return f
}

// Errorf sends sentry message
func (f Fields) Errorf(format string, args ...interface{}) {
	logrus.Info("sentry.CaptureMessage")
	logrus.WithFields(logrus.Fields(f)).Errorf(format, args...)
}

// Err is a decorator returning the argument
func (f Fields) Err(err error) error {
	if err != nil {
		logrus.Info("sentry.CaptureMessage")
		logrus.WithFields(logrus.Fields(f)).Errorf("%+v", err)
	}
	return err
}

// WithField add kv into log entry
func WithField(key string, value interface{}) Fields {
	return Fields{key: value}
}

func main() {
	l := WithField("key1", "1").WithField("key2", "2")

	wg := sync.WaitGroup{}
	for i := 0; i < 1000; i++ {
		wg.Add(1)
		go func(i int) {
			defer wg.Done()
			for k := i; k < i+1000; k++ {
				l.WithField("current i", i).WithField("current k", k).Errorf("prints %d", i)
			}
		}(i)
	}
	wg.Wait()
	l.WithField("key", "value").Errorf("error")
}

```