### PR TITLE
avoid redundant logs in "makeClient"

### DIFF
--- a/store/etcdv3/node.go
+++ b/store/etcdv3/node.go
@@ -183,8 +183,12 @@ func (m *Mercury) makeClient(ctx context.Context, node *types.Node) (client engi
 	keyFormats := []string{nodeCaKey, nodeCertKey, nodeKeyKey}
 	data := []string{"", "", ""}
 	for i := 0; i < 3; i++ {
-		if ev, err := m.GetOne(ctx, fmt.Sprintf(keyFormats[i], node.Name)); err != nil {
-			log.Warnf(ctx, "[makeClient] Get key failed %v", err)
+		ev, err := m.GetOne(ctx, fmt.Sprintf(keyFormats[i], node.Name))
+		if err != nil {
+			if !errors.Is(err, types.ErrBadCount) {
+				log.Warnf(ctx, "[makeClient] Get key failed %v", err)
+			}
+			continue
 		} else {
 			data[i] = string(ev.Value)
 		}

--- a/store/redis/node.go
+++ b/store/redis/node.go
@@ -179,7 +179,9 @@ func (r *Rediaron) makeClient(ctx context.Context, node *types.Node) (engine.API
 	for i := 0; i < 3; i++ {
 		v, err := r.GetOne(ctx, fmt.Sprintf(keyFormats[i], node.Name))
 		if err != nil {
-			log.Warnf(ctx, "[makeClient] Get key failed %v", err)
+			if !isRedisNoKeyError(err) {
+				log.Warnf(ctx, "[makeClient] Get key failed %v", err)
+			}
 			continue
 		}
 		data[i] = v

--- a/types/errors.go
+++ b/types/errors.go
@@ -97,9 +97,24 @@ var (
 	ErrRollbackMapIsNotEmpty = errors.New("rollback map is not empty")
 )
 
+type detailedErr struct {
+	err     error
+	details interface{}
+}
+
+// Error .
+func (d detailedErr) Error() string {
+	return fmt.Sprintf("%s: %v", d.err, d.details)
+}
+
+// Unwrap .
+func (d detailedErr) Unwrap() error {
+	return d.err
+}
+
 // NewDetailedErr returns an error with details
 func NewDetailedErr(err error, details interface{}) error {
-	return fmt.Errorf("%w: %v", err, details)
+	return detailedErr{err: err, details: details}
 }
 
 // validation errors

--- a/types/errors_test.go
+++ b/types/errors_test.go
@@ -16,4 +16,6 @@ func TestDetailedErr(t *testing.T) {
 
 	assert.True(t, errors.Is(dt, err))
 	assert.True(t, strings.Contains(dt.Error(), detail))
+
+	assert.True(t, errors.Is(NewDetailedErr(ErrBadCount, detail), ErrBadCount))
 }


### PR DESCRIPTION
在缓存机制挪到GetEngine里面之后，这里的日志每次调用GetNode的时候都会打一遍，数量超大。

现在改成了：如果key不存在就不会报错。