### PR TITLE
fix storage issue

### DIFF
--- a/resources/storage/storage.go
+++ b/resources/storage/storage.go
@@ -22,6 +22,9 @@ func MakeRequest(opts types.ResourceOptions) (resourcetypes.ResourceRequest, err
 		request: opts.StorageRequest,
 		limit:   opts.StorageLimit,
 	}
+	if sr.limit > 0 && sr.request == 0 {
+		sr.request = sr.limit
+	}
 	// add volume request / limit to storage request / limit
 	if len(opts.VolumeRequest) != 0 && len(opts.VolumeLimit) != len(opts.VolumeRequest) {
 		return nil, errors.Wrapf(types.ErrBadVolume, "volume request and limit must be the same length")


### PR DESCRIPTION
在之前的[PR](https://github.com/projecteru2/core/pull/572) 里，遗漏了一个地方，会导致不传storage-request的时候，会有这样的情况出现：

node有一个200G的volume，申请--storage-limit 150G，--volume-limit 100G，最终产生的storage-request为100G，而不是预期的250G。

修了一下这个问题。