### PR TITLE
[WIP] fix vet error

### DIFF
--- a/engine/docker/helper_test.go
+++ b/engine/docker/helper_test.go
@@ -29,7 +29,7 @@ func TestWithDumpFiles(t *testing.T) {
 	}
 	fp := []string{}
 	for target, content := range data {
-		withTarfileDump(context.TODO(), target, bytes.NewBuffer(content), func(target, tarfile string) error {
+		withTarfileDump(context.TODO(), target, content, 0, 0, 0, func(target, tarfile string) error {
 			assert.True(t, strings.HasPrefix(target, "/tmp/test"))
 			fp = append(fp, tarfile)
 			_, err := os.Stat(tarfile)


### PR DESCRIPTION
engine/docker下有两个test，其中有一个编译是通不过的，但是在make test的时候没有把他们包含在里面。

以及我发现github这个ci似乎有点奇怪，unit test里可能有若干个命令，但是只有最后一个命令报错的时候，才会导致ci报错。

比如现在unit test里有三步，分别是一个go vet和两个go test。第一个go vet和第一个go test报错都不会导致ci报错。有机会我想看看这个问题的原因是什么...