### PR TITLE
Fix thg bugs of "make test" and "getFullResult"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ cloc:
 	cloc --exclude-dir=vendor,3rdmocks,mocks,tools,gen --not-match-f=test .
 
 unit-test:
-	go vet `go list ./... | grep -v '/vendor/' | grep -v '/tools'`
+	go vet `go list ./... | grep -v '/vendor/' | grep -v '/tools'` && \
 	go test -race -timeout 240s -count=1 -cover ./utils/... \
 	./types/... \
 	./store/etcdv3/. \
@@ -66,7 +66,7 @@ unit-test:
 	./wal/. \
 	./wal/kv/. \
 	./store/redis/... \
-	./lock/redis/...
+	./lock/redis/... && \
 	go test -timeout 240s -count=1 -cover ./cluster/calcium/...
 
 lint:


### PR DESCRIPTION
上一个PR里我按照自己的理解改动了getFullResult，但是其实我的理解是有问题的！这里回滚一下。

如果CPU map是{0:200, 1: 200}，那么对于cpu=1的申请可以分配4个，而不是两个。之前我以为“整数核不应该被切分”的意思是“至少在单次分配中保证整数核是被独占的”，完全错了。

之前没有发现这个不一致的问题，部分原因是提PR的时候check没报错。查了一下发现GNU make 4.3会把make test里的那些命令按照加分号的形式顺序执行，导致只要make test的最后一句命令的exit code会覆盖之前命令的exit code。这里用偷鸡摸狗的方式改了一下Makefile，使其功能恢复正常。