### PR TITLE
Remove pod must specify correct name

### DIFF
--- a/store/etcdv3/pod.go
+++ b/store/etcdv3/pod.go
@@ -39,8 +39,13 @@ func (m *Mercury) RemovePod(ctx context.Context, podname string) error {
 			fmt.Sprintf("pod %s still has %d nodes, delete them first", podname, l))
 	}
 
-	_, err = m.Delete(ctx, key)
-	return err
+	resp, err := m.Delete(ctx, key)
+	if err != nil {
+		return err
+	} else if resp.Deleted != 1 {
+		return types.NewDetailedErr(types.ErrPodNotFound, podname)
+	}
+	return nil
 }
 
 // GetPod get a pod from etcd

--- a/types/errors.go
+++ b/types/errors.go
@@ -46,6 +46,7 @@ var (
 
 	ErrPodHasNodes = errors.New("pod has nodes")
 	ErrPodNoNodes  = errors.New("pod has no nodes")
+	ErrPodNotFound = errors.New("pod not found")
 
 	ErrCannotGetEngine = errors.New("cannot get engine")
 	ErrNilEngine       = errors.New("engine is nil")


### PR DESCRIPTION
删除 pod 之前总是会返回成功, 会造成误导, 比如手滑输错 podname, 但是返回成功导致并没有意识到自己操作失败了, 所以还是改了改.