### PR TITLE
Decode plugin params with encoding/json/v2 instead of mapstructure

### DIFF
--- a/engine/transform.go
+++ b/engine/transform.go
@@ -1,29 +1,27 @@
 package engine
 
 import (
-	"github.com/go-viper/mapstructure/v2"
-
 	resourcetypes "github.com/projecteru2/core/resource/types"
 )
 
 // VirtualizationResource is the decoded per-engine resource view of a workload.
 type VirtualizationResource struct {
-	CPU           map[string]int64            `json:"cpu_map" mapstructure:"cpu_map"` // cpu id to share
-	Quota         float64                     `json:"cpu" mapstructure:"cpu"`
-	Memory        int64                       `json:"memory" mapstructure:"memory"`
-	Storage       int64                       `json:"storage" mapstructure:"storage"`
-	NUMANode      string                      `json:"numa_node" mapstructure:"numa_node"`
-	Volumes       []string                    `json:"volumes" mapstructure:"volumes"`
-	VolumePlan    map[string]map[string]int64 `json:"volume_plan" mapstructure:"volume_plan"`
-	VolumeChanged bool                        `json:"volume_changed" mapstructure:"volume_changed"` // set when a realloc request brings new volumes
-	IOPSOptions   map[string]string           `json:"iops_options" mapstructure:"IOPS_options"`     // format: {device_name: "read-IOPS:write-IOPS:read-bps:write-bps"}
-	Remap         bool                        `json:"remap" mapstructure:"remap"`
+	CPU           map[string]int64            `json:"cpu_map"` // cpu id to share
+	Quota         float64                     `json:"cpu"`
+	Memory        int64                       `json:"memory"`
+	Storage       int64                       `json:"storage"`
+	NUMANode      string                      `json:"numa_node"`
+	Volumes       []string                    `json:"volumes"`
+	VolumePlan    map[string]map[string]int64 `json:"volume_plan"`
+	VolumeChanged bool                        `json:"volume_changed"` // set when a realloc request brings new volumes
+	IOPSOptions   map[string]string           `json:"iops_options"`   // format: {device_name: "read-IOPS:write-IOPS:read-bps:write-bps"}
+	Remap         bool                        `json:"remap"`
 }
 
 // Decode merges every plugin's engine params into r.
 func (r *VirtualizationResource) Decode(engineParams resourcetypes.Resources) error {
 	for _, params := range engineParams {
-		if err := mapstructure.Decode(params, r); err != nil {
+		if err := resourcetypes.Decode(params, r); err != nil {
 			return err
 		}
 	}

--- a/engine/transform_test.go
+++ b/engine/transform_test.go
@@ -25,3 +25,27 @@ func TestVirtualizationResourceDecode(t *testing.T) {
 
 	assert.NoError(t, (&VirtualizationResource{}).Decode(resourcetypes.Resources{}))
 }
+
+func TestVirtualizationResourceDecodeMergesEveryPlugin(t *testing.T) {
+	engineParams := resourcetypes.Resources{
+		"cpumem": {
+			"cpu_map": map[string]int64{"1": 100},
+			"cpu":     2.0,
+			"memory":  10000,
+		},
+		"storage": {
+			"storage":      20000,
+			"volumes":      []string{"/data:/data"},
+			"iops_options": map[string]string{"/dev/vda": "1000:1000:0:0"},
+		},
+	}
+
+	dst := &VirtualizationResource{}
+	assert.NoError(t, dst.Decode(engineParams))
+	assert.Equal(t, 2.0, dst.Quota)
+	assert.Equal(t, map[string]int64{"1": 100}, dst.CPU)
+	assert.EqualValues(t, 10000, dst.Memory)
+	assert.EqualValues(t, 20000, dst.Storage)
+	assert.Equal(t, []string{"/data:/data"}, dst.Volumes)
+	assert.Equal(t, map[string]string{"/dev/vda": "1000:1000:0:0"}, dst.IOPSOptions)
+}

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/docker/go-units v0.5.0
 	github.com/getsentry/sentry-go v0.48.0
 	github.com/go-git/go-git/v5 v5.19.2
-	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/jinzhu/configor v1.2.2
 	github.com/moby/go-archive v0.3.3
 	github.com/opencontainers/image-spec v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,6 @@ github.com/go-logr/logr v1.4.4/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ4
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
-github.com/go-viper/mapstructure/v2 v2.5.0 h1:vM5IJoUAy3d7zRSVtIwQgBj7BiWtMPfmPEgAXnvj1Ro=
-github.com/go-viper/mapstructure/v2 v2.5.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=

--- a/resource/plugins/binary/types/calculate.go
+++ b/resource/plugins/binary/types/calculate.go
@@ -5,18 +5,18 @@ import (
 )
 
 type CalculateDeployRequest struct {
-	Nodename                string                              `json:"nodename" mapstructure:"nodename"`
-	DeployCount             int                                 `json:"deploy_count" mapstructure:"deploy_count"`
-	WorkloadResourceRequest plugintypes.WorkloadResourceRequest `json:"workload_resource_request" mapstructure:"workload_resource_request"`
+	Nodename                string                              `json:"nodename"`
+	DeployCount             int                                 `json:"deploy_count"`
+	WorkloadResourceRequest plugintypes.WorkloadResourceRequest `json:"workload_resource_request"`
 }
 
 type CalculateReallocRequest struct {
-	Nodename                string                              `json:"nodename" mapstructure:"nodename"`
-	WorkloadResource        plugintypes.WorkloadResource        `json:"workload_resource" mapstructure:"workload_resource"`
-	WorkloadResourceRequest plugintypes.WorkloadResourceRequest `json:"workload_resource_request" mapstructure:"workload_resource_request"`
+	Nodename                string                              `json:"nodename"`
+	WorkloadResource        plugintypes.WorkloadResource        `json:"workload_resource"`
+	WorkloadResourceRequest plugintypes.WorkloadResourceRequest `json:"workload_resource_request"`
 }
 
 type CalculateRemapRequest struct {
-	Nodename          string                                  `json:"nodename" mapstructure:"nodename"`
-	WorkloadsResource map[string]plugintypes.WorkloadResource `json:"workloads_resource" mapstructure:"workloads_resource"`
+	Nodename          string                                  `json:"nodename"`
+	WorkloadsResource map[string]plugintypes.WorkloadResource `json:"workloads_resource"`
 }

--- a/resource/plugins/binary/types/metrics.go
+++ b/resource/plugins/binary/types/metrics.go
@@ -3,6 +3,6 @@ package types
 type GetMetricsDescriptionRequest struct{}
 
 type GetMetricsRequest struct {
-	Podname  string `json:"podname" mapstructure:"podname"`
-	Nodename string `json:"nodename" mapstructure:"nodename"`
+	Podname  string `json:"podname"`
+	Nodename string `json:"nodename"`
 }

--- a/resource/plugins/binary/types/node.go
+++ b/resource/plugins/binary/types/node.go
@@ -6,48 +6,48 @@ import (
 )
 
 type AddNodeRequest struct {
-	Nodename string                   `json:"nodename" mapstructure:"nodename"`
-	Resource plugintypes.NodeResource `json:"resource" mapstructure:"resource"`
-	Info     *enginetypes.Info        `json:"info" mapstructure:"info"`
+	Nodename string                   `json:"nodename"`
+	Resource plugintypes.NodeResource `json:"resource"`
+	Info     *enginetypes.Info        `json:"info"`
 }
 
 type RemoveNodeRequest struct {
-	Nodename string `json:"nodename" mapstructure:"nodename"`
+	Nodename string `json:"nodename"`
 }
 
 type GetNodesDeployCapacityRequest struct {
-	Nodenames        []string                     `json:"nodenames" mapstructure:"nodenames"`
-	WorkloadResource plugintypes.WorkloadResource `json:"workload_resource" mapstructure:"workload_resource"`
+	Nodenames        []string                     `json:"nodenames"`
+	WorkloadResource plugintypes.WorkloadResource `json:"workload_resource"`
 }
 
 type SetNodeResourceCapacityRequest struct {
-	Nodename        string                   `json:"nodename" mapstructure:"nodename"`
-	Resource        plugintypes.NodeResource `json:"resource" mapstructure:"resource"`
-	ResourceRequest plugintypes.NodeResource `json:"resource_request" mapstructure:"resource_request"`
-	Delta           bool                     `json:"delta" mapstructure:"delta"`
-	Incr            bool                     `json:"incr" mapstructure:"incr"`
+	Nodename        string                   `json:"nodename"`
+	Resource        plugintypes.NodeResource `json:"resource"`
+	ResourceRequest plugintypes.NodeResource `json:"resource_request"`
+	Delta           bool                     `json:"delta"`
+	Incr            bool                     `json:"incr"`
 }
 
 type GetNodeResourceInfoRequest struct {
-	Nodename          string                         `json:"nodename" mapstructure:"nodename"`
-	WorkloadsResource []plugintypes.WorkloadResource `json:"workloads_resource" mapstructure:"workloads_resource"`
+	Nodename          string                         `json:"nodename"`
+	WorkloadsResource []plugintypes.WorkloadResource `json:"workloads_resource"`
 }
 
 type SetNodeResourceInfoRequest struct {
-	Nodename string                   `json:"nodename" mapstructure:"nodename"`
-	Capacity plugintypes.NodeResource `json:"capacity" mapstructure:"capacity"`
-	Usage    plugintypes.NodeResource `json:"usage" mapstructure:"usage"`
+	Nodename string                   `json:"nodename"`
+	Capacity plugintypes.NodeResource `json:"capacity"`
+	Usage    plugintypes.NodeResource `json:"usage"`
 }
 
 type SetNodeResourceUsageRequest struct {
-	Nodename          string                         `json:"nodename" mapstructure:"nodename"`
-	WorkloadsResource []plugintypes.WorkloadResource `json:"workloads_resource" mapstructure:"workloads_resource"`
-	Resource          plugintypes.NodeResource       `json:"resource" mapstructure:"resource"`
-	ResourceRequest   plugintypes.NodeResource       `json:"resource_request" mapstructure:"resource_request"`
-	Delta             bool                           `json:"delta" mapstructure:"delta"`
-	Incr              bool                           `json:"incr" mapstructure:"incr"`
+	Nodename          string                         `json:"nodename"`
+	WorkloadsResource []plugintypes.WorkloadResource `json:"workloads_resource"`
+	Resource          plugintypes.NodeResource       `json:"resource"`
+	ResourceRequest   plugintypes.NodeResource       `json:"resource_request"`
+	Delta             bool                           `json:"delta"`
+	Incr              bool                           `json:"incr"`
 }
 
 type GetMostIdleNodeRequest struct {
-	Nodenames []string `json:"nodenames" mapstructure:"nodenames"`
+	Nodenames []string `json:"nodenames"`
 }

--- a/resource/plugins/cpumem/calculate.go
+++ b/resource/plugins/cpumem/calculate.go
@@ -5,12 +5,12 @@ import (
 	"slices"
 
 	"github.com/cockroachdb/errors"
-	"github.com/go-viper/mapstructure/v2"
 
 	"github.com/projecteru2/core/log"
 	"github.com/projecteru2/core/resource/plugins/cpumem/schedule"
 	cpumemtypes "github.com/projecteru2/core/resource/plugins/cpumem/types"
 	plugintypes "github.com/projecteru2/core/resource/plugins/types"
+	resourcetypes "github.com/projecteru2/core/resource/types"
 	coretypes "github.com/projecteru2/core/types"
 )
 
@@ -42,7 +42,7 @@ func (p Plugin) CalculateDeploy(ctx context.Context, nodename string, deployCoun
 	}
 
 	resp := &plugintypes.CalculateDeployResponse{}
-	return resp, mapstructure.Decode(map[string]any{
+	return resp, resourcetypes.Decode(map[string]any{
 		"engines_params":     enginesParams,
 		"workloads_resource": workloadsResource,
 	}, resp)
@@ -127,7 +127,7 @@ func (p Plugin) CalculateRealloc(ctx context.Context, nodename string, resource 
 	deltaWorkloadResource.Sub(originResource)
 
 	resp := &plugintypes.CalculateReallocResponse{}
-	return resp, mapstructure.Decode(map[string]any{
+	return resp, resourcetypes.Decode(map[string]any{
 		"engine_params":     engineParams,
 		"delta_resource":    deltaWorkloadResource,
 		"workload_resource": newResource,
@@ -138,7 +138,7 @@ func (p Plugin) CalculateRemap(ctx context.Context, nodename string, workloadsRe
 	resp := &plugintypes.CalculateRemapResponse{}
 	engineParamsMap := map[string]*cpumemtypes.EngineParams{}
 	if len(workloadsResource) == 0 {
-		return resp, mapstructure.Decode(map[string]any{
+		return resp, resourcetypes.Decode(map[string]any{
 			"engine_params_map": engineParamsMap,
 		}, resp)
 	}
@@ -185,7 +185,7 @@ func (p Plugin) CalculateRemap(ctx context.Context, nodename string, workloadsRe
 		}
 	}
 
-	return resp, mapstructure.Decode(map[string]any{
+	return resp, resourcetypes.Decode(map[string]any{
 		"engine_params_map": engineParamsMap,
 	}, resp)
 }

--- a/resource/plugins/cpumem/metrics.go
+++ b/resource/plugins/cpumem/metrics.go
@@ -5,9 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/go-viper/mapstructure/v2"
-
 	plugintypes "github.com/projecteru2/core/resource/plugins/types"
+	resourcetypes "github.com/projecteru2/core/resource/types"
 )
 
 const (
@@ -27,7 +26,7 @@ const (
 
 func (p Plugin) GetMetricsDescription(context.Context) (*plugintypes.GetMetricsDescriptionResponse, error) {
 	resp := &plugintypes.GetMetricsDescriptionResponse{}
-	return resp, mapstructure.Decode([]map[string]any{
+	return resp, resourcetypes.Decode([]map[string]any{
 		{
 			fieldName:   "cpu_map",
 			fieldHelp:   "node available cpu.",
@@ -92,5 +91,5 @@ func (p Plugin) GetMetrics(ctx context.Context, podname, nodename string) (*plug
 	}
 
 	resp := &plugintypes.GetMetricsResponse{}
-	return resp, mapstructure.Decode(metrics, resp)
+	return resp, resourcetypes.Decode(metrics, resp)
 }

--- a/resource/plugins/cpumem/node.go
+++ b/resource/plugins/cpumem/node.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 
 	"github.com/cockroachdb/errors"
-	"github.com/go-viper/mapstructure/v2"
 	"github.com/sanity-io/litter"
 
 	enginetypes "github.com/projecteru2/core/engine/types"
@@ -18,6 +17,7 @@ import (
 	"github.com/projecteru2/core/resource/plugins/cpumem/schedule"
 	cpumemtypes "github.com/projecteru2/core/resource/plugins/cpumem/types"
 	plugintypes "github.com/projecteru2/core/resource/plugins/types"
+	resourcetypes "github.com/projecteru2/core/resource/types"
 	coretypes "github.com/projecteru2/core/types"
 	"github.com/projecteru2/core/utils"
 )
@@ -97,7 +97,7 @@ func (p Plugin) AddNode(ctx context.Context, nodename string, resource plugintyp
 	}
 
 	resp := &plugintypes.AddNodeResponse{}
-	return resp, mapstructure.Decode(map[string]any{
+	return resp, resourcetypes.Decode(map[string]any{
 		fieldCapacity: nodeResourceInfo.Capacity,
 		fieldUsage:    nodeResourceInfo.Usage,
 	}, resp)
@@ -142,7 +142,7 @@ func (p Plugin) GetNodesDeployCapacity(ctx context.Context, nodenames []string, 
 	}
 
 	resp := &plugintypes.GetNodesDeployCapacityResponse{}
-	return resp, mapstructure.Decode(map[string]any{
+	return resp, resourcetypes.Decode(map[string]any{
 		"nodes_deploy_capacity_map": nodesDeployCapacityMap,
 		"total":                     total,
 	}, resp)
@@ -175,7 +175,7 @@ func (p Plugin) SetNodeResourceCapacity(ctx context.Context, nodename string, re
 	}
 
 	resp := &plugintypes.SetNodeResourceCapacityResponse{}
-	return resp, mapstructure.Decode(map[string]any{
+	return resp, resourcetypes.Decode(map[string]any{
 		"before": before,
 		"after":  nodeResourceInfo.Capacity,
 	}, resp)
@@ -188,7 +188,7 @@ func (p Plugin) GetNodeResourceInfo(ctx context.Context, nodename string, worklo
 	}
 
 	resp := &plugintypes.GetNodeResourceInfoResponse{}
-	return resp, mapstructure.Decode(map[string]any{
+	return resp, resourcetypes.Decode(map[string]any{
 		fieldCapacity: nodeResourceInfo.Capacity,
 		fieldUsage:    nodeResourceInfo.Usage,
 		"diffs":       diffs,
@@ -229,7 +229,7 @@ func (p Plugin) SetNodeResourceUsage(ctx context.Context, nodename string, resou
 	}
 
 	resp := &plugintypes.SetNodeResourceUsageResponse{}
-	return resp, mapstructure.Decode(map[string]any{
+	return resp, resourcetypes.Decode(map[string]any{
 		"before": before,
 		"after":  nodeResourceInfo.Usage,
 	}, resp)
@@ -255,7 +255,7 @@ func (p Plugin) GetMostIdleNode(ctx context.Context, nodenames []string) (*plugi
 	}
 
 	resp := &plugintypes.GetMostIdleNodeResponse{}
-	return resp, mapstructure.Decode(map[string]any{
+	return resp, resourcetypes.Decode(map[string]any{
 		fieldNodename: mostIdleNode,
 		fieldPriority: priority,
 	}, resp)
@@ -281,7 +281,7 @@ func (p Plugin) FixNodeResource(ctx context.Context, nodename string, workloadsR
 	}
 
 	resp := &plugintypes.GetNodeResourceInfoResponse{}
-	return resp, mapstructure.Decode(map[string]any{
+	return resp, resourcetypes.Decode(map[string]any{
 		fieldCapacity: nodeResourceInfo.Capacity,
 		fieldUsage:    nodeResourceInfo.Usage,
 		"diffs":       diffs,

--- a/resource/plugins/cpumem/node_test.go
+++ b/resource/plugins/cpumem/node_test.go
@@ -11,7 +11,6 @@ import (
 
 	enginetypes "github.com/projecteru2/core/engine/types"
 	"github.com/projecteru2/core/resource/plugins/cpumem/types"
-	cpumemtypes "github.com/projecteru2/core/resource/plugins/cpumem/types"
 	plugintypes "github.com/projecteru2/core/resource/plugins/types"
 	coretypes "github.com/projecteru2/core/types"
 )
@@ -34,7 +33,7 @@ func TestAddNode(t *testing.T) {
 
 	r, err := cm.AddNode(ctx, nodeForAdd, req, info)
 	assert.Nil(t, err)
-	assert.Equal(t, r.Capacity["memory"], int64(4*units.GB*rate/10))
+	assert.Equal(t, r.Capacity["memory"], float64(4*units.GB*rate/10))
 }
 
 func TestRemoveNode(t *testing.T) {
@@ -383,7 +382,7 @@ func TestSetNodeResourceUsage(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Len(t, r.After["cpu_map"], 2)
 	assert.Equal(t, r.After["cpu"], 0.0)
-	assert.Equal(t, r.After["memory"], int64(0))
+	assert.Equal(t, r.After["memory"], 0.0)
 
 	r, err = cm.SetNodeResourceUsage(ctx, node, nil, nodeResourceRequest, nil, true, true)
 	assert.Nil(t, err)
@@ -393,7 +392,7 @@ func TestSetNodeResourceUsage(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Len(t, r.After["cpu_map"], 2)
 	assert.Equal(t, r.After["cpu"], 0.0)
-	assert.Equal(t, r.After["memory"], int64(0))
+	assert.Equal(t, r.After["memory"], 0.0)
 
 	r, err = cm.SetNodeResourceUsage(ctx, node, nil, nil, workloadsResource, true, true)
 	assert.Nil(t, err)
@@ -403,19 +402,19 @@ func TestSetNodeResourceUsage(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Len(t, r.After["cpu_map"], 2)
 	assert.Equal(t, r.After["cpu"], 0.0)
-	assert.Equal(t, r.After["memory"], int64(0))
+	assert.Equal(t, r.After["memory"], 0.0)
 
 	r, err = cm.SetNodeResourceUsage(ctx, node, nil, nil, nil, true, false)
 	assert.Nil(t, err)
 	assert.Len(t, r.After["cpu_map"], 2)
 	assert.Equal(t, r.After["cpu"], 0.0)
-	assert.Equal(t, r.After["memory"], int64(0))
+	assert.Equal(t, r.After["memory"], 0.0)
 
 	r, err = cm.SetNodeResourceUsage(ctx, node, nil, nodeResourceRequest, nil, false, false)
 	assert.Nil(t, err)
 	assert.Len(t, r.After["cpu_map"], 2)
 	assert.Equal(t, r.After["cpu"], 2.0)
-	assert.Equal(t, r.After["memory"], int64(2*units.GB))
+	assert.Equal(t, r.After["memory"], float64(2*units.GB))
 }
 
 func TestGetMostIdleNode(t *testing.T) {
@@ -465,7 +464,7 @@ func TestAddNodeSplitsMemoryPerNUMANode(t *testing.T) {
 	r, err := cm.AddNode(ctx, "numa-node", req, nil)
 	assert.Nil(t, err)
 
-	numaMemory, ok := r.Capacity["numa_memory"].(cpumemtypes.NUMAMemory)
+	numaMemory, ok := r.Capacity["numa_memory"].(map[string]any)
 	assert.True(t, ok)
-	assert.Equal(t, cpumemtypes.NUMAMemory{"0": 4 * units.GB, "1": 4 * units.GB}, numaMemory)
+	assert.Equal(t, map[string]any{"0": float64(4 * units.GB), "1": float64(4 * units.GB)}, numaMemory)
 }

--- a/resource/plugins/cpumem/types/engine.go
+++ b/resource/plugins/cpumem/types/engine.go
@@ -1,9 +1,9 @@
 package types
 
 type EngineParams struct {
-	CPU      float64 `json:"cpu" mapstructure:"cpu"`
-	CPUMap   CPUMap  `json:"cpu_map" mapstructure:"cpu_map"`
-	NUMANode string  `json:"numa_node" mapstructure:"numa_node"`
-	Memory   int64   `json:"memory" mapstructure:"memory"`
-	Remap    bool    `json:"remap" mapstructure:"remap"`
+	CPU      float64 `json:"cpu"`
+	CPUMap   CPUMap  `json:"cpu_map"`
+	NUMANode string  `json:"numa_node"`
+	Memory   int64   `json:"memory"`
+	Remap    bool    `json:"remap"`
 }

--- a/resource/plugins/cpumem/types/node.go
+++ b/resource/plugins/cpumem/types/node.go
@@ -6,8 +6,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/go-viper/mapstructure/v2"
-
 	resourcetypes "github.com/projecteru2/core/resource/types"
 	coretypes "github.com/projecteru2/core/types"
 	coreutils "github.com/projecteru2/core/utils"
@@ -15,15 +13,15 @@ import (
 
 // NodeResource is the cpu and memory of one node.
 type NodeResource struct {
-	CPU        float64    `json:"cpu" mapstructure:"cpu"`
-	CPUMap     CPUMap     `json:"cpu_map" mapstructure:"cpu_map"`
-	Memory     int64      `json:"memory" mapstructure:"memory"`
-	NUMAMemory NUMAMemory `json:"numa_memory" mapstructure:"numa_memory"`
-	NUMA       NUMA       `json:"numa" mapstructure:"numa"`
+	CPU        float64    `json:"cpu"`
+	CPUMap     CPUMap     `json:"cpu_map"`
+	Memory     int64      `json:"memory"`
+	NUMAMemory NUMAMemory `json:"numa_memory"`
+	NUMA       NUMA       `json:"numa"`
 }
 
 func (r *NodeResource) Parse(rawParams resourcetypes.RawParams) error {
-	return mapstructure.Decode(rawParams, r)
+	return resourcetypes.Decode(rawParams, r)
 }
 
 func (r *NodeResource) DeepCopy() *NodeResource {

--- a/resource/plugins/cpumem/types/workload.go
+++ b/resource/plugins/cpumem/types/workload.go
@@ -4,7 +4,6 @@ import (
 	"maps"
 
 	"github.com/cockroachdb/errors"
-	"github.com/go-viper/mapstructure/v2"
 
 	resourcetypes "github.com/projecteru2/core/resource/types"
 	coreutils "github.com/projecteru2/core/utils"
@@ -12,17 +11,17 @@ import (
 
 // WorkloadResource is the cpu and memory allocated to one workload.
 type WorkloadResource struct {
-	CPURequest    float64    `json:"cpu_request" mapstructure:"cpu_request"`
-	CPULimit      float64    `json:"cpu_limit" mapstructure:"cpu_limit"`
-	MemoryRequest int64      `json:"memory_request" mapstructure:"memory_request"`
-	MemoryLimit   int64      `json:"memory_limit" mapstructure:"memory_limit"`
-	CPUMap        CPUMap     `json:"cpu_map" mapstructure:"cpu_map"`
-	NUMAMemory    NUMAMemory `json:"numa_memory" mapstructure:"numa_memory"`
-	NUMANode      string     `json:"numa_node" mapstructure:"numa_node"`
+	CPURequest    float64    `json:"cpu_request"`
+	CPULimit      float64    `json:"cpu_limit"`
+	MemoryRequest int64      `json:"memory_request"`
+	MemoryLimit   int64      `json:"memory_limit"`
+	CPUMap        CPUMap     `json:"cpu_map"`
+	NUMAMemory    NUMAMemory `json:"numa_memory"`
+	NUMANode      string     `json:"numa_node"`
 }
 
 func (w *WorkloadResource) Parse(rawParams resourcetypes.RawParams) error {
-	return mapstructure.Decode(rawParams, w)
+	return resourcetypes.Decode(rawParams, w)
 }
 
 func (w *WorkloadResource) DeepCopy() *WorkloadResource {

--- a/resource/plugins/types/calculate.go
+++ b/resource/plugins/types/calculate.go
@@ -1,16 +1,16 @@
 package types
 
 type CalculateDeployResponse struct {
-	EnginesParams     []EngineParams     `json:"engines_params" mapstructure:"engines_params"`
-	WorkloadsResource []WorkloadResource `json:"workloads_resource" mapstructure:"workloads_resource"`
+	EnginesParams     []EngineParams     `json:"engines_params"`
+	WorkloadsResource []WorkloadResource `json:"workloads_resource"`
 }
 
 type CalculateReallocResponse struct {
-	EngineParams     EngineParams     `json:"engine_params" mapstructure:"engine_params"`
-	DeltaResource    WorkloadResource `json:"delta_resource" mapstructure:"delta_resource"`
-	WorkloadResource WorkloadResource `json:"workload_resource" mapstructure:"workload_resource"`
+	EngineParams     EngineParams     `json:"engine_params"`
+	DeltaResource    WorkloadResource `json:"delta_resource"`
+	WorkloadResource WorkloadResource `json:"workload_resource"`
 }
 
 type CalculateRemapResponse struct {
-	EngineParamsMap map[string]EngineParams `json:"engine_params_map" mapstructure:"engine_params_map"`
+	EngineParamsMap map[string]EngineParams `json:"engine_params_map"`
 }

--- a/resource/plugins/types/metrics.go
+++ b/resource/plugins/types/metrics.go
@@ -1,19 +1,19 @@
 package types
 
 type MetricsDescription struct {
-	Name   string   `json:"name" mapstructure:"name"`
-	Help   string   `json:"help" mapstructure:"help"`
-	Type   string   `json:"type" mapstructure:"type"`
-	Labels []string `json:"labels" mapstructure:"labels"`
+	Name   string   `json:"name"`
+	Help   string   `json:"help"`
+	Type   string   `json:"type"`
+	Labels []string `json:"labels"`
 }
 
 type GetMetricsDescriptionResponse []*MetricsDescription
 
 type Metrics struct {
-	Name   string   `json:"name" mapstructure:"name"`
-	Labels []string `json:"labels" mapstructure:"labels"`
-	Key    string   `json:"key" mapstructure:"key"`
-	Value  string   `json:"value" mapstructure:"value"`
+	Name   string   `json:"name"`
+	Labels []string `json:"labels"`
+	Key    string   `json:"key"`
+	Value  string   `json:"value"`
 }
 
 type GetMetricsResponse []*Metrics

--- a/resource/plugins/types/node.go
+++ b/resource/plugins/types/node.go
@@ -9,8 +9,8 @@ type NodeResourceRequest = resourcetypes.RawParams
 type NodeResource = resourcetypes.RawParams
 
 type AddNodeResponse struct {
-	Capacity NodeResource `json:"capacity" mapstructure:"capacity"`
-	Usage    NodeResource `json:"usage" mapstructure:"usage"`
+	Capacity NodeResource `json:"capacity"`
+	Usage    NodeResource `json:"usage"`
 }
 
 type RemoveNodeResponse struct{}
@@ -26,26 +26,26 @@ type NodeDeployCapacity struct {
 }
 
 type GetNodesDeployCapacityResponse struct {
-	NodeDeployCapacityMap map[string]*NodeDeployCapacity `json:"nodes_deploy_capacity_map" mapstructure:"nodes_deploy_capacity_map"`
-	Total                 int                            `json:"total" mapstructure:"total"`
+	NodeDeployCapacityMap map[string]*NodeDeployCapacity `json:"nodes_deploy_capacity_map"`
+	Total                 int                            `json:"total"`
 }
 
 type SetNodeResourceCapacityResponse struct {
-	Before NodeResource `json:"before" mapstructure:"before"`
-	After  NodeResource `json:"after" mapstructure:"after"`
+	Before NodeResource `json:"before"`
+	After  NodeResource `json:"after"`
 }
 
 type GetNodeResourceInfoResponse struct {
-	Capacity NodeResource `json:"capacity" mapstructure:"capacity"`
-	Usage    NodeResource `json:"usage" mapstructure:"usage"`
-	Diffs    []string     `json:"diffs" mapstructure:"diffs"`
+	Capacity NodeResource `json:"capacity"`
+	Usage    NodeResource `json:"usage"`
+	Diffs    []string     `json:"diffs"`
 }
 
 type SetNodeResourceInfoResponse struct{}
 
 type SetNodeResourceUsageResponse struct {
-	Before NodeResource `json:"before" mapstructure:"before"`
-	After  NodeResource `json:"after" mapstructure:"after"`
+	Before NodeResource `json:"before"`
+	After  NodeResource `json:"after"`
 }
 
 type GetMostIdleNodeResponse struct {

--- a/resource/types/decode.go
+++ b/resource/types/decode.go
@@ -1,0 +1,12 @@
+package types
+
+import "encoding/json/v2"
+
+// Decode round-trips in through JSON into out.
+func Decode(in, out any) error {
+	body, err := json.Marshal(in)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(body, out)
+}

--- a/resource/types/decode_test.go
+++ b/resource/types/decode_test.go
@@ -1,0 +1,48 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDecodeKeysAMapByJSONTag(t *testing.T) {
+	out := RawParams{}
+	assert.NoError(t, Decode(decodeTarget{Name: "n1", Size: 3}, &out))
+	assert.Equal(t, RawParams{"name": "n1", "size": float64(3)}, out)
+}
+
+func TestDecodeReadsAMapIntoAStruct(t *testing.T) {
+	out := &decodeTarget{}
+	assert.NoError(t, Decode(map[string]any{"name": "n1", "size": int64(3)}, out))
+	assert.Equal(t, &decodeTarget{Name: "n1", Size: 3}, out)
+}
+
+func TestDecodeLeavesFieldsTheInputOmits(t *testing.T) {
+	out := &decodeTarget{Name: "kept", Size: 7}
+	assert.NoError(t, Decode(map[string]any{"size": 9}, out))
+	assert.Equal(t, &decodeTarget{Name: "kept", Size: 9}, out)
+}
+
+func TestDecodeRejectsAFractionalInteger(t *testing.T) {
+	assert.Error(t, Decode(map[string]any{"size": 1.5}, &decodeTarget{}))
+}
+
+func TestDecodeRejectsAnUnmarshalableInput(t *testing.T) {
+	assert.Error(t, Decode(map[string]any{"size": func() {}}, &decodeTarget{}))
+}
+
+func BenchmarkDecode(b *testing.B) {
+	in := map[string]any{"name": "n1", "size": int64(3)}
+	for b.Loop() {
+		out := &decodeTarget{}
+		if err := Decode(in, out); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+type decodeTarget struct {
+	Name string `json:"name"`
+	Size int64  `json:"size"`
+}

--- a/resource/types/resource.go
+++ b/resource/types/resource.go
@@ -2,9 +2,8 @@ package types
 
 import (
 	"fmt"
+	"maps"
 	"strconv"
-
-	"github.com/go-viper/mapstructure/v2"
 )
 
 type RawParams map[string]any
@@ -64,7 +63,7 @@ func (r RawParams) RawParams(key string) RawParams {
 	if r.IsSet(key) {
 		if m, ok := r[key].(map[string]any); ok {
 			n = RawParams{}
-			_ = mapstructure.Decode(m, &n)
+			maps.Copy(n, m)
 		}
 	}
 	return n
@@ -77,7 +76,7 @@ func (r RawParams) SliceRawParams(key string) []RawParams {
 	}
 	n := make([]RawParams, len(res))
 	for i, v := range res {
-		_ = mapstructure.Decode(v, &n[i])
+		n[i] = maps.Clone(v)
 	}
 	return n
 }


### PR DESCRIPTION
Stacked on #647.

## Summary

All 16 `mapstructure.Decode` sites (resource/types, resource/plugins/*, engine/transform.go) carried `mapstructure:` tags byte-identical to their `json:` tags, so the wire contract with binary plugins is unchanged. They now go through one `resourcetypes.Decode(in, out)` helper — a JSON round-trip on `encoding/json/v2` (Go 1.27, no GOEXPERIMENT) — and `github.com/go-viper/mapstructure/v2` leaves go.mod.

## Performance A/B

`go test -bench`, `-count=3 -benchmem`, NodeResourceRequest-shaped payload (cpu map, numa, numa_memory, storage, volumes), both arm orders — identical results:

| arm | ns/op | B/op | allocs/op |
|---|---|---|---|
| mapstructure | 6142–6589 | 5536 | 135 |
| json/v2 | 4555–4669 | 1754 | 42 |

json/v2 is ~26% faster with 3.2× fewer allocations on the cpumem RPC path. resource-extend measured the same direction on its payloads (projecteru2/resource-extend#1).

## Evidence

```
GOWORK=off go test -race -count=1 ./resource/... ./engine/ ./types/  -> ok
GOWORK=off golangci-lint run ./...                                 -> 0 issues.
asl ./...                                                          -> 0 findings
```