### PR TITLE
[SPCLD-6491] fix bugs of cpu realloc algorithm

### DIFF
--- a/types/helper.go
+++ b/types/helper.go
@@ -6,3 +6,8 @@ import "math"
 func Round(f float64) float64 {
 	return math.Round(f*1000000000) / 1000000000
 }
+
+// RoundToInt for float64 to int
+func RoundToInt(f float64) int64 {
+	return int64(math.Round(f))
+}

--- a/types/helper_test.go
+++ b/types/helper_test.go
@@ -16,3 +16,12 @@ func TestRound(t *testing.T) {
 	a = 19.99998
 	assert.InDelta(t, (Round(a)), 19.99998, 1e-6)
 }
+
+func TestRoundToInt(t *testing.T) {
+	a := 0.0199999998
+	assert.EqualValues(t, RoundToInt(a), 0)
+	a = 0.1999998
+	assert.EqualValues(t, RoundToInt(a), 0)
+	a = 1.999998
+	assert.EqualValues(t, RoundToInt(a), 2)
+}


### PR DESCRIPTION
旧版算法里cpu从0.1 -> 0.2的过程中会有bug，导致无法realloc。修复了一下这个问题，顺便修了一下realloc里的其他bug。