### PR TITLE
Register the stop expectation before the control call in TestControlStop

### DIFF
--- a/cluster/calcium/control_test.go
+++ b/cluster/calcium/control_test.go
@@ -116,8 +116,8 @@ func TestControlStop(t *testing.T) {
 		assert.Error(t, r.Error)
 	}
 	workload.Hook.Force = false
-	ch, err = c.ControlWorkload(ctx, []string{"id1"}, cluster.WorkloadStop, false)
 	engine.On("VirtualizationStop", mock.Anything, mock.Anything, mock.Anything).Return(types.ErrNilEngine).Once()
+	ch, err = c.ControlWorkload(ctx, []string{"id1"}, cluster.WorkloadStop, false)
 	assert.NoError(t, err)
 	for r := range ch {
 		assert.Error(t, r.Error)


### PR DESCRIPTION
Flaky on CI (run 8e2884e0): `ControlWorkload` executes on the goroutine pool, and the second phase registered its `VirtualizationStop` expectation after the call that consumes it, so the mock sometimes panicked inside the worker and the phase asserted on the wrong result. The expectation now precedes the call; `go test -race -count=20 -run TestControl` passes.