### PR TITLE
Close opened fd

### DIFF
--- a/engine/docker/container.go
+++ b/engine/docker/container.go
@@ -326,6 +326,7 @@ func (e *Engine) VirtualizationCopyTo(ctx context.Context, ID, target string, co
 		if err != nil {
 			return err
 		}
+		defer content.Close()
 		return e.client.CopyToContainer(ctx, ID, filepath.Dir(target), content, dockertypes.CopyToContainerOptions{AllowOverwriteDirWithFile: true, CopyUIDGID: false})
 	})
 }


### PR DESCRIPTION
实际操作和观察了一下, 其实好像并没有 fd 泄露, 这是因为 `newFile` 里注册了 `runtime.SetFinalizer(f.file, (*file).close)`, 所以会在 gc 的时候自动 close...

不过 explicit 肯定好于 implicit, 我还是加上.

源码可以看: [os/unix_file.go](https://golang.org/src/os/file_unix.go)