### PR TITLE
change the node lock to the pod level

### DIFF
--- a/cluster/calcium/capacity.go
+++ b/cluster/calcium/capacity.go
@@ -21,7 +21,7 @@ func (c *Calcium) CalculateCapacity(ctx context.Context, opts *types.DeployOptio
 		NodeCapacities: map[string]int{},
 	}
 
-	return msg, c.withNodesResourceLocked(ctx, opts.NodeFilter, func(ctx context.Context, nodeMap map[string]*types.Node) error {
+	return msg, c.withNodesPodLocked(ctx, opts.NodeFilter, func(ctx context.Context, nodeMap map[string]*types.Node) error {
 		if opts.DeployStrategy != strategy.Dummy {
 			if _, msg.NodeCapacities, err = c.doAllocResource(ctx, nodeMap, opts); err != nil {
 				logger.Errorf(ctx, "[Calcium.CalculateCapacity] doAllocResource failed: %+v", err)

--- a/cluster/calcium/create.go
+++ b/cluster/calcium/create.go
@@ -97,7 +97,7 @@ func (c *Calcium) doCreateWorkloads(ctx context.Context, opts *types.DeployOptio
 						ch <- &types.CreateWorkloadMessage{Error: logger.Err(ctx, err)}
 					}
 				}()
-				return c.withNodesResourceLocked(ctx, opts.NodeFilter, func(ctx context.Context, nodeMap map[string]*types.Node) (err error) {
+				return c.withNodesPodLocked(ctx, opts.NodeFilter, func(ctx context.Context, nodeMap map[string]*types.Node) (err error) {
 					// calculate plans
 					if plans, deployMap, err = c.doAllocResource(ctx, nodeMap, opts); err != nil {
 						return err
@@ -138,7 +138,7 @@ func (c *Calcium) doCreateWorkloads(ctx context.Context, opts *types.DeployOptio
 					return
 				}
 				for nodename, rollbackIndices := range rollbackMap {
-					if e := c.withNodeResourceLocked(ctx, nodename, func(ctx context.Context, node *types.Node) error {
+					if e := c.withNodePodLocked(ctx, nodename, func(ctx context.Context, node *types.Node) error {
 						for _, plan := range plans {
 							plan.RollbackChangesOnNode(node, rollbackIndices...) // nolint:scopelint
 						}

--- a/cluster/calcium/dissociate.go
+++ b/cluster/calcium/dissociate.go
@@ -25,7 +25,7 @@ func (c *Calcium) DissociateWorkload(ctx context.Context, ids []string) (chan *t
 		defer close(ch)
 
 		for nodename, workloadIDs := range nodeWorkloadGroup {
-			if err := c.withNodeResourceLocked(ctx, nodename, func(ctx context.Context, node *types.Node) error {
+			if err := c.withNodePodLocked(ctx, nodename, func(ctx context.Context, node *types.Node) error {
 				for _, workloadID := range workloadIDs { // nolint:scopelint
 					msg := &types.DissociateWorkloadMessage{WorkloadID: workloadID} // nolint:scopelint
 					if err := c.withWorkloadLocked(ctx, workloadID, func(ctx context.Context, workload *types.Workload) error {

--- a/cluster/calcium/node.go
+++ b/cluster/calcium/node.go
@@ -30,7 +30,7 @@ func (c *Calcium) RemoveNode(ctx context.Context, nodename string) error {
 	if nodename == "" {
 		return logger.Err(ctx, errors.WithStack(types.ErrEmptyNodeName))
 	}
-	return c.withNodeResourceLocked(ctx, nodename, func(ctx context.Context, node *types.Node) error {
+	return c.withNodePodLocked(ctx, nodename, func(ctx context.Context, node *types.Node) error {
 		ws, err := c.ListNodeWorkloads(ctx, node.Name, nil)
 		if err != nil {
 			return logger.Err(ctx, err)
@@ -107,7 +107,7 @@ func (c *Calcium) SetNode(ctx context.Context, opts *types.SetNodeOptions) (*typ
 		return nil, logger.Err(ctx, err)
 	}
 	var n *types.Node
-	return n, c.withNodeResourceLocked(ctx, opts.Nodename, func(ctx context.Context, node *types.Node) error {
+	return n, c.withNodePodLocked(ctx, opts.Nodename, func(ctx context.Context, node *types.Node) error {
 		logger.Infof(ctx, "set node")
 		opts.Normalize(node)
 		n = node

--- a/cluster/calcium/pod.go
+++ b/cluster/calcium/pod.go
@@ -30,7 +30,7 @@ func (c *Calcium) RemovePod(ctx context.Context, podname string) error {
 		Podname: podname,
 		All:     true,
 	}
-	return c.withNodesResourceLocked(ctx, nf, func(ctx context.Context, nodes map[string]*types.Node) error {
+	return c.withNodesPodLocked(ctx, nf, func(ctx context.Context, nodes map[string]*types.Node) error {
 		// TODO dissociate workload to node
 		// TODO should remove node first
 		return logger.Err(ctx, errors.WithStack(c.store.RemovePod(ctx, podname)))

--- a/cluster/calcium/realloc.go
+++ b/cluster/calcium/realloc.go
@@ -21,7 +21,7 @@ func (c *Calcium) ReallocResource(ctx context.Context, opts *types.ReallocOption
 	if err != nil {
 		return
 	}
-	return c.withNodeResourceLocked(ctx, workload.Nodename, func(ctx context.Context, node *types.Node) error {
+	return c.withNodePodLocked(ctx, workload.Nodename, func(ctx context.Context, node *types.Node) error {
 
 		return c.withWorkloadLocked(ctx, opts.ID, func(ctx context.Context, workload *types.Workload) error {
 			rrs, err := resources.MakeRequests(

--- a/cluster/calcium/remove.go
+++ b/cluster/calcium/remove.go
@@ -33,7 +33,7 @@ func (c *Calcium) RemoveWorkload(ctx context.Context, ids []string, force bool) 
 			utils.SentryGo(func(nodename string, workloadIDs []string) func() {
 				return func() {
 					defer wg.Done()
-					if err := c.withNodeResourceLocked(ctx, nodename, func(ctx context.Context, node *types.Node) error {
+					if err := c.withNodePodLocked(ctx, nodename, func(ctx context.Context, node *types.Node) error {
 						for _, workloadID := range workloadIDs {
 							ret := &types.RemoveWorkloadMessage{WorkloadID: workloadID, Success: true, Hook: []*bytes.Buffer{}}
 							if err := c.withWorkloadLocked(ctx, workloadID, func(ctx context.Context, workload *types.Workload) error {

--- a/cluster/calcium/resource.go
+++ b/cluster/calcium/resource.go
@@ -64,7 +64,7 @@ func (c *Calcium) NodeResource(ctx context.Context, nodename string, fix bool) (
 
 func (c *Calcium) doGetNodeResource(ctx context.Context, nodename string, fix bool) (*types.NodeResource, error) {
 	var nr *types.NodeResource
-	return nr, c.withNodeResourceLocked(ctx, nodename, func(ctx context.Context, node *types.Node) error {
+	return nr, c.withNodePodLocked(ctx, nodename, func(ctx context.Context, node *types.Node) error {
 		workloads, err := c.ListNodeWorkloads(ctx, node.Name, nil)
 		if err != nil {
 			return err

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -30,8 +30,8 @@ const (
 	WorkloadRestart = "restart"
 	// WorkloadLock for lock workload
 	WorkloadLock = "clock_%s"
-	// NodeResourceLock for lock node resource
-	NodeResourceLock = "cnode_%s_%s"
+	// PodLock for lock pod
+	PodLock = "plock_%s"
 	// NodeOperationLock for lock node operation
 	NodeOperationLock = "cnode_op_%s_%s"
 )

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	go.etcd.io/etcd/tests/v3 v3.5.0
 	go.uber.org/automaxprocs v1.3.0
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519
-	golang.org/x/exp v0.0.0-20220323204016-c86f0da35e87
+	golang.org/x/exp v0.0.0-20220328175248-053ad81199eb
 	golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	google.golang.org/grpc v1.40.0

--- a/go.sum
+++ b/go.sum
@@ -665,6 +665,8 @@ golang.org/x/exp v0.0.0-20191030013958-a1ab85dbe136/go.mod h1:JXzH8nQsPlswgeRAPE
 golang.org/x/exp v0.0.0-20200908183739-ae8ad444f925/go.mod h1:1phAWC201xIgDyaFpmDeZkgf70Q4Pd/CNqfRtVPtxNw=
 golang.org/x/exp v0.0.0-20220323204016-c86f0da35e87 h1:pFVxvJFSIGjuRLaw0mTTDfxn/AMeSYzY6Y/Hr7adkVU=
 golang.org/x/exp v0.0.0-20220323204016-c86f0da35e87/go.mod h1:lgLbSvA5ygNOMpwM/9anMpWVlVJ7Z+cHWq/eFuinpGE=
+golang.org/x/exp v0.0.0-20220328175248-053ad81199eb h1:pC9Okm6BVmxEw76PUu0XUbOTQ92JX11hfvqTjAV3qxM=
+golang.org/x/exp v0.0.0-20220328175248-053ad81199eb/go.mod h1:lgLbSvA5ygNOMpwM/9anMpWVlVJ7Z+cHWq/eFuinpGE=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=


### PR DESCRIPTION
把node resource锁的粒度改到了pod级别，可以大大优化deploy时的抢锁时间。