### PR TITLE
fix map concurrent write issue

### DIFF
--- a/cluster/calcium/create.go
+++ b/cluster/calcium/create.go
@@ -419,7 +419,10 @@ func (c *Calcium) doMakeWorkloadOptions(ctx context.Context, no int, msg *types.
 	config.Restart = entry.Restart
 	if entry.Log != nil {
 		config.LogType = entry.Log.Type
-		config.LogConfig = entry.Log.Config
+		config.LogConfig = map[string]string{}
+		for k, v := range entry.Log.Config {
+			config.LogConfig[k] = v
+		}
 	}
 	// name
 	suffix := utils.RandomString(6)


### PR DESCRIPTION
这里生成的config后续会被用于Engine.VirtualizationCreate，里面会写入config.LogConfig。所以如果这里简单地使用entry.Log.Config的话，实质上所有的config.LogConfig都是同一个map，就会造成并发写入，直接panic。