### PR TITLE
fix: let the docker client negotiate the API version

### DIFF
--- a/core.yaml.sample
+++ b/core.yaml.sample
@@ -49,7 +49,6 @@ redis:                                                                  # option
     db: 0
 
 docker:
-    version: "1.40"                                                     # required, default 1.40 (the moby client minimum)
     network_mode: "bridge"                                              # required, default host
     use_local_dns: true
     log:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -96,7 +96,6 @@ warning at startup and the build API returns an error.
 
 | Key | Type | Default | Meaning |
 | --- | --- | --- | --- |
-| `docker.version` | string | `1.40` | Docker API version the client pins; setting it disables version negotiation, and the moby client supports 1.40 and up |
 | `docker.network_mode` | string | `host` | Network mode for workloads that do not request a network |
 | `docker.use_local_dns` | bool | `false` | When the deploy request sets no DNS, use the node's own IP as the workload's resolver |
 | `docker.log.type` | string | `journald` | Default log driver for workloads (`journald`, `json-file`, `none`, …) |

--- a/engine/docker/docker.go
+++ b/engine/docker/docker.go
@@ -62,7 +62,7 @@ func MakeClient(ctx context.Context, config coretypes.Config, nodename, endpoint
 		}
 	}
 
-	logger.Debugf(ctx, "create docker client for %s, %s", endpoint, config.Docker.APIVersion)
+	logger.Debugf(ctx, "create docker client for %s", endpoint)
 	e, err := makeDockerClient(ctx, config, client, endpoint)
 	if err != nil {
 		return nil, err
@@ -76,7 +76,6 @@ func makeDockerClient(_ context.Context, config coretypes.Config, client *http.C
 	own := *client
 	cli, err := dockerapi.New(
 		dockerapi.WithHost(endpoint),
-		dockerapi.WithAPIVersion(config.Docker.APIVersion),
 		dockerapi.WithHTTPClient(&own),
 	)
 	if err != nil {

--- a/types/config.go
+++ b/types/config.go
@@ -94,7 +94,6 @@ type RedisConfig struct {
 }
 
 type DockerConfig struct {
-	APIVersion  string    `yaml:"version" required:"true" default:"1.40"`
 	NetworkMode string    `yaml:"network_mode" required:"true" default:"host"`
 	UseLocalDNS bool      `yaml:"use_local_dns"` // use node IP as dns
 	Log         LogConfig `yaml:"log"`           // docker log driver

--- a/utils/config_test.go
+++ b/utils/config_test.go
@@ -55,7 +55,7 @@ func TestLoadConfigAppliesDefaults(t *testing.T) {
 		{"string default holding a colon", config.ProbeTarget, "8.8.8.8:80"},
 		{"int default", config.Scheduler.ShareBase, 100},
 		{"negative int default", config.Scheduler.MaxShare, -1},
-		{"nested struct default", config.Docker.APIVersion, "1.40"},
+		{"nested struct default", config.Docker.NetworkMode, "host"},
 		{"twice-nested struct default", config.Docker.Log.Type, "journald"},
 		{"default in a section the file omits", config.Redis.Addr, "localhost:6379"},
 	}
@@ -81,7 +81,7 @@ func TestLoadConfigLetsTheFileOverrideDefaults(t *testing.T) {
 		{"nested string", config.Etcd.LockPrefix, "core/_lock"},
 		{"nested struct field", config.Docker.NetworkMode, "bridge"},
 		{"slice", config.Etcd.Machines, []string{"http://127.0.0.1:2379"}},
-		{"untouched default alongside overrides", config.Docker.APIVersion, "1.40"},
+		{"untouched default alongside overrides", config.Virt.APIVersion, "v1"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
The docker engine pinned API version 1.40 through `docker.version`. Docker 29 refuses clients below 1.44, so `node add` failed against a current daemon. The moby client negotiates the version by default; the pinned option and the config knob are removed, docs and sample updated.

Found on the test cluster while registering the first nodes.