### PR TITLE
[SPPSP-4850] fix the issue of realloc algorithm

### DIFF
--- a/scheduler/complex/cpu_test.go
+++ b/scheduler/complex/cpu_test.go
@@ -80,6 +80,7 @@ func TestCPUReallocPlan(t *testing.T) {
 		"1": 30,
 		"2": 40,
 	}
+	scheduleInfo.CPU.Add(CPU)
 	si, remain, aff := cpuReallocPlan(scheduleInfo, 1, CPU, 100)
 	assert.EqualValues(t, 0, remain)
 	assert.True(t, reflect.DeepEqual(aff, types.CPUMap{"0": 100}))
@@ -101,6 +102,7 @@ func TestCPUReallocPlan(t *testing.T) {
 		"1": 30,
 		"2": 40,
 	}
+	scheduleInfo.CPU.Add(CPU)
 	si, remain, aff = cpuReallocPlan(scheduleInfo, 1.2, CPU, 100)
 	assert.EqualValues(t, 0, remain)
 	assert.True(t, reflect.DeepEqual(aff, types.CPUMap{"0": 100, "2": 20}))
@@ -124,6 +126,7 @@ func TestCPUReallocPlan(t *testing.T) {
 		"2": 40,
 		"3": 10,
 	}
+	scheduleInfo.CPU.Add(CPU)
 	si, remain, aff = cpuReallocPlan(scheduleInfo, 2, CPU, 100)
 	assert.EqualValues(t, 0, remain)
 	assert.True(t, reflect.DeepEqual(aff, types.CPUMap{"0": 100, "1": 100}))
@@ -145,6 +148,7 @@ func TestCPUReallocPlan(t *testing.T) {
 		"1": 30,
 		"2": 40,
 	}
+	scheduleInfo.CPU.Add(CPU)
 	si, remain, aff = cpuReallocPlan(scheduleInfo, 2, CPU, 100)
 	assert.EqualValues(t, 1, remain)
 	assert.True(t, reflect.DeepEqual(aff, types.CPUMap{"0": 100}))
@@ -174,6 +178,7 @@ func TestCPUReallocWithPriorPlan(t *testing.T) {
 		"1": 30,
 		"2": 40,
 	}
+	scheduleInfo.CPU.Add(CPU)
 	si, cpuPlans, total, err := po.ReselectCPUNodes(context.TODO(), scheduleInfo, CPU, 2, 0)
 	assert.Nil(t, err)
 	assert.EqualValues(t, 1, total)
@@ -198,6 +203,7 @@ func TestCPUReallocWithPriorPlan(t *testing.T) {
 		"1": 30,
 		"2": 40,
 	}
+	scheduleInfo.CPU.Add(CPU)
 	si, cpuPlans, total, err = po.ReselectCPUNodes(context.TODO(), scheduleInfo, CPU, 2, 0)
 	assert.Nil(t, err)
 	assert.EqualValues(t, 3, total)
@@ -233,6 +239,7 @@ func TestCPUReallocWithPriorPlan(t *testing.T) {
 		"1": 30,
 		"2": 40,
 	}
+	scheduleInfo.CPU.Add(CPU)
 	_, _, _, err = po.ReselectCPUNodes(context.TODO(), scheduleInfo, CPU, 2, 0)
 	assert.EqualError(t, err, "failed to reschedule cpu: no node remains 1.00 pieces of cpu and 0 bytes of memory at the same time: not enough resource")
 }
@@ -262,7 +269,7 @@ func TestGetFullResult(t *testing.T) {
 		{"1": 100, "2": 100},
 	})
 
-	res = h.getFullResult(2,  []resourceInfo{
+	res = h.getFullResult(2, []resourceInfo{
 		{
 			id:     "0",
 			pieces: 200,

--- a/scheduler/complex/potassium.go
+++ b/scheduler/complex/potassium.go
@@ -204,6 +204,7 @@ func cpuReallocPlan(scheduleInfo resourcetypes.ScheduleInfo, quota float64, CPU 
 		cpuIDs = append(cpuIDs, cpuID)
 	}
 	sort.Slice(cpuIDs, func(i, j int) bool { return CPU[cpuIDs[i]] < CPU[cpuIDs[j]] })
+	scheduleInfo.CPU.Sub(CPU)
 
 	// shrink, ensure affinity
 	if diff <= 0 {


### PR DESCRIPTION
CPU的realloc算法有个陈年bug，在potassium.cpuReallocPlan里假定scheduleInfo.CPU是当前CPU余量。实际上，因为在cluster层做了RecycleResources操作，此时拿到的scheduleInfo是将existing归还给资源池后的状态。

这个bug会导致在没有设置超卖的node上，出现某个核分配了2 * sharebase的情况。