### PR TITLE
Fix issue of too many logs due to raw bytes

### DIFF
--- a/cluster/calcium/create.go
+++ b/cluster/calcium/create.go
@@ -28,7 +28,7 @@ func (c *Calcium) CreateWorkload(ctx context.Context, opts *types.DeployOptions)
 	}
 
 	opts.ProcessIdent = utils.RandomString(16)
-	log.Infof(ctx, "[CreateWorkload %s] Creating workload with options:\n%s", opts.ProcessIdent, litter.Sdump(opts))
+	log.Infof(ctx, "[CreateWorkload %s] Creating workload with options:\n%s", opts.ProcessIdent, litter.Options{Compact: true}.Sdump(opts))
 	// Count 要大于0
 	if opts.Count <= 0 {
 		return nil, logger.Err(ctx, errors.WithStack(types.NewDetailedErr(types.ErrBadCount, opts.Count)))

--- a/store/etcdv3/processing.go
+++ b/store/etcdv3/processing.go
@@ -59,7 +59,7 @@ func (m *Mercury) doLoadProcessing(ctx context.Context, appname, entryname strin
 		nodesCount[nodename] += count
 	}
 
-	log.Debug(ctx, "[doLoadProcessing] Processing result: %s", litter.Sdump())
+	log.Debug(ctx, "[doLoadProcessing] Processing result: ", litter.Options{Compact: true}.Sdump(nodesCount))
 	setCount(nodesCount, strategyInfos)
 	return nil
 }

--- a/types/options.go
+++ b/types/options.go
@@ -1,6 +1,11 @@
 package types
 
-import "github.com/pkg/errors"
+import (
+	"fmt"
+	"io"
+
+	"github.com/pkg/errors"
+)
 
 // TODO should validate options
 
@@ -28,7 +33,7 @@ type DeployOptions struct {
 	ProcessIdent   string            // ProcessIdent ident this deploy
 	IgnoreHook     bool              // IgnoreHook ignore hook process
 	AfterCreate    []string          // AfterCreate support run cmds after create
-	RawArgs        []byte            // RawArgs for raw args processing
+	RawArgs        RawArgs           // RawArgs for raw args processing
 	Lambda         bool              // indicate is lambda workload or not
 }
 
@@ -100,6 +105,16 @@ func (f LinuxFile) Clone() LinuxFile {
 		GID:      f.GID,
 		Mode:     f.Mode,
 	}
+}
+
+// String for %+v
+func (f LinuxFile) String() string {
+	return fmt.Sprintf("file %v:%v:%v:%#o, len: %v", f.Filename, f.UID, f.GID, f.Mode, len(f.Content))
+}
+
+// LitterDump for litter.Sdump
+func (f LinuxFile) LitterDump(w io.Writer) {
+	w.Write([]byte(fmt.Sprintf(`{Content:{%d bytes},Filename:%s,UID:%d,GID:%d,Mode:%#o"}`, len(f.Content), f.Filename, f.UID, f.GID, f.Mode))) // nolint:errcheck // here can't import core/log due to cycle dependence
 }
 
 // SendOptions for send files to multiple workload
@@ -296,4 +311,17 @@ func ParseTriOption(opt TriOptions, original bool) (res bool) {
 		res = false
 	}
 	return
+}
+
+// RawArgs .
+type RawArgs []byte
+
+// String for %+v
+func (r RawArgs) String() string {
+	return string(r)
+}
+
+// LitterDump fro litter.Dumper
+func (r RawArgs) LitterDump(w io.Writer) {
+	w.Write(r) // nolint:errcheck // here can't import core/log due to cycle dependence
 }


### PR DESCRIPTION
1. CreateWorkload 里的用户请求用 compact 模式, 打印在一行
2. LinuxFile 和 RawArgs 这两个 bytes 字段, 实现了 String() 和 LitterDump() 方法, 避免输出 raw bytes, 只输出长度和其他信息