### PR TITLE
optimize global strategy

### DIFF
--- a/strategy/global_test.go
+++ b/strategy/global_test.go
@@ -5,9 +5,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/projecteru2/core/types"
 )
 
 func TestGlobalPlan1(t *testing.T) {
+	// normal case
 	n1 := Info{
 		Nodename: "n1",
 		Usage:    0.8,
@@ -17,8 +20,8 @@ func TestGlobalPlan1(t *testing.T) {
 	n2 := Info{
 		Nodename: "n2",
 		Usage:    0.5,
-		Rate:     0.11,
-		Capacity: 1,
+		Rate:     0.12,
+		Capacity: 2,
 	}
 	n3 := Info{
 		Nodename: "n3",
@@ -26,55 +29,143 @@ func TestGlobalPlan1(t *testing.T) {
 		Rate:     0.05,
 		Capacity: 1,
 	}
-	arg := []Info{n3, n2, n1}
+	arg := []Info{n1, n2, n3}
 	r, err := GlobalPlan(context.TODO(), arg, 3, 100, 0)
 	assert.NoError(t, err)
-	assert.Equal(t, r[arg[0].Nodename], 1)
-}
+	assert.Equal(t, r, map[string]int{"n1": 1, "n2": 2})
 
-func TestGlobalPlan2(t *testing.T) {
-	n1 := Info{
+	// normal case 2
+	n1 = Info{
+		Nodename: "n1",
+		Usage:    0.8,
+		Rate:     0.05,
+		Capacity: 4,
+	}
+	n2 = Info{
+		Nodename: "n2",
+		Usage:    0.5,
+		Rate:     0.35,
+		Capacity: 1,
+	}
+	n3 = Info{
+		Nodename: "n3",
+		Usage:    2.2,
+		Rate:     0.05,
+		Capacity: 1,
+	}
+	arg = []Info{n1, n2, n3}
+	r, err = GlobalPlan(context.TODO(), arg, 3, 100, 0)
+	assert.Equal(t, r, map[string]int{"n1": 2, "n2": 1})
+
+	// insufficient total
+	n1 = Info{
+		Nodename: "n1",
+		Usage:    0.8,
+		Rate:     0.05,
+		Capacity: 4,
+	}
+	n2 = Info{
+		Nodename: "n2",
+		Usage:    0.5,
+		Rate:     0.35,
+		Capacity: 1,
+	}
+	n3 = Info{
+		Nodename: "n3",
+		Usage:    2.2,
+		Rate:     0.05,
+		Capacity: 1,
+	}
+	arg = []Info{n1, n2, n3}
+	r, err = GlobalPlan(context.TODO(), arg, 100, 6, 0)
+	assert.ErrorIs(t, err, types.ErrInsufficientRes)
+
+	// fake total
+	n1 = Info{
+		Nodename: "n1",
+		Usage:    0.8,
+		Rate:     0.05,
+		Capacity: 4,
+	}
+	n2 = Info{
+		Nodename: "n2",
+		Usage:    0.5,
+		Rate:     0.35,
+		Capacity: 1,
+	}
+	n3 = Info{
+		Nodename: "n3",
+		Usage:    2.2,
+		Rate:     0.05,
+		Capacity: 1,
+	}
+	arg = []Info{n1, n2, n3}
+	r, err = GlobalPlan(context.TODO(), arg, 10, 100, 0)
+	assert.ErrorIs(t, err, types.ErrInsufficientRes)
+
+	// small rate
+	n1 = Info{
+		Nodename: "n1",
+		Usage:    0.8,
+		Rate:     0,
+		Capacity: 1e10,
+	}
+	n2 = Info{
+		Nodename: "n2",
+		Usage:    0.5,
+		Rate:     0,
+		Capacity: 1e10,
+	}
+	n3 = Info{
+		Nodename: "n3",
+		Usage:    2.2,
+		Rate:     0,
+		Capacity: 1e10,
+	}
+	arg = []Info{n1, n2, n3}
+	r, err = GlobalPlan(context.TODO(), arg, 10, 100, 0)
+	assert.NoError(t, err)
+	assert.Equal(t, r, map[string]int{"n2": 10})
+
+	// old test case 2
+	n1 = Info{
 		Nodename: "n1",
 		Usage:    1.6,
 		Rate:     0.05,
 		Capacity: 100,
 	}
-	n2 := Info{
+	n2 = Info{
 		Nodename: "n2",
 		Usage:    0.5,
 		Rate:     0.11,
 		Capacity: 100,
 	}
-	arg := []Info{n2, n1}
-	r, err := GlobalPlan(context.TODO(), arg, 2, 100, 0)
+	arg = []Info{n2, n1}
+	r, err = GlobalPlan(context.TODO(), arg, 2, 100, 0)
 	assert.NoError(t, err)
-	assert.Equal(t, r[arg[0].Nodename], 2)
-}
+	assert.Equal(t, r, map[string]int{"n2": 2})
 
-func TestGlobalPlan3(t *testing.T) {
-	n1 := Info{
+	// old test case 3
+	n1 = Info{
 		Nodename: "n1",
 		Usage:    0.5259232954545454,
 		Rate:     0.0000712,
 		Capacity: 100,
 	}
 
-	r, err := GlobalPlan(context.TODO(), []Info{n1}, 1, 100, 0)
+	r, err = GlobalPlan(context.TODO(), []Info{n1}, 1, 100, 0)
 	assert.NoError(t, err)
 	assert.Equal(t, r["n1"], 1)
-}
 
-func TestGlobal3(t *testing.T) {
-	_, err := GlobalPlan(context.TODO(), []Info{}, 10, 1, 0)
-	assert.Error(t, err)
-	nodeInfo := Info{
+	// old test case 4
+	n1 = Info{
 		Nodename: "n1",
 		Usage:    1,
 		Rate:     0.3,
 		Capacity: 100,
 		Count:    21,
 	}
-	r, err := GlobalPlan(context.TODO(), []Info{nodeInfo}, 10, 100, 0)
+	r, err = GlobalPlan(context.TODO(), []Info{n1}, 10, 100, 0)
 	assert.NoError(t, err)
 	assert.Equal(t, r["n1"], 10)
 }


### PR DESCRIPTION
之前的global strategy有点问题，所以优化了一下global strategy。基本思路如下：

已知`info.Usage`代表当前资源用量占比，`info.Capacity`代表最多还能部署的实例数量，`info.Rate`表示单个实例占用资源的比例。那么`info.Rate + info.Usage`可以代表“如果在这个node上部署一个实例，最终的资源用量占比”。

最终的目的是：尽量在分配完成后，各个info上的usage差不多。

所以就用这个`info.Rate + info.Usage`作为评价标准，来创建一个小顶堆。每次从小顶堆里pop出来一个info，然后在这个info对应的node上部署1个实例（也就是info.Usage += info.Rate，并且info.Capacity--），再把这个info放回去。简单想了想，这样应该很有助于最终info.Usage的均匀。

对比来看，如果简单地用info.Usage来构建小顶堆，可能会出现以下情况：

node1: usage 0.5, capacity 1, rate 0.5
node2: usage 0.6, capacity 4, rate 0.1

想要部署1个实例，如果用usage构建堆，那么会部署到node1上，最终node1的usage达到100%。但是用rate + usage构建堆的话，会部署到node2上，最终node1的usage还是50%，node2的usage则是70%，对比起来似乎更合理一些。

粗略实现了一下，后续还需要仔细的测试，因为要过年了，得等年后才能继续了...