### PR TITLE
[SPVR-80] create workload metadata before starting workload

### DIFF
--- a/cluster/calcium/create_test.go
+++ b/cluster/calcium/create_test.go
@@ -149,6 +149,7 @@ func TestCreateWorkloadTxn(t *testing.T) {
 	store.On("MakeDeployStatus", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 		errors.Wrap(context.DeadlineExceeded, "MakeDeployStatus"),
 	).Once()
+	store.On("RemoveWorkload", mock.Anything, mock.Anything).Return(nil)
 
 	ch, err := c.CreateWorkload(ctx, opts)
 	assert.Nil(t, err)

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -615,6 +615,7 @@ func (v *Vibranium) CreateWorkload(opts *pb.DeployOptions, stream pb.CoreRPC_Cre
 		return grpcstatus.Error(CreateWorkload, err.Error())
 	}
 	for m := range ch {
+		log.Debugf(ctx, "[CreateWorkload] create workload message: %+v", m)
 		if err = stream.Send(toRPCCreateWorkloadMessage(m)); err != nil {
 			v.logUnsentMessages(ctx, "CreateWorkload", err, m)
 		}

--- a/store/etcdv3/meta/etcd.go
+++ b/store/etcdv3/meta/etcd.go
@@ -277,7 +277,7 @@ func (e *ETCD) bindStatusWithTTL(ctx context.Context, entityKey, statusKey, stat
 	// There isn't the entity kv pair.
 	if !entityTxn.Succeeded {
 		e.revokeLease(ctx, leaseID)
-		return nil
+		return types.ErrEntityNotExists
 	}
 
 	// There isn't a status bound to the entity.

--- a/store/etcdv3/meta/etcd_test.go
+++ b/store/etcdv3/meta/etcd_test.go
@@ -102,7 +102,7 @@ func TestBindStatusButEntityTxnUnsuccessful(t *testing.T) {
 
 	etcd.On("Grant", mock.Anything, mock.Anything).Return(&clientv3.LeaseGrantResponse{}, nil).Once()
 	etcd.On("Txn", mock.Anything).Return(txn).Once()
-	require.Equal(t, nil, e.BindStatus(context.Background(), "/entity", "/status", "status", 1))
+	require.Equal(t, types.ErrEntityNotExists, e.BindStatus(context.Background(), "/entity", "/status", "status", 1))
 }
 
 func TestBindStatusButStatusTxnUnsuccessful(t *testing.T) {

--- a/store/etcdv3/workload_test.go
+++ b/store/etcdv3/workload_test.go
@@ -153,7 +153,7 @@ func TestSetWorkloadStatus(t *testing.T) {
 	workload.StatusMeta.Nodename = "n1"
 	// no workload, err nil
 	err = m.SetWorkloadStatus(ctx, workload.StatusMeta, 10)
-	assert.NoError(t, err)
+	assert.Equal(t, err, types.ErrEntityNotExists)
 	assert.NoError(t, m.AddWorkload(ctx, workload, nil))
 	// no status key, put succ, err nil
 	err = m.SetWorkloadStatus(ctx, workload.StatusMeta, 10)

--- a/store/redis/rediaron.go
+++ b/store/redis/rediaron.go
@@ -272,10 +272,10 @@ func (r *Rediaron) BindStatus(ctx context.Context, entityKey, statusKey, statusV
 	if err != nil {
 		return err
 	}
-	// doesn't exist, returns nil, does nothing
+	// doesn't exist, returns error
 	// to behave just like etcd
 	if count != 1 {
-		return nil
+		return types.ErrEntityNotExists
 	}
 
 	_, err = r.cli.Set(ctx, statusKey, statusValue, time.Duration(ttl)*time.Second).Result()

--- a/store/redis/workload_test.go
+++ b/store/redis/workload_test.go
@@ -157,7 +157,7 @@ func (s *RediaronTestSuite) TestSetWorkloadStatus() {
 	workload.StatusMeta.Nodename = "n1"
 	// no workload, err nil
 	err = m.SetWorkloadStatus(ctx, workload.StatusMeta, 10)
-	s.NoError(err)
+	s.ErrorIs(err, types.ErrEntityNotExists)
 	s.NoError(m.AddWorkload(ctx, workload, nil))
 	// no status key, put succ, err nil
 	err = m.SetWorkloadStatus(ctx, workload.StatusMeta, 10)

--- a/types/errors.go
+++ b/types/errors.go
@@ -85,6 +85,7 @@ var (
 
 	ErrNodeNotExists     = errors.New("node not exists")
 	ErrWorkloadNotExists = errors.New("workload not exists")
+	ErrEntityNotExists   = errors.New("entity not exists")
 
 	ErrUnregisteredWALEventType = errors.New("unregistered WAL event type")
 	ErrInvalidWALBucket         = errors.New("invalid WAL bucket")


### PR DESCRIPTION
之前部署workload时，流程是：1. 启动workload 2. 将workload的metadata存储至ETCD中。

在这两步之间，存在一小段时间，这个workload已经启动，但是ETCD里还没有相关的数据。如果这段时间agent来上报workload状态，就会报错。

这个PR更改了部署workload的流程，变成：1. 写入metadata 2. 启动workload 3. 检查metadata是否需要变更，如果需要的话则update。