### PR TITLE
Make batchupdate idempotent

### DIFF
--- a/store/etcdv3/meta/etcd.go
+++ b/store/etcdv3/meta/etcd.go
@@ -308,7 +308,7 @@ func (e *ETCD) Grant(ctx context.Context, ttl int64) (*clientv3.LeaseGrantRespon
 func (e *ETCD) batchUpdate(ctx context.Context, data map[string]string, opts ...clientv3.OpOption) (*clientv3.TxnResponse, error) {
 	limit := map[string]map[string]string{}
 	for key := range data {
-		limit[key] = map[string]string{cmpVersion: "!=", cmpValue: "!="} // ignore same data
+		limit[key] = map[string]string{cmpVersion: "!="}
 	}
 	resp, err := e.batchPut(ctx, data, limit, opts...)
 	if err != nil {

--- a/store/etcdv3/meta/etcd_test.go
+++ b/store/etcdv3/meta/etcd_test.go
@@ -326,7 +326,7 @@ func TestETCD(t *testing.T) {
 	require.True(t, r.Succeeded)
 	// UpdateFail
 	r, err = m.Update(ctx, "test/3", "b")
-	require.Error(t, err)
+	require.NoError(t, err)
 	require.False(t, r.Succeeded)
 	// BatchUpdate
 	data = map[string]string{
@@ -336,13 +336,13 @@ func TestETCD(t *testing.T) {
 	r, err = m.BatchUpdate(ctx, data)
 	require.NoError(t, err)
 	require.True(t, r.Succeeded)
-	// BatchUpdateFail
+	// BatchUpdate
 	data = map[string]string{
 		"k1": "c1",
 		"k3": "b2",
 	}
 	r, err = m.BatchUpdate(ctx, data)
-	require.Error(t, err)
+	require.NoError(t, err)
 	require.False(t, r.Succeeded)
 	// Watch
 	ctx2, cancel := context.WithCancel(ctx)

--- a/store/etcdv3/node_test.go
+++ b/store/etcdv3/node_test.go
@@ -205,7 +205,7 @@ func TestUpdateNode(t *testing.T) {
 		},
 	}
 	assert.Error(t, m.UpdateNodes(ctx, fakeNode))
-	assert.Error(t, m.UpdateNodes(ctx, node), "ETCD Txn condition failed")
+	assert.NoError(t, m.UpdateNodes(ctx, node))
 	node.Available = false
 	assert.NoError(t, m.UpdateNodes(ctx, node))
 }

--- a/store/etcdv3/workload_test.go
+++ b/store/etcdv3/workload_test.go
@@ -36,7 +36,7 @@ func TestAddORUpdateWorkload(t *testing.T) {
 	assert.NoError(t, err)
 	// success updat
 	err = m.UpdateWorkload(ctx, workload)
-	assert.Error(t, err, "ETCD Txn condition failed")
+	assert.NoError(t, err)
 	// success updat
 	workload.Name = "test_app_2"
 	err = m.UpdateWorkload(ctx, workload)


### PR DESCRIPTION
本质上要解决的问题依然是 `store.UpdateNodes(ctx, n1, n2)` 的时候, 如果 n1 数据有变但是 n2 没变的情况, 这个 pr 把检查数据变化的 txn 条件删除了, 让接口变得幂等.