### PR TITLE
reduce unnecessary context.Background()

### DIFF
--- a/cluster/calcium/dissociate.go
+++ b/cluster/calcium/dissociate.go
@@ -57,7 +57,7 @@ func (c *Calcium) DissociateWorkload(ctx context.Context, ids []string) (chan *t
 					}
 					ch <- msg
 				}
-				c.doRemapResourceAndLog(context.Background(), logger, node)
+				c.doRemapResourceAndLog(logger, node)
 				return nil
 			}); err != nil {
 				logger.WithField("nodename", nodename).Errorf("failed to lock node: %+v", err)

--- a/cluster/calcium/lambda.go
+++ b/cluster/calcium/lambda.go
@@ -56,7 +56,7 @@ func (c *Calcium) RunAndWait(ctx context.Context, opts *types.DeployOptions, inC
 
 		lambda := func(message *types.CreateWorkloadMessage) {
 			defer func() {
-				if err := c.doRemoveWorkloadSync(context.Background(), []string{message.WorkloadID}); err != nil {
+				if err := c.doRemoveWorkloadSync(context.TODO(), []string{message.WorkloadID}); err != nil {
 					logger.Errorf("[RunAndWait] Remove lambda workload failed %+v", err)
 				} else {
 					log.Infof("[RunAndWait] Workload %s finished and removed", utils.ShortID(message.WorkloadID))

--- a/cluster/calcium/realloc.go
+++ b/cluster/calcium/realloc.go
@@ -101,7 +101,7 @@ func (c *Calcium) doReallocOnNode(ctx context.Context, nodename string, workload
 			return
 		}
 
-		c.doRemapResourceAndLog(context.Background(), log.WithField("Calcium", "doReallocOnNode"), node)
+		c.doRemapResourceAndLog(log.WithField("Calcium", "doReallocOnNode"), node)
 		return nil
 	})
 }

--- a/cluster/calcium/remove.go
+++ b/cluster/calcium/remove.go
@@ -66,7 +66,7 @@ func (c *Calcium) RemoveWorkload(ctx context.Context, ids []string, force bool, 
 						}
 						ch <- ret
 					}
-					c.doRemapResourceAndLog(context.Background(), logger, node)
+					c.doRemapResourceAndLog(logger, node)
 					return nil
 				}); err != nil {
 					logger.WithField("nodename", nodename).Errorf("failed to lock node: %+v", err)

--- a/cluster/calcium/replace.go
+++ b/cluster/calcium/replace.go
@@ -198,8 +198,8 @@ func (c *Calcium) doReplaceWorkload(
 		return createMessage, removeMessage, err
 	}
 
-	if err := c.withNodeLocked(ctx, node.Name, func(ctx context.Context, node *types.Node) error {
-		c.doRemapResourceAndLog(context.Background(), log.WithField("Calcium", "doReplaceWorkload"), node)
+	if err := c.withNodeLocked(ctx, node.Name, func(_ context.Context, node *types.Node) error {
+		c.doRemapResourceAndLog(log.WithField("Calcium", "doReplaceWorkload"), node)
 		return nil
 	}); err != nil {
 		log.Errorf("[replaceAndRemove] failed to lock node to remap: %v", err)

--- a/cluster/calcium/resource.go
+++ b/cluster/calcium/resource.go
@@ -186,8 +186,10 @@ func (c *Calcium) remapResource(ctx context.Context, node *types.Node) (ch <-cha
 	return ch, errors.WithStack(err)
 }
 
-func (c *Calcium) doRemapResourceAndLog(ctx context.Context, logger log.Fields, node *types.Node) {
+func (c *Calcium) doRemapResourceAndLog(logger log.Fields, node *types.Node) {
 	log.Debugf("[doRemapResourceAndLog] remap node %s", node.Name)
+	ctx, cancel := context.WithTimeout(context.Background(), c.config.GlobalTimeout)
+	defer cancel()
 	logger = logger.WithField("Calcium", "doRemapResourceAndLog").WithField("nodename", node.Name)
 	if ch, err := c.remapResource(ctx, node); logger.Err(err) == nil {
 		for msg := range ch {

--- a/cluster/calcium/resource_test.go
+++ b/cluster/calcium/resource_test.go
@@ -303,5 +303,5 @@ func TestRemapResource(t *testing.T) {
 	_, err := c.remapResource(context.Background(), node)
 	assert.Nil(t, err)
 
-	c.doRemapResourceAndLog(context.Background(), log.WithField("test", "zc"), node)
+	c.doRemapResourceAndLog(log.WithField("test", "zc"), node)
 }

--- a/discovery/helium/helium.go
+++ b/discovery/helium/helium.go
@@ -25,7 +25,7 @@ func New(config types.GRPCConfig, stor store.Store) *Helium {
 	h.config = config
 	h.stor = stor
 	h.Do(func() {
-		h.start(context.Background()) // rewrite ctx here, because this will run only once!
+		h.start(context.TODO()) // rewrite ctx here, because this will run only once!
 	})
 	return h
 }

--- a/engine/docker/container.go
+++ b/engine/docker/container.go
@@ -261,7 +261,7 @@ func (e *Engine) VirtualizationResourceRemap(ctx context.Context, opts *enginety
 	go func() {
 		defer close(ch)
 		for id, resource := range freeWorkloadResources {
-			pool.Go(func(id string, resource enginetypes.VirtualizationResource) func() {
+			pool.Go(ctx, func(id string, resource enginetypes.VirtualizationResource) func() {
 				return func() {
 					updateConfig := dockercontainer.UpdateConfig{Resources: dockercontainer.Resources{
 						CPUQuota:   int64(resource.Quota * float64(corecluster.CPUPeriodBase)),
@@ -277,7 +277,7 @@ func (e *Engine) VirtualizationResourceRemap(ctx context.Context, opts *enginety
 				}
 			}(id, resource))
 		}
-		pool.Wait()
+		pool.Wait(ctx)
 	}()
 
 	return ch, nil

--- a/lock/redis/lock.go
+++ b/lock/redis/lock.go
@@ -49,7 +49,9 @@ func New(cli *redis.Client, key string, waitTimeout, lockTTL time.Duration) (*Re
 // Lock acquires the lock
 // will try waitTimeout time before getting the lock
 func (r *RedisLock) Lock(ctx context.Context) (context.Context, error) {
-	return r.lock(ctx, opts)
+	lockCtx, cancel := context.WithTimeout(ctx, r.timeout)
+	defer cancel()
+	return r.lock(lockCtx, opts)
 }
 
 // TryLock tries to lock
@@ -66,7 +68,7 @@ func (r *RedisLock) lock(ctx context.Context, opts *redislock.Options) (context.
 	}
 
 	r.l = l
-	return context.Background(), nil
+	return context.TODO(), nil // no need wrapped, not like etcd
 }
 
 // Unlock releases the lock

--- a/store/redis/rediaron.go
+++ b/store/redis/rediaron.go
@@ -100,7 +100,9 @@ func (r *Rediaron) KNotify(ctx context.Context, pattern string) chan *KNotifyMes
 		for {
 			select {
 			case <-ctx.Done():
-				_ = pubsub.PUnsubscribe(context.Background(), channel)
+				ctx, cancel := context.WithTimeout(context.Background(), r.config.GlobalTimeout)
+				defer cancel()
+				_ = pubsub.PUnsubscribe(ctx, channel)
 				return
 			case v := <-subC:
 				if v == nil {

--- a/utils/gopool_test.go
+++ b/utils/gopool_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -11,11 +12,11 @@ func TestGoroutinePool(t *testing.T) {
 	pool := NewGoroutinePool(1)
 	cnt := 0
 	for i := 0; i < 3; i++ {
-		pool.Go(func() {
+		pool.Go(context.TODO(), func() {
 			time.Sleep(time.Duration(i) * 100 * time.Microsecond)
 			cnt++
 		})
 	}
-	pool.Wait()
+	pool.Wait(context.TODO())
 	assert.Equal(t, 3, cnt)
 }


### PR DESCRIPTION
1. use context.TODO replace context.Background if not sure how to cancel it
2. not modified wal implementation, @anrs can do
3. should consider carefully in create/realloc/replace
4. goroutine pool with ctx outside
5. removed context in doRemapResourceAndLog
6. ~~seems redis lock should return wrapped context like etcd lock @tonicbupt~~