### PR TITLE
Load config with yaml.v3 and a default/required walker instead of configor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/docker/go-units v0.5.0
 	github.com/getsentry/sentry-go v0.48.0
 	github.com/go-git/go-git/v5 v5.19.2
-	github.com/jinzhu/configor v1.2.2
 	github.com/moby/go-archive v0.3.3
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/panjf2000/ants/v2 v2.12.1
@@ -36,11 +35,11 @@ require (
 	google.golang.org/grpc v1.83.1
 	google.golang.org/protobuf v1.36.12
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
 	dario.cat/mergo v1.0.2 // indirect
-	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/ProtonMail/go-crypto v1.4.1 // indirect
 	github.com/alicebob/gopher-json v0.0.0-20230218143504-906a9b012302 // indirect
@@ -136,7 +135,6 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20260819154853-08b0e4226688 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260819154853-08b0e4226688 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/utils v0.0.0-20260707023825-cf1189d6abe3 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,9 +4,6 @@ github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 h1:He8af
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEKWjV8V+WSxDXJ4NFATAsZjh8iIbsQIg=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
-github.com/BurntSushi/toml v1.2.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
-github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
-github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
@@ -144,8 +141,6 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 h1:/Tnpcb2E0Pz/tN9s3bfEY2Q8ePC
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0/go.mod h1:zOBXOsUaBSjKgmH4OGzV1esUpR3oUSCPYVd2cUBjKYY=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
-github.com/jinzhu/configor v1.2.2 h1:sLgh6KMzpCmaQB4e+9Fu/29VErtBUqsS2t8C9BNIVsA=
-github.com/jinzhu/configor v1.2.2/go.mod h1:iFFSfOBKP3kC2Dku0ZGB3t3aulfQgTGJknodhFavsU8=
 github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=
 github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=

--- a/utils/config.go
+++ b/utils/config.go
@@ -1,14 +1,89 @@
 package utils
 
 import (
-	"github.com/jinzhu/configor"
+	"os"
+	"reflect"
+
+	"github.com/cockroachdb/errors"
+	"gopkg.in/yaml.v3"
 
 	"github.com/projecteru2/core/types"
 )
 
+type fieldWalker func(reflect.Value) error
+
 // LoadConfig loads the config from the YAML file at configPath.
 func LoadConfig(configPath string) (types.Config, error) {
 	config := types.Config{}
+	value := reflect.ValueOf(&config).Elem()
+	if err := applyDefaults(value); err != nil {
+		return config, err
+	}
 
-	return config, configor.Load(&config, configPath)
+	data, err := os.ReadFile(configPath) //nolint:gosec // the config path comes from the operator's own flag
+	if err != nil {
+		return config, err
+	}
+	if err = yaml.Unmarshal(data, &config); err != nil {
+		return config, err
+	}
+	return config, checkRequired(value)
+}
+
+// defaults land before the file is read so an explicit zero in the file still wins
+func applyDefaults(value reflect.Value) error {
+	for i := range value.NumField() {
+		field := value.Field(i)
+		if !field.CanSet() {
+			continue
+		}
+		structField := value.Type().Field(i)
+		if tag := structField.Tag.Get("default"); tag != "" && field.IsZero() {
+			if err := yaml.Unmarshal([]byte(tag), field.Addr().Interface()); err != nil {
+				return errors.Wrapf(err, "bad default for %s", structField.Name)
+			}
+		}
+		if err := walkNested(field, applyDefaults); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func checkRequired(value reflect.Value) error {
+	for i := range value.NumField() {
+		field := value.Field(i)
+		if !field.CanSet() {
+			continue
+		}
+		if structField := value.Type().Field(i); structField.Tag.Get("required") == "true" && field.IsZero() {
+			return errors.Newf("%s is required, but blank", structField.Name)
+		}
+		if err := walkNested(field, checkRequired); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func walkNested(field reflect.Value, walk fieldWalker) error {
+	for field.Kind() == reflect.Pointer {
+		if field.IsNil() {
+			return nil
+		}
+		field = field.Elem()
+	}
+	switch field.Kind() {
+	case reflect.Struct:
+		return walk(field)
+	case reflect.Slice:
+		for i := range field.Len() {
+			if elem := reflect.Indirect(field.Index(i)); elem.Kind() == reflect.Struct {
+				if err := walk(elem); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
 }

--- a/utils/config_test.go
+++ b/utils/config_test.go
@@ -1,26 +1,21 @@
 package utils
 
 import (
-	"bytes"
-	"io"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestLoadConfig(t *testing.T) {
-	f1 := "test"
-	buffer := bytes.NewBufferString(f1)
-	fname, err := TempFile(io.NopCloser(buffer))
-	assert.NoError(t, err)
-	_, err = LoadConfig(fname)
-	assert.Error(t, err)
-	os.Remove(fname)
+const (
+	minimalConfig = `etcd:
+    machines:
+        - "http://127.0.0.1:2379"
+`
 
-	f1 = `log_level: "DEBUG"
-bind: ":5001"
+	fullConfig = `bind: ":5001"
 statsd: "127.0.0.1:8125"
 profile: ":12346"
 global_timeout: 300s
@@ -33,30 +28,101 @@ etcd:
         - "http://127.0.0.1:2379"
     lock_prefix: "core/_lock"
 git:
-    public_key: "***REMOVED***"
-    private_key: "***REMOVED***"
-    token: "***REMOVED***"
     scm_type: "github"
 docker:
     network_mode: "bridge"
-    cert_path: "/etc/eru/tls"
     hub: "hub.docker.com"
     namespace: "projecteru2"
     build_pod: "eru-test"
-    local_dns: true
+scheduler:
+    sharebase: 50
 `
+)
 
-	buffer = bytes.NewBufferString(f1)
-	fname, err = TempFile(io.NopCloser(buffer))
+func TestLoadConfigAppliesDefaults(t *testing.T) {
+	config, err := LoadConfig(writeConfig(t, minimalConfig))
 	assert.NoError(t, err)
-	config, err := LoadConfig(fname)
+
+	tests := []struct {
+		name string
+		got  any
+		want any
+	}{
+		{"duration default", config.LockTimeout, 30 * time.Second},
+		{"duration default on a nested struct", config.GRPCConfig.ServiceHeartbeatInterval, 15 * time.Second},
+		{"string default", config.Etcd.Prefix, "/eru"},
+		{"numeric string default", config.Bind, "5001"},
+		{"string default holding a colon", config.ProbeTarget, "8.8.8.8:80"},
+		{"int default", config.Scheduler.ShareBase, 100},
+		{"negative int default", config.Scheduler.MaxShare, -1},
+		{"nested struct default", config.Docker.APIVersion, "1.32"},
+		{"twice-nested struct default", config.Docker.Log.Type, "journald"},
+		{"default in a section the file omits", config.Redis.Addr, "localhost:6379"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.got)
+		})
+	}
+}
+
+func TestLoadConfigLetsTheFileOverrideDefaults(t *testing.T) {
+	config, err := LoadConfig(writeConfig(t, fullConfig))
 	assert.NoError(t, err)
-	assert.Equal(t, config.LockTimeout, time.Duration(time.Second*30))
-	assert.Equal(t, config.GlobalTimeout, time.Duration(time.Second*300))
-	assert.Equal(t, config.Etcd.Prefix, "/eru")
-	assert.Equal(t, config.Docker.Log.Type, "journald")
-	assert.Equal(t, config.Docker.APIVersion, "1.32")
-	assert.Equal(t, config.Scheduler.MaxShare, -1)
-	assert.Equal(t, config.Scheduler.ShareBase, 100)
-	os.Remove(fname)
+
+	tests := []struct {
+		name string
+		got  any
+		want any
+	}{
+		{"duration", config.GlobalTimeout, 300 * time.Second},
+		{"string", config.Bind, ":5001"},
+		{"int", config.Scheduler.ShareBase, 50},
+		{"nested string", config.Etcd.LockPrefix, "core/_lock"},
+		{"nested struct field", config.Docker.NetworkMode, "bridge"},
+		{"slice", config.Etcd.Machines, []string{"http://127.0.0.1:2379"}},
+		{"untouched default alongside overrides", config.Docker.APIVersion, "1.32"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.got)
+		})
+	}
+}
+
+func TestLoadConfigRejectsBadInput(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"missing required field", "bind: \":5001\"\n"},
+		{"required field set to its zero value", minimalConfig + "scheduler:\n    maxshare: 0\n"},
+		{"file is not a mapping", "test\n"},
+		{"malformed yaml", "bind: \":5001\"\n  broken\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := LoadConfig(writeConfig(t, tt.body))
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestLoadConfigNamesTheMissingRequiredField(t *testing.T) {
+	_, err := LoadConfig(writeConfig(t, "bind: \":5001\"\n"))
+	assert.ErrorContains(t, err, "Machines is required, but blank")
+}
+
+func TestLoadConfigRejectsAMissingFile(t *testing.T) {
+	_, err := LoadConfig(filepath.Join(t.TempDir(), "absent.yaml"))
+	assert.Error(t, err)
+}
+
+func writeConfig(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "core.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
 }


### PR DESCRIPTION
Stacked on the json/v2 PR (and #647).

## Summary

`github.com/jinzhu/configor` (no releases, last push 2024-04) was used for one call, `configor.Load`. `utils.LoadConfig` now unmarshals the YAML file with `gopkg.in/yaml.v3` and walks `types.Config` with reflect: every `default:` tag is parsed as a YAML scalar into the field's type (so `default:"30s"` still yields a `time.Duration`, `default:"5001"` a string), and a `required:"true"` field left zero is an error — configor's semantics, covered by table-driven tests (duration/string/int defaults, nested structs, required missing, file overriding defaults).

## Performance A/B

Startup-only path; measured anyway (`go test -bench`, `-count=3 -benchmem`, loading `core.yaml.sample`, both orders):

| arm | ns/op | B/op | allocs/op |
|---|---|---|---|
| configor | 225k–254k | 288.6k | 2509 |
| yaml.v3 + walker | 185k–193k (one outlier 417k in the first run) | 236.5k | 1834 |

## Evidence

```
GOWORK=off go test -race -count=1 ./utils/  -> ok
GOWORK=off go mod tidy                      -> no change
```