### PR TITLE
[SPVR-122] Node should be up instead of down after restarting eru-agent for node

### DIFF
--- a/cluster/calcium/node.go
+++ b/cluster/calcium/node.go
@@ -73,6 +73,12 @@ func (c *Calcium) SetNode(ctx context.Context, opts *types.SetNodeOptions) (*typ
 		n.Bypass = (opts.BypassOpt == types.TriTrue) || (opts.BypassOpt == types.TriKeep && n.Bypass)
 		if n.IsDown() {
 			logger.Errorf(ctx, "[SetNodeAvailable] node marked down: %s", opts.Nodename)
+			// remove node status
+			err := c.store.SetNodeStatus(ctx, node, -1)
+			if err != nil {
+				// don't return here
+				log.Errorf(ctx, "[SetNode] failed to set node status, err: %v", err)
+			}
 		}
 		if opts.WorkloadsDown {
 			workloads, err := c.store.ListNodeWorkloads(ctx, opts.Nodename, nil)

--- a/cluster/calcium/node_test.go
+++ b/cluster/calcium/node_test.go
@@ -140,6 +140,7 @@ func TestSetNode(t *testing.T) {
 	store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
 	lock.On("Lock", mock.Anything).Return(context.TODO(), nil)
 	lock.On("Unlock", mock.Anything).Return(nil)
+	store.On("SetNodeStatus", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	// fail by validating
 	_, err := c.SetNode(ctx, &types.SetNodeOptions{Nodename: ""})

--- a/cluster/calcium/node_test.go
+++ b/cluster/calcium/node_test.go
@@ -250,9 +250,9 @@ func TestSetNode(t *testing.T) {
 	n, err = c.SetNode(ctx, setOpts)
 	assert.Error(t, err)
 	// succ set cpu, add and del
-	n.CPU = types.CPUMap{"1": 1, "2": 2}
+	n.CPU = types.CPUMap{"1": 10, "2": 2}
 	n.InitCPU = types.CPUMap{"1": 10, "2": 10}
-	setOpts.DeltaCPU = types.CPUMap{"1": 0, "2": -1, "3": 10}
+	setOpts.DeltaCPU = types.CPUMap{"1": -10, "2": -1, "3": 10}
 	n, err = c.SetNode(ctx, setOpts)
 	assert.NoError(t, err)
 	_, ok := n.CPU["1"]

--- a/store/etcdv3/node_test.go
+++ b/store/etcdv3/node_test.go
@@ -141,13 +141,13 @@ RdCPRPt513WozkJZZAjUSP2U
 	m.config.CertPath = "/tmp"
 	node3, err := m.doAddNode(ctx, nodename3, endpoint3, podname, ca, cert, certkey, cpu, share, memory, storage, labels, nil, nil, nil)
 	assert.NoError(t, err)
-	engine3, err := m.makeClient(ctx, node3, true)
+	engine3, err := m.makeClient(ctx, node3)
 	assert.NoError(t, err)
 	_, err = engine3.Info(ctx)
 	assert.Error(t, err)
 	// failed by get key
 	node3.Name = "nokey"
-	_, err = m.makeClient(ctx, node3, true)
+	_, err = m.makeClient(ctx, node3)
 	assert.NoError(t, err)
 }
 

--- a/store/redis/node_test.go
+++ b/store/redis/node_test.go
@@ -138,13 +138,13 @@ RdCPRPt513WozkJZZAjUSP2U
 	s.rediaron.config.CertPath = "/tmp"
 	node3, err := s.rediaron.doAddNode(ctx, nodename3, endpoint3, podname, ca, cert, certkey, cpu, share, memory, storage, labels, nil, nil, nil)
 	s.NoError(err)
-	engine3, err := s.rediaron.makeClient(ctx, node3, true)
+	engine3, err := s.rediaron.makeClient(ctx, node3)
 	s.NoError(err)
 	_, err = engine3.Info(ctx)
 	s.Error(err)
 	// failed by get key
 	node3.Name = "nokey"
-	_, err = s.rediaron.makeClient(ctx, node3, true)
+	_, err = s.rediaron.makeClient(ctx, node3)
 	s.NoError(err)
 }
 


### PR DESCRIPTION
在SetNode的时候，如果`node.available == false`，就把node status给删掉。

在这个PR之前，agent在crash的时候会调用`SetNode`来把当前node设置为`available: false`，但是没有删除node status。如果在node status过期之前，agent重启成功，那么node status就会一直是`alive: true`，并且selfmon无法从`NodeStatusStream`里监听到任何变化，导致这个node一直是`available: false`。