### PR TITLE
[WIP] Support multiple uuid when creating vm

### DIFF
--- a/cluster/calcium/create.go
+++ b/cluster/calcium/create.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/cornelk/hashmap"
+
 	"github.com/projecteru2/core/cluster"
 	enginetypes "github.com/projecteru2/core/engine/types"
 	"github.com/projecteru2/core/log"
@@ -332,6 +333,13 @@ func (c *Calcium) doDeployOneWorkload(
 			if !decrProcessing {
 				processing = nil
 			}
+
+			info, err := workload.Inspect(ctx) // 补充Labels
+			if err != nil {
+				return err
+			}
+			workload.Labels = info.Labels
+
 			// add workload metadata first
 			if err := c.store.AddWorkload(ctx, workload, processing); err != nil {
 				return errors.WithStack(err)
@@ -484,6 +492,8 @@ func (c *Calcium) doMakeWorkloadOptions(ctx context.Context, no int, msg *types.
 	for key, value := range opts.Labels {
 		config.Labels[key] = value
 	}
+
+	config.Seq = no
 
 	return config
 }

--- a/engine/types/virtualization.go
+++ b/engine/types/virtualization.go
@@ -42,6 +42,8 @@ type VirtualizationCreateOptions struct {
 	RawArgs []byte
 	Lambda  bool
 
+	Seq int
+
 	AncestorWorkloadID string
 }
 

--- a/types/errors.go
+++ b/types/errors.go
@@ -64,6 +64,7 @@ var (
 	ErrRunAndWaitCountOneWithStdin = errors.New("Count must be 1 if OpenStdin is true")
 	ErrUnknownControlType          = errors.New("Unknown control type")
 	ErrNoRemoteDigest              = errors.New("got no digest")
+	ErrNotEnoughUUID               = errors.New("not enough uuid")
 
 	ErrNoETCD             = errors.New("ETCD must be set")
 	ErrKeyNotExists       = errors.New("Key not exists")

--- a/types/workload.go
+++ b/types/workload.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	engine "github.com/projecteru2/core/engine"
+	"github.com/projecteru2/core/engine"
 	enginetypes "github.com/projecteru2/core/engine/types"
 
 	"github.com/pkg/errors"


### PR DESCRIPTION
When deploying multiple vms the uuids can be set individually in spec.

Provide multiple uuids in `labels/DMIUUID` when using eru-cli or gRPC call.
```yaml
appname: name
entrypoints:
    dev:
labels:
    DMIUUID: 111,222,333,444,555
```

UUID will also be stored in the workload meta data in `labels/DMIUUID` for getWorkload.