### PR TITLE
Fix build image from exist

### DIFF
--- a/cluster/calcium/build_test.go
+++ b/cluster/calcium/build_test.go
@@ -125,7 +125,7 @@ func TestBuild(t *testing.T) {
 	store.On("GetWorkload", mock.Anything, mock.Anything).Return(&types.Workload{Nodename: "123"}, nil)
 	store.On("GetNode", mock.Anything, mock.Anything).Return(&types.Node{Engine: engine}, nil)
 	ch, err = c.BuildImage(ctx, opts)
-	assert.NoError(t, err)
+	assert.EqualError(t, err, types.ErrEngineNotImplemented.Error())
 	// unknown build method
 	opts.BuildMethod = types.BuildFromUnknown
 	ch, err = c.BuildImage(ctx, opts)

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -30,7 +30,7 @@ type API interface {
 	ImageBuildCachePrune(ctx context.Context, all bool) (uint64, error)
 	ImageLocalDigests(ctx context.Context, image string) ([]string, error)
 	ImageRemoteDigest(ctx context.Context, image string) (string, error)
-	ImageBuildFromExist(ctx context.Context, ID, name, user string) (string, error)
+	ImageBuildFromExist(ctx context.Context, ID string, refs []string, user string) (string, error)
 
 	BuildRefs(ctx context.Context, name string, tags []string) []string
 	BuildContent(ctx context.Context, scm coresource.Source, opts *enginetypes.BuildContentOptions) (string, io.Reader, error)

--- a/engine/mocks/API.go
+++ b/engine/mocks/API.go
@@ -67,20 +67,20 @@ func (_m *API) BuildRefs(ctx context.Context, name string, tags []string) []stri
 	return r0
 }
 
-// ExecExitCode provides a mock function with given fields: ctx, ID, pid
-func (_m *API) ExecExitCode(ctx context.Context, ID string, pid string) (int, error) {
-	ret := _m.Called(ctx, ID, pid)
+// ExecExitCode provides a mock function with given fields: ctx, ID, result
+func (_m *API) ExecExitCode(ctx context.Context, ID string, result string) (int, error) {
+	ret := _m.Called(ctx, ID, result)
 
 	var r0 int
 	if rf, ok := ret.Get(0).(func(context.Context, string, string) int); ok {
-		r0 = rf(ctx, ID, pid)
+		r0 = rf(ctx, ID, result)
 	} else {
 		r0 = ret.Get(0).(int)
 	}
 
 	var r1 error
 	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
-		r1 = rf(ctx, ID, pid)
+		r1 = rf(ctx, ID, result)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -194,20 +194,20 @@ func (_m *API) ImageBuildCachePrune(ctx context.Context, all bool) (uint64, erro
 	return r0, r1
 }
 
-// ImageBuildFromExist provides a mock function with given fields: ctx, ID, name, user
-func (_m *API) ImageBuildFromExist(ctx context.Context, ID string, name string, user string) (string, error) {
-	ret := _m.Called(ctx, ID, name, user)
+// ImageBuildFromExist provides a mock function with given fields: ctx, ID, refs, user
+func (_m *API) ImageBuildFromExist(ctx context.Context, ID string, refs []string, user string) (string, error) {
+	ret := _m.Called(ctx, ID, refs, user)
 
 	var r0 string
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) string); ok {
-		r0 = rf(ctx, ID, name, user)
+	if rf, ok := ret.Get(0).(func(context.Context, string, []string, string) string); ok {
+		r0 = rf(ctx, ID, refs, user)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
-		r1 = rf(ctx, ID, name, user)
+	if rf, ok := ret.Get(1).(func(context.Context, string, []string, string) error); ok {
+		r1 = rf(ctx, ID, refs, user)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/engine/virt/image.go
+++ b/engine/virt/image.go
@@ -48,10 +48,14 @@ func (v *Virt) ImageBuild(ctx context.Context, input io.Reader, refs []string) (
 }
 
 // ImageBuildFromExist builds vm image from running vm
-func (v *Virt) ImageBuildFromExist(ctx context.Context, ID, name, user string) (string, error) {
+func (v *Virt) ImageBuildFromExist(ctx context.Context, ID string, names []string, user string) (string, error) {
 	if len(user) < 1 {
 		return "", types.ErrNoImageUser
 	}
+	if len(names) > 1 {
+		return "", types.ErrBadRefs
+	}
+	name := names[0]
 
 	// TODO: removes below 2 lines
 	// upper layer may remove 'hub.docker.io/...../<name>' prefix and tag from the name.

--- a/types/errors.go
+++ b/types/errors.go
@@ -55,6 +55,7 @@ var (
 	ErrInvaildUsername = errors.New("invaild username")
 	ErrNotFitLabels    = errors.New("not fit labels")
 
+	ErrBadRefs                     = errors.New("invalid image refs")
 	ErrNoImage                     = errors.New("no image")
 	ErrNoImageUser                 = errors.New("no image user")
 	ErrNoBuildPod                  = errors.New("No build pod set in config")


### PR DESCRIPTION
~~这个 PR 居然总计还减少了 3 行代码, 好耶.~~

1. BuildFromExist 这个 interface 居然只接受一个 tag, 改成接受多个 tags.
2. BuildFromExist 的 pushImage 操作居然在 engine 层实现的, 而其他两类 build (from raw/scm) 都是规规矩矩在 cluster 层去 push, 我给统一到 cluster 层了.