### PR TITLE
add new types of node lock

### DIFF
--- a/cluster/calcium/capacity.go
+++ b/cluster/calcium/capacity.go
@@ -21,7 +21,7 @@ func (c *Calcium) CalculateCapacity(ctx context.Context, opts *types.DeployOptio
 		NodeCapacities: map[string]int{},
 	}
 
-	return msg, c.withNodesLocked(ctx, opts.NodeFilter, func(ctx context.Context, nodeMap map[string]*types.Node) error {
+	return msg, c.withNodesResourceLocked(ctx, opts.NodeFilter, func(ctx context.Context, nodeMap map[string]*types.Node) error {
 		if opts.DeployStrategy != strategy.Dummy {
 			if _, msg.NodeCapacities, err = c.doAllocResource(ctx, nodeMap, opts); err != nil {
 				logger.Errorf(ctx, "[Calcium.CalculateCapacity] doAllocResource failed: %+v", err)

--- a/cluster/calcium/create.go
+++ b/cluster/calcium/create.go
@@ -95,7 +95,7 @@ func (c *Calcium) doCreateWorkloads(ctx context.Context, opts *types.DeployOptio
 						ch <- &types.CreateWorkloadMessage{Error: logger.Err(ctx, err)}
 					}
 				}()
-				return c.withNodesLocked(ctx, opts.NodeFilter, func(ctx context.Context, nodeMap map[string]*types.Node) (err error) {
+				return c.withNodesResourceLocked(ctx, opts.NodeFilter, func(ctx context.Context, nodeMap map[string]*types.Node) (err error) {
 					// calculate plans
 					if plans, deployMap, err = c.doAllocResource(ctx, nodeMap, opts); err != nil {
 						return err
@@ -136,7 +136,7 @@ func (c *Calcium) doCreateWorkloads(ctx context.Context, opts *types.DeployOptio
 					return
 				}
 				for nodename, rollbackIndices := range rollbackMap {
-					if e := c.withNodeLocked(ctx, nodename, func(ctx context.Context, node *types.Node) error {
+					if e := c.withNodeResourceLocked(ctx, nodename, func(ctx context.Context, node *types.Node) error {
 						for _, plan := range plans {
 							plan.RollbackChangesOnNode(node, rollbackIndices...) // nolint:scopelint
 						}
@@ -249,12 +249,8 @@ func (c *Calcium) doDeployWorkloadsOnNode(ctx context.Context, ch chan *types.Cr
 	// remap 就不搞进事务了吧, 回滚代价太大了
 	// 放任 remap 失败的后果是, share pool 没有更新, 这个后果姑且认为是可以承受的
 	// 而且 remap 是一个幂等操作, 就算这次 remap 失败, 下次 remap 也能收敛到正确到状态
-	if err := c.withNodeLocked(ctx, nodename, func(ctx context.Context, node *types.Node) error {
-		c.doRemapResourceAndLog(ctx, logger, node)
-		return nil
-	}); err != nil {
-		logger.Errorf(ctx, "failed to lock node to remap: %v", err)
-	}
+	go c.doRemapResourceAndLog(ctx, logger, node)
+
 	return indices, err
 }
 

--- a/cluster/calcium/dissociate.go
+++ b/cluster/calcium/dissociate.go
@@ -25,7 +25,7 @@ func (c *Calcium) DissociateWorkload(ctx context.Context, ids []string) (chan *t
 		defer close(ch)
 
 		for nodename, workloadIDs := range nodeWorkloadGroup {
-			if err := c.withNodeLocked(ctx, nodename, func(ctx context.Context, node *types.Node) error {
+			if err := c.withNodeResourceLocked(ctx, nodename, func(ctx context.Context, node *types.Node) error {
 				for _, workloadID := range workloadIDs { // nolint:scopelint
 					msg := &types.DissociateWorkloadMessage{WorkloadID: workloadID} // nolint:scopelint
 					if err := c.withWorkloadLocked(ctx, workloadID, func(ctx context.Context, workload *types.Workload) error {
@@ -57,7 +57,7 @@ func (c *Calcium) DissociateWorkload(ctx context.Context, ids []string) (chan *t
 					}
 					ch <- msg
 				}
-				c.doRemapResourceAndLog(ctx, logger, node)
+				go c.doRemapResourceAndLog(ctx, logger, node)
 				return nil
 			}); err != nil {
 				logger.WithField("nodename", nodename).Errorf(ctx, "failed to lock node: %+v", err)

--- a/cluster/calcium/dissociate_test.go
+++ b/cluster/calcium/dissociate_test.go
@@ -3,6 +3,7 @@ package calcium
 import (
 	"context"
 	"testing"
+	"time"
 
 	lockmocks "github.com/projecteru2/core/lock/mocks"
 	storemocks "github.com/projecteru2/core/store/mocks"
@@ -66,9 +67,11 @@ func TestDissociateWorkload(t *testing.T) {
 	for r := range ch {
 		assert.Error(t, r.Error)
 	}
+	time.Sleep(time.Second)
 	store.AssertExpectations(t)
 
 	store.On("RemoveWorkload", mock.Anything, mock.Anything).Return(nil)
+
 	// success
 	ch, err = c.DissociateWorkload(ctx, []string{"c1"})
 	assert.NoError(t, err)

--- a/cluster/calcium/node.go
+++ b/cluster/calcium/node.go
@@ -28,7 +28,7 @@ func (c *Calcium) RemoveNode(ctx context.Context, nodename string) error {
 	if nodename == "" {
 		return logger.Err(ctx, errors.WithStack(types.ErrEmptyNodeName))
 	}
-	return c.withNodeLocked(ctx, nodename, func(ctx context.Context, node *types.Node) error {
+	return c.withNodeResourceLocked(ctx, nodename, func(ctx context.Context, node *types.Node) error {
 		ws, err := c.ListNodeWorkloads(ctx, node.Name, nil)
 		if err != nil {
 			return logger.Err(ctx, err)
@@ -91,7 +91,7 @@ func (c *Calcium) SetNode(ctx context.Context, opts *types.SetNodeOptions) (*typ
 		return nil, logger.Err(ctx, err)
 	}
 	var n *types.Node
-	return n, c.withNodeLocked(ctx, opts.Nodename, func(ctx context.Context, node *types.Node) error {
+	return n, c.withNodeResourceLocked(ctx, opts.Nodename, func(ctx context.Context, node *types.Node) error {
 		logger.Infof(ctx, "set node")
 		opts.Normalize(node)
 		n = node

--- a/cluster/calcium/pod.go
+++ b/cluster/calcium/pod.go
@@ -30,7 +30,7 @@ func (c *Calcium) RemovePod(ctx context.Context, podname string) error {
 		Podname: podname,
 		All:     true,
 	}
-	return c.withNodesLocked(ctx, nf, func(ctx context.Context, nodes map[string]*types.Node) error {
+	return c.withNodesResourceLocked(ctx, nf, func(ctx context.Context, nodes map[string]*types.Node) error {
 		// TODO dissociate workload to node
 		// TODO should remove node first
 		return logger.Err(ctx, errors.WithStack(c.store.RemovePod(ctx, podname)))

--- a/cluster/calcium/realloc.go
+++ b/cluster/calcium/realloc.go
@@ -21,7 +21,7 @@ func (c *Calcium) ReallocResource(ctx context.Context, opts *types.ReallocOption
 	if err != nil {
 		return
 	}
-	return c.withNodeLocked(ctx, workload.Nodename, func(ctx context.Context, node *types.Node) error {
+	return c.withNodeResourceLocked(ctx, workload.Nodename, func(ctx context.Context, node *types.Node) error {
 
 		return c.withWorkloadLocked(ctx, opts.ID, func(ctx context.Context, workload *types.Workload) error {
 			rrs, err := resources.MakeRequests(
@@ -108,7 +108,7 @@ func (c *Calcium) doReallocOnNode(ctx context.Context, node *types.Node, workloa
 		return
 	}
 
-	c.doRemapResourceAndLog(ctx, log.WithField("Calcium", "doReallocOnNode"), node)
+	go c.doRemapResourceAndLog(ctx, log.WithField("Calcium", "doReallocOnNode"), node)
 	return nil
 }
 

--- a/cluster/calcium/realloc_test.go
+++ b/cluster/calcium/realloc_test.go
@@ -3,6 +3,7 @@ package calcium
 import (
 	"context"
 	"testing"
+	"time"
 
 	enginemocks "github.com/projecteru2/core/engine/mocks"
 	enginetypes "github.com/projecteru2/core/engine/types"
@@ -362,6 +363,7 @@ func TestReallocBindCpu(t *testing.T) {
 	err = c.ReallocResource(ctx, newReallocOptions("c5", 0.1, 2*int64(units.MiB), nil, types.TriFalse, types.TriKeep))
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(c5.ResourceMeta.CPU))
+	time.Sleep(time.Second)
 	store.AssertExpectations(t)
 
 	store.On("GetWorkload", mock.Anything, "c6").Return(c6, nil)

--- a/cluster/calcium/remove.go
+++ b/cluster/calcium/remove.go
@@ -33,7 +33,7 @@ func (c *Calcium) RemoveWorkload(ctx context.Context, ids []string, force bool, 
 			utils.SentryGo(func(nodename string, workloadIDs []string) func() {
 				return func() {
 					defer wg.Done()
-					if err := c.withNodeLocked(ctx, nodename, func(ctx context.Context, node *types.Node) error {
+					if err := c.withNodeResourceLocked(ctx, nodename, func(ctx context.Context, node *types.Node) error {
 						for _, workloadID := range workloadIDs {
 							ret := &types.RemoveWorkloadMessage{WorkloadID: workloadID, Success: true, Hook: []*bytes.Buffer{}}
 							if err := c.withWorkloadLocked(ctx, workloadID, func(ctx context.Context, workload *types.Workload) error {
@@ -66,7 +66,7 @@ func (c *Calcium) RemoveWorkload(ctx context.Context, ids []string, force bool, 
 							}
 							ch <- ret
 						}
-						c.doRemapResourceAndLog(ctx, logger, node)
+						go c.doRemapResourceAndLog(ctx, logger, node)
 						return nil
 					}); err != nil {
 						logger.WithField("nodename", nodename).Errorf(ctx, "failed to lock node: %+v", err)

--- a/cluster/calcium/replace.go
+++ b/cluster/calcium/replace.go
@@ -206,12 +206,7 @@ func (c *Calcium) doReplaceWorkload(
 		return createMessage, removeMessage, err
 	}
 
-	if err := c.withNodeLocked(ctx, node.Name, func(_ context.Context, node *types.Node) error {
-		c.doRemapResourceAndLog(ctx, log.WithField("Calcium", "doReplaceWorkload"), node)
-		return nil
-	}); err != nil {
-		log.Errorf(ctx, "[replaceAndRemove] failed to lock node to remap: %v", err)
-	}
+	go c.doRemapResourceAndLog(ctx, log.WithField("Calcium", "doReplaceWorkload"), node)
 
 	return createMessage, removeMessage, err
 }

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -30,8 +30,10 @@ const (
 	WorkloadRestart = "restart"
 	// WorkloadLock for lock workload
 	WorkloadLock = "clock_%s"
-	// NodeLock for lock node
-	NodeLock = "cnode_%s_%s"
+	// NodeResourceLock for lock node resource
+	NodeResourceLock = "cnode_%s_%s"
+	// NodeOperationLock for lock node operation
+	NodeOperationLock = "cnode_op_%s_%s"
 )
 
 // Cluster define all interface


### PR DESCRIPTION
之前remap要拿一个node的锁，而且remap流程还挺长的，一直拿着锁会卡住其它部署请求。而remap的锁只是为了保证不会有多个请求同时去remap，其实可以用chan来代替锁的功能。

修改之后会有一个goroutine来循环监听remapChan，调用方只需要异步将node name塞进remapChan即可，大大节约了持有锁的时间。

为了尽量防止脏数据的问题，remap里的实现也稍微改了下，每次都要重新获取node的资源信息。