### PR TITLE
fix race condition when TTL=0

### DIFF
--- a/store/etcdv3/meta/etcd_test.go
+++ b/store/etcdv3/meta/etcd_test.go
@@ -150,6 +150,7 @@ func TestBindStatusWithZeroTTL(t *testing.T) {
 	defer txn.AssertExpectations(t)
 	txn.On("If", mock.Anything).Return(txn).Once()
 	txn.On("Then", mock.Anything).Return(txn).Once()
+	txn.On("Else", mock.Anything).Return(txn).Once()
 	txn.On("Commit").Return(entityTxn, nil)
 
 	etcd.On("Txn", mock.Anything).Return(txn).Once()
@@ -189,7 +190,8 @@ func TestBindStatusButValueTxnUnsuccessful(t *testing.T) {
 	txn.On("Commit").Return(entityTxn, nil)
 
 	etcd.On("Txn", mock.Anything).Return(txn).Once()
-	require.Equal(t, nil, e.BindStatus(context.Background(), "/entity", "/status", "status", 0))
+	etcd.On("Grant", mock.Anything, mock.Anything).Return(&clientv3.LeaseGrantResponse{}, nil).Once()
+	require.Equal(t, nil, e.BindStatus(context.Background(), "/entity", "/status", "status", 1))
 }
 
 func TestBindStatus(t *testing.T) {


### PR DESCRIPTION
有这么一种 race: 在 core 创建容器的时候, 还没有把容器保存下来呢, agent 那边进程起来了, detect 到了, 开始报 status 了.
* 如果 TTL 不是 0, 那么 agent 会一直报, 前几次可能没有容器数据所以也没有成功写入 status, 但是之后总可以成功.
* 如果 TTL 是 0, 这是 agent 开启了 selfmon 模式, 那么第一次之后因为数据相同都不会尝试请求了, 而第一次尝试写入又是失败的, 这样这个容器除非 agent 重启, 否则永远没有 status 了.

考虑到以上, 觉得 TTL 为 0 的时候不需要去检测有没有 entity, 没有就没有吧... 多大点事... 毕竟这个事情不能在 agent 这改, agent 是尝试多少次好呢, 多少次都不行... 顺便, 有没有可能 cachecloud 拿个 IP 要半天就是因为这个, 那个集群里 120s 才能报一次呢, 如果第一次写失败, 下一次需要等两分钟...