### PR TITLE
Return error for txn condition not succeeded

### DIFF
--- a/store/etcdv3/node_test.go
+++ b/store/etcdv3/node_test.go
@@ -205,6 +205,8 @@ func TestUpdateNode(t *testing.T) {
 		},
 	}
 	assert.Error(t, m.UpdateNodes(ctx, fakeNode))
+	assert.Error(t, m.UpdateNodes(ctx, node), "ETCD Txn condition failed")
+	node.Available = false
 	assert.NoError(t, m.UpdateNodes(ctx, node))
 }
 

--- a/store/etcdv3/workload_test.go
+++ b/store/etcdv3/workload_test.go
@@ -36,6 +36,10 @@ func TestAddORUpdateWorkload(t *testing.T) {
 	assert.NoError(t, err)
 	// success updat
 	err = m.UpdateWorkload(ctx, workload)
+	assert.Error(t, err, "ETCD Txn condition failed")
+	// success updat
+	workload.Name = "test_app_2"
+	err = m.UpdateWorkload(ctx, workload)
 	assert.NoError(t, err)
 }
 

--- a/types/errors.go
+++ b/types/errors.go
@@ -66,10 +66,11 @@ var (
 	ErrRunAndWaitCountOneWithStdin = errors.New("Count must be 1 if OpenStdin is true")
 	ErrUnknownControlType          = errors.New("Unknown control type")
 
-	ErrNoETCD       = errors.New("ETCD must be set")
-	ErrKeyNotExists = errors.New("Key not exists")
-	ErrKeyExists    = errors.New("Key exists")
-	ErrNoOps        = errors.New("No txn ops")
+	ErrNoETCD             = errors.New("ETCD must be set")
+	ErrKeyNotExists       = errors.New("Key not exists")
+	ErrKeyExists          = errors.New("Key exists")
+	ErrNoOps              = errors.New("No txn ops")
+	ErrTxnConditionFailed = errors.New("ETCD Txn condition failed")
 
 	ErrNotSupport = errors.New("Not Support")
 	ErrSCMNotSet  = errors.New("SCM not set")


### PR DESCRIPTION
比如对 BatchUpdate 来说, 我们的 txn 是:
1. if 所有 key 都存在, 且不等于新 value
2. 则 put
3. 否则 get

所以对于业务调用方, 比如 UpdateWorkloads, 成功更新 workloads meta 和事务条件的成功与否强相关, 所以这个 pr 对 txn response.Succeed 做了判断.