### PR TITLE
Cache runtime client in engine/factory module

### DIFF
--- a/engine/factory/factory.go
+++ b/engine/factory/factory.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/projecteru2/core/engine"
 	"github.com/projecteru2/core/engine/docker"
@@ -11,21 +12,35 @@ import (
 	"github.com/projecteru2/core/engine/systemd"
 	"github.com/projecteru2/core/engine/virt"
 	"github.com/projecteru2/core/types"
+	"github.com/projecteru2/core/utils"
 )
 
 type factory func(ctx context.Context, config types.Config, nodename, endpoint, ca, cert, key string) (engine.API, error)
 
-var engines = map[string]factory{
-	docker.TCPPrefixKey:  docker.MakeClient,
-	docker.SockPrefixKey: docker.MakeClient,
-	virt.HTTPPrefixKey:   virt.MakeClient,
-	virt.GRPCPrefixKey:   virt.MakeClient,
-	systemd.TCPPrefix:    systemd.MakeClient,
-	fakeengine.PrefixKey: fakeengine.MakeClient,
-}
+var (
+	engines = map[string]factory{
+		docker.TCPPrefixKey:  docker.MakeClient,
+		docker.SockPrefixKey: docker.MakeClient,
+		virt.HTTPPrefixKey:   virt.MakeClient,
+		virt.GRPCPrefixKey:   virt.MakeClient,
+		systemd.TCPPrefix:    systemd.MakeClient,
+		fakeengine.PrefixKey: fakeengine.MakeClient,
+	}
+	engineCache = utils.NewEngineCache(12*time.Hour, 10*time.Minute)
+)
 
 // GetEngine get engine
-func GetEngine(ctx context.Context, config types.Config, nodename, endpoint, ca, cert, key string) (engine.API, error) {
+func GetEngine(ctx context.Context, config types.Config, nodename, endpoint, ca, cert, key string) (client engine.API, err error) {
+	if client = engineCache.Get(endpoint); client != nil {
+		return
+	}
+
+	defer func() {
+		if err == nil && client != nil {
+			engineCache.Set(endpoint, client)
+		}
+	}()
+
 	prefix, err := getEnginePrefix(endpoint)
 	if err != nil {
 		return nil, err

--- a/store/etcdv3/mercury.go
+++ b/store/etcdv3/mercury.go
@@ -2,11 +2,9 @@ package etcdv3
 
 import (
 	"testing"
-	"time"
 
 	"github.com/projecteru2/core/store/etcdv3/meta"
 	"github.com/projecteru2/core/types"
-	"github.com/projecteru2/core/utils"
 )
 
 const (
@@ -39,5 +37,3 @@ func New(config types.Config, t *testing.T) (m *Mercury, err error) {
 	m.KV, err = meta.NewETCD(config.Etcd, t)
 	return
 }
-
-var _cache = utils.NewEngineCache(12*time.Hour, 10*time.Minute)

--- a/store/redis/rediaron.go
+++ b/store/redis/rediaron.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/projecteru2/core/log"
 	"github.com/projecteru2/core/types"
-	"github.com/projecteru2/core/utils"
 
 	"github.com/go-redis/redis/v8"
 	perrors "github.com/pkg/errors"
@@ -27,8 +26,6 @@ var (
 	// ErrKeyNotExitsts indicates no key found
 	// When do update, we need to ensure the key exists, just like the behavior of etcd client
 	ErrKeyNotExitsts = errors.New("[Redis exists] Key not exists")
-
-	_cache = utils.NewEngineCache(12*time.Hour, 10*time.Minute)
 )
 
 const (

--- a/utils/cache.go
+++ b/utils/cache.go
@@ -22,13 +22,13 @@ func NewEngineCache(expire time.Duration, cleanupInterval time.Duration) *Engine
 }
 
 // Set connection with host
-func (c *EngineCache) Set(host string, client engine.API) {
-	c.cache.Set(host, client, cache.DefaultExpiration)
+func (c *EngineCache) Set(endpoint string, client engine.API) {
+	c.cache.Set(endpoint, client, cache.DefaultExpiration)
 }
 
 // Get connection by host
-func (c *EngineCache) Get(host string) engine.API {
-	e, found := c.cache.Get(host)
+func (c *EngineCache) Get(endpoint string) engine.API {
+	e, found := c.cache.Get(endpoint)
 	if found {
 		return e.(engine.API)
 	}
@@ -36,6 +36,6 @@ func (c *EngineCache) Get(host string) engine.API {
 }
 
 // Delete connection by host
-func (c *EngineCache) Delete(host string) {
+func (c *EngineCache) Delete(host string, endpoint ...string) {
 	c.cache.Delete(host)
 }


### PR DESCRIPTION
1. 原来的 cache 逻辑在 store 实现里, 导致 redis / etcd store 都要重复实现, 给移到 engine/factory 模块下, 这样就 DIY 了
2. cache key 从 nodename 改成 endpoint, 这样如果更新了 node endpoint url 不会被脏数据污染
3. cached client 连接中断后也会自动重连, 毕竟智能 client...

又减少代码了, 好耶.