### PR TITLE
optimize the logic of cpu allocation

### DIFF
--- a/scheduler/complex/potassium_test.go
+++ b/scheduler/complex/potassium_test.go
@@ -476,7 +476,7 @@ func TestComplexNodes(t *testing.T) {
 		t.Fatalf("how to alloc 29 workloads when you only have 28?")
 	}
 
-	//test5
+	// test5
 	nodes = getComplexNodes()
 	res6, _, err := SelectCPUNodes(k, nodes, nil, 1, 1, 2, true)
 	assert.NoError(t, err)
@@ -507,6 +507,19 @@ func TestCPUWithMaxShareLimit(t *testing.T) {
 	_, _, err = SelectCPUNodes(k, nodes, nil, 1.7, 1, 3, false)
 	assert.True(t, errors.Is(err, types.ErrInsufficientRes))
 	assert.Contains(t, err.Error(), "available: 2")
+
+	// test2
+	nodes = []resourcetypes.ScheduleInfo{
+		{
+			NodeMeta: types.NodeMeta{
+				CPU:    types.CPUMap{"0": 0, "1": 0, "2": 100, "3": 100},
+				MemCap: 12 * int64(units.GiB),
+				Name:   "nodes1",
+			},
+		},
+	}
+	_, _, err = SelectCPUNodes(k, nodes, nil, 1.2, 1, 1, false)
+	assert.Nil(t, err)
 }
 
 func TestCpuOverSell(t *testing.T) {

--- a/scheduler/complex/resource.go
+++ b/scheduler/complex/resource.go
@@ -28,7 +28,7 @@ func newHost(resourceMap types.ResourceMap, share int) *host {
 		if pieces >= int64(share) && pieces%int64(share) == 0 {
 			// 只给 share 份
 			result.full = append(result.full, resourceInfo{id: id, pieces: pieces})
-		} else {
+		} else if pieces > 0 {
 			result.fragment = append(result.fragment, resourceInfo{id: id, pieces: pieces})
 		}
 	}
@@ -184,23 +184,13 @@ func (h *host) getFragmentsResult(resources []resourceInfo, fragments ...int64) 
 func (h *host) getFullResult(full int, resources []resourceInfo) []types.ResourceMap {
 	result := []types.ResourceMap{}
 
-	for len(resources)/full > 0 {
-		count, rem := len(resources)/full, len(resources)%full
-		newResources := []resourceInfo{}
-		for i := 0; i < count; i++ {
-			plan := types.ResourceMap{}
-			for j := i * full; j < i*full+full; j++ {
-				// 洗掉没配额的
-				last := resources[j].pieces - int64(h.share)
-				if last > 0 {
-					newResources = append(newResources, resourceInfo{resources[j].id, last})
-				}
-				plan[resources[j].id] = int64(h.share)
-			}
-			result = append(result, plan)
+	count := len(resources) / full
+	for i := 0; i < count; i++ {
+		plan := types.ResourceMap{}
+		for j := i * full; j < i*full+full; j++ {
+			plan[resources[j].id] = int64(h.share)
 		}
-
-		resources = append(newResources, resources[len(resources)-rem:]...)
+		result = append(result, plan)
 	}
 
 	return result


### PR DESCRIPTION
cache cloud那边有个需求，希望让同一台机器上的所有redis共享同一个核心来做bgsave，所以core里加入了一个配置项叫“maxshare”，限制最大的碎片核数。

不过在分配cpu的时候，core会把所有剩余pieces为0的核划分为碎片核，这样就会导致如下问题：对于一个四核的node，如果core设置了`maxshare=1`，那么在分配了一个带`--cpu-bind --cpu=1.1`的workload之后，再申请创建同样的workload会提示资源不足。原因是在第一个workload分配之后，有一个核剩余pieces是0，被识别为碎片核，core就不会再分配新的碎片核了。

所以改动了一下这里的逻辑，对于pieces为0的核，不再视为碎片核。