### PR TITLE
let goreleaser build debug file

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.17
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,16 +6,46 @@ before:
     - go mod download
 
 builds:
-  - binary: eru-core
+  - id: eru-core-debug
+    binary: eru-core.dbg
     env:
       - CGO_ENABLED=0
     ldflags:
-      - -s -w
+      - -X github.com/projecteru2/core/version.REVISION={{.Commit}}
+      - -X github.com/projecteru2/core/version.VERSION={{.Env.VERSION}}
+      - -X github.com/projecteru2/core/version.BUILTAT={{.Date}}
+    hooks:
+      post:
+        - cp {{.Path}} ./eru-core-{{.Os}}.dbg
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+
+  # the best practice is using prebuilt builder
+  # however it's a Pro feature
+  - id: eru-core-linux
+    binary: eru-core
+    hooks:
+      post:
+        - cp ./eru-core-{{.Os}}.dbg {{.Path}}
+        - strip {{.Path}}
+    goos:
+      - linux
+    goarch:
+      - amd64
+
+  - id: eru-core-darwin
+    binary: eru-core
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -w -s
       - -X github.com/projecteru2/core/version.REVISION={{.Commit}}
       - -X github.com/projecteru2/core/version.VERSION={{.Env.VERSION}}
       - -X github.com/projecteru2/core/version.BUILTAT={{.Date}}
     goos:
-      - linux
       - darwin
     goarch:
       - amd64


### PR DESCRIPTION
~~1. goreleaser pro 才能用 prebuilder, 所以用笨办法, build 两次~~
~~2. 因此要保证 Reproducible Builds, 按照[文档](https://goreleaser.com/customization/build/?h=mod_timestamp#reproducible-builds), 把 {{.Data}} 改成了 {{.CommitDate}}.~~
~~3. 先在 v21.10.27 试试~~

经过反复尝试终于改了一版能用的..
1. 升级到 go1.17, 坐等 1.18, 对 dwarf 有大改动
2. release 的 tarball 里包含两个 bin: eru-core, eru-core.dbg, 生产环境还是正常用 eru-core 这个 bin, 不包含符号表和 dwarf 的纯享版.

第一个使用了这个 goreleaser 的版本: https://github.com/projecteru2/core/releases/tag/v21.10.27