### PR TITLE
fix: keep the node status when a running node is bypassed

### DIFF
--- a/cluster/calcium/node.go
+++ b/cluster/calcium/node.go
@@ -71,8 +71,10 @@ func (c *Calcium) SetNode(ctx context.Context, opts *types.SetNodeOptions) (*typ
 
 		n.Available = (opts.StatusOpt == types.TriTrue) || (opts.StatusOpt == types.TriKeep && n.Available)
 		n.Bypass = (opts.BypassOpt == types.TriTrue) || (opts.BypassOpt == types.TriKeep && n.Bypass)
-		if !n.Bypass && !n.Available {
+		if n.IsDown() {
 			log.Errorf(ctx, "[SetNodeAvailable] node marked down: %s", opts.Nodename)
+		}
+		if !n.Available {
 			// remove node status
 			if err := c.store.SetNodeStatus(ctx, node, -1); err != nil {
 				// don't return here
@@ -104,7 +106,7 @@ func (c *Calcium) SetNode(ctx context.Context, opts *types.SetNodeOptions) (*typ
 
 				// mark workload which belongs to this node as unhealthy
 				if err = c.store.SetWorkloadStatus(ctx, workload.StatusMeta, 0); err != nil {
-					log.Errorf(ctx, "[SetNodeAvailable] Set workload %s on node %s as inactive failed %v", workload.ID, opts.Nodename, err)
+					log.Errorf(ctx, "[SetNodeAvailable] Set workload %s on node %s as inactive failed %v", workload.ID, opts.Nodename, errors.WithStack(err))
 				} else {
 					log.Infof(ctx, "[SetNodeAvailable] Set workload %s on node %s as inactive", workload.ID, opts.Nodename)
 				}

--- a/store/etcdv3/meta/etcd.go
+++ b/store/etcdv3/meta/etcd.go
@@ -289,6 +289,7 @@ func (e *ETCD) bindStatusWithTTL(ctx context.Context, entityKey, statusKey, stat
 	// There is a status bound to the entity yet but its value isn't same as the expected one.
 	valueTxn := statusTxn.Responses[0].GetResponseTxn()
 	if !valueTxn.Succeeded {
+		log.Infof(ctx, "[bindStatusWithTTL] put: key %s value %s", statusKey, statusValue)
 		return nil
 	}
 
@@ -318,6 +319,9 @@ func (e *ETCD) bindStatusWithoutTTL(ctx context.Context, statusKey, statusValue 
 		)).
 		Else(updateStatus...). // otherwise deal with non-existing status key
 		Commit()
+	if err == nil {
+		log.Infof(ctx, "[bindStatusWithoutTTL] put: key %s value %s", statusKey, statusValue)
+	}
 	return err
 }
 


### PR DESCRIPTION
场景：一个node被设置了bypass，但是我们只希望它不参与后续的部署，node上面的workloads还可以正常提供服务。

问题：agent启动后更新了node status，selfmon收到了变更信息，调用SetNode，打算把这个node设置成UP。但是因为它被bypass了，所以触发了n.IsDown()，node status又被删除。selfmon再次收到变更信息，然后调用SetNode把node设置为DOWN，并且将上面所有workload标记为not running。

修复：修改一下判断条件，只有在非bypass且down的情况才会删除node status。