### PR TITLE
fix the issue of building docker image

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -2,8 +2,6 @@ name: docker-image
 
 on:
   push:
-    branches:
-      - master
     tags:
       - v*
 
@@ -13,6 +11,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: build and push to github packages
         uses: docker/build-push-action@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:alpine AS BUILD
 
 # make binary
 RUN apk add --no-cache build-base musl-dev git curl make cmake
-RUN git clone https://github.com/projecteru2/core.git /go/src/github.com/projecteru2/core
+COPY . /go/src/github.com/projecteru2/core
 WORKDIR /go/src/github.com/projecteru2/core
 ARG KEEP_SYMBOL
 RUN make build && ./eru-core --version


### PR DESCRIPTION
发现在非master的分支上打tag的时候，自动构建的docker image是基于触发时最新的master版本构建的，而非触发构建的那个commit。这会导致用docker部署hotfix版本的时候，以为hotfix只是基于过去某个tag做了一点点小改动，实际上部署的是当前最新的版本，可能会包含未经测试的功能，从而有神秘的隐患。

这个PR修了一下这个问题。agent / cli也有同样的问题。