### PR TITLE
optimize 'getFullResult'

### DIFF
--- a/scheduler/complex/cpu_test.go
+++ b/scheduler/complex/cpu_test.go
@@ -253,11 +253,33 @@ func TestGetFullResult(t *testing.T) {
 			pieces: 400,
 		},
 	})
-	assert.EqualValues(t, 4, len(res))
+	assert.EqualValues(t, 5, len(res))
 	assert.ElementsMatch(t, res, []types.ResourceMap{
 		{"0": 100, "1": 100},
+		{"0": 100, "2": 100},
+		{"0": 100, "2": 100},
+		{"0": 100, "2": 100},
+		{"1": 100, "2": 100},
+	})
+
+	res = h.getFullResult(2,  []resourceInfo{
+		{
+			id:     "0",
+			pieces: 200,
+		},
+		{
+			id:     "1",
+			pieces: 200,
+		},
+		{
+			id:     "2",
+			pieces: 200,
+		},
+	})
+	assert.EqualValues(t, 3, len(res))
+	assert.ElementsMatch(t, res, []types.ResourceMap{
 		{"0": 100, "1": 100},
 		{"0": 100, "2": 100},
-		{"0": 100, "2": 100},
+		{"1": 100, "2": 100},
 	})
 }


### PR DESCRIPTION
优化了一下getFullResult，使其能够分配更多的workload。

对于cpu map是{0: 200, 1: 200, 2: 200}，workload请求cpu=2的情况，之前的算法只能创建2个workload，即两个`{0: 100, 1: 100}`。优化了之后，现在能返回3个workload，即`{0: 100, 1: 100}`，`{0: 100, 2: 100}`，`{1: 100, 2: 100}`。

这个优化也不是完美的，不能像之前的那个算法一样保证优先分配剩余pieces较少的核。所以我加了一个sort，通过比较origin index的总和，来尽量使这个优先级有效。例如上文提到的这3个cpu plan中，`{0: 100, 2: 100}`就要比`{1: 100, 2: 100}`靠前，因为0+2 < 1+2。

可能需要讨论一下这样是否能接受。