### PR TITLE
fix: close the write-ahead log's coverage gaps

### DIFF
--- a/cluster/calcium/node.go
+++ b/cluster/calcium/node.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"slices"
 
+	"github.com/cockroachdb/errors"
+
 	enginefactory "github.com/projecteru2/core/engine/factory"
 	enginetypes "github.com/projecteru2/core/engine/types"
 	"github.com/projecteru2/core/log"
@@ -37,6 +39,18 @@ func (c *Calcium) AddNode(ctx context.Context, opts *types.AddNodeOptions) (*typ
 	return node, utils.Txn(
 		ctx,
 		func(ctx context.Context) error {
+			res, err = c.rmgr.AddNode(ctx, opts.Nodename, opts.Resources, nodeInfo)
+			if !errors.Is(err, types.ErrNodeExists) {
+				return err
+			}
+			_, getErr := c.store.GetNode(ctx, opts.Nodename)
+			if getErr == nil || !c.store.NotFound(getErr) {
+				return err
+			}
+			logger.Warn(ctx, "node known to the resource plugins only, dropping the stale metadata")
+			if err = c.rmgr.RemoveNode(ctx, opts.Nodename); err != nil {
+				return err
+			}
 			res, err = c.rmgr.AddNode(ctx, opts.Nodename, opts.Resources, nodeInfo)
 			return err
 		},

--- a/cluster/calcium/node_test.go
+++ b/cluster/calcium/node_test.go
@@ -64,6 +64,36 @@ func TestAddNode(t *testing.T) {
 	assert.Equal(t, n.Name, name)
 }
 
+func TestAddNodeRedoesTheStalePluginMetadata(t *testing.T) {
+	c := NewTestCluster()
+	ctx := context.Background()
+	factory.InitEngineCache(ctx, c.config, nil)
+
+	nodename := "nodename"
+	opts := &types.AddNodeOptions{
+		Nodename: nodename,
+		Podname:  "podname",
+		Endpoint: fmt.Sprintf("mock://%s", nodename),
+	}
+
+	rmgr := c.rmgr.(*resourcemocks.Manager)
+	rmgr.On("AddNode", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, types.ErrNodeExists).Once()
+	rmgr.On("RemoveNode", mock.Anything, nodename).Return(nil).Once()
+	rmgr.On("AddNode", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(resourcetypes.Resources{}, nil).Once()
+	rmgr.On("GetNodeMetrics", mock.Anything, mock.Anything).Return([]*plugintypes.Metrics{}, nil).Maybe()
+
+	store := c.store.(*storemocks.Store)
+	store.On("GetNode", mock.Anything, nodename).Return(nil, types.ErrMockError).Once()
+	store.On("NotFound", types.ErrMockError).Return(true).Once()
+	store.On("AddNode", mock.Anything, mock.Anything).Return(&types.Node{NodeMeta: types.NodeMeta{Name: nodename}}, nil).Once()
+
+	n, err := c.AddNode(ctx, opts)
+	assert.NoError(t, err)
+	assert.Equal(t, nodename, n.Name)
+	rmgr.AssertExpectations(t)
+	store.AssertExpectations(t)
+}
+
 func TestRemoveNode(t *testing.T) {
 	c := NewTestCluster()
 	ctx := context.Background()

--- a/cluster/calcium/realloc.go
+++ b/cluster/calcium/realloc.go
@@ -38,10 +38,20 @@ func (c *Calcium) doReallocOnNode(ctx context.Context, node *types.Node, workloa
 	if err != nil {
 		return err
 	}
+	defer func() {
+		if commitErr := nodeCommit(); commitErr != nil {
+			logger.Errorf(ctx, commitErr, "commit wal failed: %s", eventWorkloadResourceAllocated)
+		}
+	}()
 	workloadCommit, err := c.wal.Log(eventWorkloadReallocated, workload.ID)
 	if err != nil {
 		return err
 	}
+	defer func() {
+		if commitErr := workloadCommit(); commitErr != nil {
+			logger.Errorf(ctx, commitErr, "commit wal failed: %s", eventWorkloadReallocated)
+		}
+	}()
 
 	err = utils.Txn(
 		ctx,
@@ -74,13 +84,6 @@ func (c *Calcium) doReallocOnNode(ctx context.Context, node *types.Node, workloa
 	if err != nil {
 		return err
 	}
-	if commitErr := nodeCommit(); commitErr != nil {
-		logger.Errorf(ctx, commitErr, "commit wal failed: %s", eventWorkloadResourceAllocated)
-	}
-	if commitErr := workloadCommit(); commitErr != nil {
-		logger.Errorf(ctx, commitErr, "commit wal failed: %s", eventWorkloadReallocated)
-	}
-
 	_ = c.pool.Invoke(func() { c.RemapResourceAndLog(ctx, logger, node) })
 	return nil
 }

--- a/cluster/calcium/realloc.go
+++ b/cluster/calcium/realloc.go
@@ -34,6 +34,15 @@ func (c *Calcium) doReallocOnNode(ctx context.Context, node *types.Node, workloa
 	var err error
 
 	logger := log.WithFunc("calcium.doReallocOnNode").WithField("opts", opts)
+	nodeCommit, err := c.wal.Log(eventWorkloadResourceAllocated, []*types.Node{node})
+	if err != nil {
+		return err
+	}
+	workloadCommit, err := c.wal.Log(eventWorkloadReallocated, workload.ID)
+	if err != nil {
+		return err
+	}
+
 	err = utils.Txn(
 		ctx,
 		func(ctx context.Context) error {
@@ -65,6 +74,13 @@ func (c *Calcium) doReallocOnNode(ctx context.Context, node *types.Node, workloa
 	if err != nil {
 		return err
 	}
+	if commitErr := nodeCommit(); commitErr != nil {
+		logger.Errorf(ctx, commitErr, "commit wal failed: %s", eventWorkloadResourceAllocated)
+	}
+	if commitErr := workloadCommit(); commitErr != nil {
+		logger.Errorf(ctx, commitErr, "commit wal failed: %s", eventWorkloadReallocated)
+	}
+
 	_ = c.pool.Invoke(func() { c.RemapResourceAndLog(ctx, logger, node) })
 	return nil
 }

--- a/cluster/calcium/realloc_test.go
+++ b/cluster/calcium/realloc_test.go
@@ -16,6 +16,8 @@ import (
 	resourcetypes "github.com/projecteru2/core/resource/types"
 	storemocks "github.com/projecteru2/core/store/mocks"
 	"github.com/projecteru2/core/types"
+	"github.com/projecteru2/core/wal"
+	walmocks "github.com/projecteru2/core/wal/mocks"
 )
 
 func TestRealloc(t *testing.T) {
@@ -100,4 +102,40 @@ func TestRealloc(t *testing.T) {
 	store.On("ListNodeWorkloads", mock.Anything, mock.Anything, mock.Anything).Return(nil, types.ErrMockError)
 	err = c.ReallocResource(ctx, opts)
 	assert.Nil(t, err)
+}
+
+func TestReallocJournalsRepairEntries(t *testing.T) {
+	c := NewTestCluster()
+	ctx := context.Background()
+
+	logged := []string{}
+	committed := 0
+	mwal := &walmocks.WAL{}
+	mwal.On("Log", mock.Anything, mock.Anything).Return(func(eventyp string, _ any) (wal.Commit, error) {
+		logged = append(logged, eventyp)
+		return func() error { committed++; return nil }, nil
+	})
+	c.wal = mwal
+
+	lock := &lockmocks.DistributedLock{}
+	lock.On("Lock", mock.Anything).Return(ctx, nil)
+	lock.On("Unlock", mock.Anything).Return(nil)
+	engine := &enginemocks.API{}
+	engine.On("VirtualizationUpdateResource", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	node := &types.Node{NodeMeta: types.NodeMeta{Name: "node1"}, Engine: engine}
+	workload := &types.Workload{ID: "c1", Nodename: "node1", Engine: engine, Resources: resourcetypes.Resources{}}
+
+	store := c.store.(*storemocks.Store)
+	store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
+	store.On("UpdateWorkload", mock.Anything, mock.Anything).Return(nil)
+	store.On("ListNodeWorkloads", mock.Anything, mock.Anything, mock.Anything).Return(nil, types.ErrMockError)
+	rmgr := c.rmgr.(*resourcemocks.Manager)
+	rmgr.On("Realloc", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+		resourcetypes.Resources{}, resourcetypes.Resources{}, resourcetypes.Resources{}, nil,
+	)
+
+	opts := &types.ReallocOptions{ID: "c1", Resources: resourcetypes.Resources{}}
+	assert.NoError(t, c.doReallocOnNode(ctx, node, workload, *workload, opts))
+	assert.Equal(t, []string{eventWorkloadResourceAllocated, eventWorkloadReallocated}, logged)
+	assert.Equal(t, 2, committed)
 }

--- a/cluster/calcium/remove.go
+++ b/cluster/calcium/remove.go
@@ -34,12 +34,11 @@ func (c *Calcium) RemoveWorkload(ctx context.Context, IDs []string, force bool) 
 					for _, workloadID := range workloadIDs {
 						ret := &types.RemoveWorkloadMessage{WorkloadID: workloadID, Success: true, Hook: []*bytes.Buffer{}}
 						if workloadErr := c.withWorkloadLocked(ctx, workloadID, false, func(ctx context.Context, workload *types.Workload) error {
-							return c.withResourceReleased(ctx, node, workload, func(ctx context.Context) (err error) {
-								if err = c.doRemoveWorkload(ctx, workload, force); err == nil {
-									logger.Infof(ctx, "workload %s removed", workload.ID)
-								}
+							if err := c.doRemoveOneWorkload(ctx, node, workload, force); err != nil {
 								return err
-							})
+							}
+							logger.Infof(ctx, "workload %s removed", workload.ID)
+							return nil
 						}); workloadErr != nil {
 							logger.WithField("id", workloadID).Error(ctx, workloadErr, "failed to remove workload")
 							ret.Hook = append(ret.Hook, bytes.NewBufferString(workloadErr.Error()))
@@ -61,6 +60,34 @@ func (c *Calcium) RemoveWorkload(ctx context.Context, IDs []string, force bool) 
 
 func (c *Calcium) RemoveWorkloadSync(ctx context.Context, IDs []string) error {
 	return c.doRemoveWorkloadSync(ctx, IDs)
+}
+
+func (c *Calcium) doRemoveOneWorkload(ctx context.Context, node *types.Node, workload *types.Workload, force bool) error {
+	logger := log.WithFunc("calcium.doRemoveOneWorkload").WithField("id", workload.ID)
+
+	nodeCommit, err := c.wal.Log(eventWorkloadResourceAllocated, []*types.Node{node})
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if commitErr := nodeCommit(); commitErr != nil {
+			logger.Errorf(ctx, commitErr, "commit wal failed: %s", eventWorkloadResourceAllocated)
+		}
+	}()
+
+	workloadCommit, err := c.wal.Log(eventWorkloadCreated, &types.Workload{ID: workload.ID, Nodename: workload.Nodename})
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if commitErr := workloadCommit(); commitErr != nil {
+			logger.Errorf(ctx, commitErr, "commit wal failed: %s", eventWorkloadCreated)
+		}
+	}()
+
+	return c.withResourceReleased(ctx, node, workload, func(ctx context.Context) error {
+		return c.doRemoveWorkload(ctx, workload, force)
+	})
 }
 
 func (c *Calcium) doRemoveWorkload(ctx context.Context, workload *types.Workload, force bool) error {

--- a/cluster/calcium/remove_test.go
+++ b/cluster/calcium/remove_test.go
@@ -16,6 +16,8 @@ import (
 	resourcetypes "github.com/projecteru2/core/resource/types"
 	storemocks "github.com/projecteru2/core/store/mocks"
 	"github.com/projecteru2/core/types"
+	"github.com/projecteru2/core/wal"
+	walmocks "github.com/projecteru2/core/wal/mocks"
 )
 
 func TestRemoveWorkload(t *testing.T) {
@@ -83,4 +85,44 @@ func TestRemoveWorkload(t *testing.T) {
 		assert.True(t, r.Success)
 	}
 	store.AssertExpectations(t)
+}
+
+func TestRemoveWorkloadJournalsRepairEntries(t *testing.T) {
+	c := NewTestCluster()
+	ctx := context.Background()
+
+	logged := []string{}
+	committed := 0
+	mwal := &walmocks.WAL{}
+	mwal.On("Log", mock.Anything, mock.Anything).Return(func(eventyp string, _ any) (wal.Commit, error) {
+		logged = append(logged, eventyp)
+		return func() error { committed++; return nil }, nil
+	})
+	c.wal = mwal
+
+	lock := &lockmocks.DistributedLock{}
+	lock.On("Lock", mock.Anything).Return(ctx, nil)
+	lock.On("Unlock", mock.Anything).Return(nil)
+	engine := &enginemocks.API{}
+	engine.On("VirtualizationRemove", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	workload := &types.Workload{ID: "xx", Name: "test", Nodename: "test", Engine: engine}
+
+	store := c.store.(*storemocks.Store)
+	store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
+	store.On("GetWorkloads", mock.Anything, mock.Anything).Return([]*types.Workload{workload}, nil)
+	store.On("GetNode", mock.Anything, mock.Anything).Return(&types.Node{NodeMeta: types.NodeMeta{Name: "test"}}, nil)
+	store.On("RemoveWorkload", mock.Anything, mock.Anything).Return(nil)
+	store.On("ListNodeWorkloads", mock.Anything, mock.Anything, mock.Anything).Return(nil, types.ErrMockError)
+	rmgr := c.rmgr.(*resourcemocks.Manager)
+	rmgr.On("SetNodeResourceUsage", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+		resourcetypes.Resources{}, resourcetypes.Resources{}, nil,
+	)
+
+	ch, err := c.RemoveWorkload(ctx, []string{"xx"}, true)
+	assert.NoError(t, err)
+	for r := range ch {
+		assert.True(t, r.Success)
+	}
+	assert.Equal(t, []string{eventWorkloadResourceAllocated, eventWorkloadCreated}, logged)
+	assert.Equal(t, 2, committed)
 }

--- a/cluster/calcium/replace.go
+++ b/cluster/calcium/replace.go
@@ -143,12 +143,14 @@ func (c *Calcium) doReplaceWorkload(
 					if err != nil {
 						return err
 					}
+					defer func() {
+						if commitErr := commit(); commitErr != nil {
+							logger.Errorf(ctx, commitErr, "commit wal failed: %s", eventWorkloadReplaced)
+						}
+					}()
 					if err = c.doRemoveWorkload(ctx, workload, true); err != nil {
 						logger.Error(ctx, err, "the new started but the old failed to stop")
 						return err
-					}
-					if commitErr := commit(); commitErr != nil {
-						logger.Errorf(ctx, commitErr, "commit wal failed: %s", eventWorkloadReplaced)
 					}
 					removeMessage.Success = true
 					return nil

--- a/cluster/calcium/replace.go
+++ b/cluster/calcium/replace.go
@@ -139,12 +139,19 @@ func (c *Calcium) doReplaceWorkload(
 					return c.doDeployOneWorkload(ctx, node, &opts.DeployOptions, createMessage, vco, false)
 				},
 				func(ctx context.Context) (err error) {
+					commit, err := c.wal.Log(eventWorkloadReplaced, &workloadReplacement{OldID: workload.ID, NewID: createMessage.WorkloadID})
+					if err != nil {
+						return err
+					}
 					if err = c.doRemoveWorkload(ctx, workload, true); err != nil {
 						logger.Error(ctx, err, "the new started but the old failed to stop")
 						return err
 					}
+					if commitErr := commit(); commitErr != nil {
+						logger.Errorf(ctx, commitErr, "commit wal failed: %s", eventWorkloadReplaced)
+					}
 					removeMessage.Success = true
-					return err
+					return nil
 				},
 				nil,
 				c.config.GlobalTimeout,

--- a/cluster/calcium/wal.go
+++ b/cluster/calcium/wal.go
@@ -121,6 +121,10 @@ func (h *CreateWorkloadHandler) Handle(ctx context.Context, raw any) (err error)
 
 	node, err := h.calcium.GetNode(ctx, wrk.Nodename)
 	if err != nil {
+		if h.calcium.store.NotFound(err) {
+			logger.Info(ctx, "node is gone, nothing to remove")
+			return nil
+		}
 		logger.Error(ctx, err)
 		return err
 	}

--- a/cluster/calcium/wal.go
+++ b/cluster/calcium/wal.go
@@ -18,6 +18,7 @@ const (
 	eventCreateLambda              = "create-lambda"
 	eventWorkloadCreated           = "create-workload"   // created but yet to start
 	eventWorkloadReplaced          = "replace-workload"
+	eventWorkloadReallocated       = "realloc-workload"
 	eventWorkloadResourceAllocated = "allocate-workload" // resource updated in node meta but yet to create all workloads
 	eventProcessingCreated         = "create-processing" // processing created but yet to delete
 
@@ -129,6 +130,41 @@ func (h *CreateWorkloadHandler) Handle(ctx context.Context, raw any) (err error)
 	}
 
 	logger.Info(ctx, "workload removed")
+	return nil
+}
+
+// ReallocWorkloadHandler re-applies the stored engine params of an interrupted realloc.
+type ReallocWorkloadHandler struct {
+	walBase[string]
+
+	calcium *Calcium
+}
+
+func newReallocWorkloadHandler(calcium *Calcium) *ReallocWorkloadHandler {
+	return &ReallocWorkloadHandler{calcium: calcium}
+}
+
+func (h *ReallocWorkloadHandler) Typ() string {
+	return eventWorkloadReallocated
+}
+
+func (h *ReallocWorkloadHandler) Handle(ctx context.Context, raw any) error {
+	workloadID, _ := raw.(string)
+	logger := log.WithFunc("calcium.ReallocWorkloadHandler.Handle").WithField("ID", workloadID)
+
+	ctx, cancel := getReplayContext(ctx)
+	defer cancel()
+
+	workload, err := getWorkloadIfExists(ctx, h.calcium, workloadID)
+	if err != nil || workload == nil {
+		return err
+	}
+
+	if err = workload.Engine.VirtualizationUpdateResource(ctx, workloadID, workload.EngineParams); err != nil {
+		logger.Error(ctx, err)
+		return err
+	}
+	logger.Info(ctx, "engine params reapplied")
 	return nil
 }
 
@@ -269,6 +305,7 @@ func enableWAL(config types.Config, calcium *Calcium, store store.Store) (wal.WA
 	hydro.Register(newCreateLambdaHandler(calcium, hydro))
 	hydro.Register(newCreateWorkloadHandler(calcium))
 	hydro.Register(newReplaceWorkloadHandler(calcium))
+	hydro.Register(newReallocWorkloadHandler(calcium))
 	hydro.Register(newWorkloadResourceAllocatedHandler(calcium))
 	hydro.Register(newProcessingCreatedHandler(store))
 	return hydro, nil

--- a/cluster/calcium/wal.go
+++ b/cluster/calcium/wal.go
@@ -17,6 +17,7 @@ import (
 const (
 	eventCreateLambda              = "create-lambda"
 	eventWorkloadCreated           = "create-workload"   // created but yet to start
+	eventWorkloadReplaced          = "replace-workload"
 	eventWorkloadResourceAllocated = "allocate-workload" // resource updated in node meta but yet to create all workloads
 	eventProcessingCreated         = "create-processing" // processing created but yet to delete
 
@@ -198,6 +199,51 @@ func (h *ProcessingCreatedHandler) Handle(ctx context.Context, raw any) (err err
 	return err
 }
 
+type workloadReplacement struct {
+	OldID string `json:"old_id"`
+	NewID string `json:"new_id"`
+}
+
+// ReplaceWorkloadHandler removes the workload an interrupted replace left behind.
+type ReplaceWorkloadHandler struct {
+	walBase[*workloadReplacement]
+
+	calcium *Calcium
+}
+
+func newReplaceWorkloadHandler(calcium *Calcium) *ReplaceWorkloadHandler {
+	return &ReplaceWorkloadHandler{calcium: calcium}
+}
+
+func (h *ReplaceWorkloadHandler) Typ() string {
+	return eventWorkloadReplaced
+}
+
+func (h *ReplaceWorkloadHandler) Handle(ctx context.Context, raw any) error {
+	replacement, _ := raw.(*workloadReplacement)
+	logger := log.WithFunc("calcium.ReplaceWorkloadHandler.Handle").WithField("ID", replacement.OldID)
+
+	ctx, cancel := getReplayContext(ctx)
+	defer cancel()
+
+	newWorkload, err := getWorkloadIfExists(ctx, h.calcium, replacement.NewID)
+	if err != nil || newWorkload == nil {
+		return err
+	}
+
+	oldWorkload, err := getWorkloadIfExists(ctx, h.calcium, replacement.OldID)
+	if err != nil || oldWorkload == nil {
+		return err
+	}
+
+	if err = h.calcium.doRemoveWorkload(ctx, oldWorkload, true); err != nil {
+		logger.Error(ctx, err)
+		return err
+	}
+	logger.Info(ctx, "replaced workload removed")
+	return nil
+}
+
 type walBase[T any] struct{}
 
 func (walBase[T]) Encode(raw any) ([]byte, error) {
@@ -222,6 +268,7 @@ func enableWAL(config types.Config, calcium *Calcium, store store.Store) (wal.WA
 
 	hydro.Register(newCreateLambdaHandler(calcium, hydro))
 	hydro.Register(newCreateWorkloadHandler(calcium))
+	hydro.Register(newReplaceWorkloadHandler(calcium))
 	hydro.Register(newWorkloadResourceAllocatedHandler(calcium))
 	hydro.Register(newProcessingCreatedHandler(store))
 	return hydro, nil

--- a/cluster/calcium/wal.go
+++ b/cluster/calcium/wal.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	eventCreateLambda              = "create-lambda"
-	eventWorkloadCreated           = "create-workload"   // created but yet to start
+	eventWorkloadCreated           = "create-workload" // created but yet to start
 	eventWorkloadReplaced          = "replace-workload"
 	eventWorkloadReallocated       = "realloc-workload"
 	eventWorkloadResourceAllocated = "allocate-workload" // resource updated in node meta but yet to create all workloads
@@ -133,6 +133,51 @@ func (h *CreateWorkloadHandler) Handle(ctx context.Context, raw any) (err error)
 	return nil
 }
 
+type workloadReplacement struct {
+	OldID string `json:"old_id"`
+	NewID string `json:"new_id"`
+}
+
+// ReplaceWorkloadHandler removes the workload an interrupted replace left behind.
+type ReplaceWorkloadHandler struct {
+	walBase[*workloadReplacement]
+
+	calcium *Calcium
+}
+
+func newReplaceWorkloadHandler(calcium *Calcium) *ReplaceWorkloadHandler {
+	return &ReplaceWorkloadHandler{calcium: calcium}
+}
+
+func (h *ReplaceWorkloadHandler) Typ() string {
+	return eventWorkloadReplaced
+}
+
+func (h *ReplaceWorkloadHandler) Handle(ctx context.Context, raw any) error {
+	replacement, _ := raw.(*workloadReplacement)
+	logger := log.WithFunc("calcium.ReplaceWorkloadHandler.Handle").WithField("ID", replacement.OldID)
+
+	ctx, cancel := getReplayContext(ctx)
+	defer cancel()
+
+	newWorkload, err := getWorkloadIfExists(ctx, h.calcium, replacement.NewID)
+	if err != nil || newWorkload == nil {
+		return err
+	}
+
+	oldWorkload, err := getWorkloadIfExists(ctx, h.calcium, replacement.OldID)
+	if err != nil || oldWorkload == nil {
+		return err
+	}
+
+	if err = h.calcium.doRemoveWorkload(ctx, oldWorkload, true); err != nil {
+		logger.Error(ctx, err)
+		return err
+	}
+	logger.Info(ctx, "replaced workload removed")
+	return nil
+}
+
 // ReallocWorkloadHandler re-applies the stored engine params of an interrupted realloc.
 type ReallocWorkloadHandler struct {
 	walBase[string]
@@ -233,51 +278,6 @@ func (h *ProcessingCreatedHandler) Handle(ctx context.Context, raw any) (err err
 	}
 	logger.Info(ctx, "obsolete processing deleted")
 	return err
-}
-
-type workloadReplacement struct {
-	OldID string `json:"old_id"`
-	NewID string `json:"new_id"`
-}
-
-// ReplaceWorkloadHandler removes the workload an interrupted replace left behind.
-type ReplaceWorkloadHandler struct {
-	walBase[*workloadReplacement]
-
-	calcium *Calcium
-}
-
-func newReplaceWorkloadHandler(calcium *Calcium) *ReplaceWorkloadHandler {
-	return &ReplaceWorkloadHandler{calcium: calcium}
-}
-
-func (h *ReplaceWorkloadHandler) Typ() string {
-	return eventWorkloadReplaced
-}
-
-func (h *ReplaceWorkloadHandler) Handle(ctx context.Context, raw any) error {
-	replacement, _ := raw.(*workloadReplacement)
-	logger := log.WithFunc("calcium.ReplaceWorkloadHandler.Handle").WithField("ID", replacement.OldID)
-
-	ctx, cancel := getReplayContext(ctx)
-	defer cancel()
-
-	newWorkload, err := getWorkloadIfExists(ctx, h.calcium, replacement.NewID)
-	if err != nil || newWorkload == nil {
-		return err
-	}
-
-	oldWorkload, err := getWorkloadIfExists(ctx, h.calcium, replacement.OldID)
-	if err != nil || oldWorkload == nil {
-		return err
-	}
-
-	if err = h.calcium.doRemoveWorkload(ctx, oldWorkload, true); err != nil {
-		logger.Error(ctx, err)
-		return err
-	}
-	logger.Info(ctx, "replaced workload removed")
-	return nil
 }
 
 type walBase[T any] struct{}

--- a/cluster/calcium/wal.go
+++ b/cluster/calcium/wal.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/cockroachdb/errors"
 
-	"github.com/projecteru2/core/cluster"
 	"github.com/projecteru2/core/log"
 	"github.com/projecteru2/core/store"
 	"github.com/projecteru2/core/types"
@@ -26,11 +25,12 @@ const (
 
 // CreateLambdaHandler waits for a replayed lambda workload and removes it.
 type CreateLambdaHandler struct {
-	calcium cluster.Cluster
+	calcium *Calcium
+	wal     wal.WAL
 }
 
-func newCreateLambdaHandler(calcium cluster.Cluster) *CreateLambdaHandler {
-	return &CreateLambdaHandler{calcium: calcium}
+func newCreateLambdaHandler(calcium *Calcium, wal wal.WAL) *CreateLambdaHandler {
+	return &CreateLambdaHandler{calcium: calcium, wal: wal}
 }
 
 func (h *CreateLambdaHandler) Typ() string {
@@ -55,25 +55,19 @@ func (h *CreateLambdaHandler) Handle(ctx context.Context, raw any) error {
 		return errors.Wrapf(types.ErrInvalidWALDataType, "%+v", raw)
 	}
 
+	commit, err := h.wal.Log(eventCreateLambda, workloadID)
+	if err != nil {
+		return err
+	}
+
 	logger := log.WithFunc("calcium.CreateLambdaHandler.Handle").WithField("ID", workloadID)
 	go func() {
-		workload, err := h.calcium.GetWorkload(ctx, workloadID)
-		if err != nil {
-			logger.Error(ctx, err, "get workload failed")
+		if err := h.waitAndRemove(ctx, logger, workloadID); err != nil {
+			logger.Error(ctx, err, "wait and remove failed")
 			return
 		}
-
-		r, err := workload.Engine.VirtualizationWait(ctx, workloadID, "")
-		if err != nil {
-			logger.Error(ctx, err, "wait failed")
-			return
-		}
-		if r.Code != 0 {
-			logger.Warnf(ctx, "lambda run failed: %s", r.Message)
-		}
-
-		if err := h.calcium.RemoveWorkloadSync(ctx, []string{workloadID}); err != nil {
-			logger.Error(ctx, err, "remove failed")
+		if err := commit(); err != nil {
+			logger.Errorf(ctx, err, "commit wal %s failed", eventCreateLambda)
 		}
 		logger.Info(ctx, "waited and removed")
 	}()
@@ -81,14 +75,30 @@ func (h *CreateLambdaHandler) Handle(ctx context.Context, raw any) error {
 	return nil
 }
 
+func (h *CreateLambdaHandler) waitAndRemove(ctx context.Context, logger *log.Fields, workloadID string) error {
+	workload, err := getWorkloadIfExists(ctx, h.calcium, workloadID)
+	if err != nil || workload == nil {
+		return err
+	}
+
+	r, err := workload.Engine.VirtualizationWait(ctx, workloadID, "")
+	if err != nil {
+		return err
+	}
+	if r.Code != 0 {
+		logger.Warnf(ctx, "lambda run failed: %s", r.Message)
+	}
+	return h.calcium.RemoveWorkloadSync(ctx, []string{workloadID})
+}
+
 // CreateWorkloadHandler removes a workload left behind by an interrupted create.
 type CreateWorkloadHandler struct {
 	walBase[*types.Workload]
 
-	calcium cluster.Cluster
+	calcium *Calcium
 }
 
-func newCreateWorkloadHandler(calcium cluster.Cluster) *CreateWorkloadHandler {
+func newCreateWorkloadHandler(calcium *Calcium) *CreateWorkloadHandler {
 	return &CreateWorkloadHandler{calcium: calcium}
 }
 
@@ -125,10 +135,10 @@ func (h *CreateWorkloadHandler) Handle(ctx context.Context, raw any) (err error)
 type WorkloadResourceAllocatedHandler struct {
 	walBase[[]*types.Node]
 
-	calcium cluster.Cluster
+	calcium *Calcium
 }
 
-func newWorkloadResourceAllocatedHandler(calcium cluster.Cluster) *WorkloadResourceAllocatedHandler {
+func newWorkloadResourceAllocatedHandler(calcium *Calcium) *WorkloadResourceAllocatedHandler {
 	return &WorkloadResourceAllocatedHandler{calcium: calcium}
 }
 
@@ -204,13 +214,13 @@ func (walBase[T]) Decode(bs []byte) (any, error) {
 	return v, err
 }
 
-func enableWAL(config types.Config, calcium cluster.Cluster, store store.Store) (wal.WAL, error) {
+func enableWAL(config types.Config, calcium *Calcium, store store.Store) (wal.WAL, error) {
 	hydro, err := wal.NewHydro(config.WALFile, config.WALOpenTimeout)
 	if err != nil {
 		return nil, err
 	}
 
-	hydro.Register(newCreateLambdaHandler(calcium))
+	hydro.Register(newCreateLambdaHandler(calcium, hydro))
 	hydro.Register(newCreateWorkloadHandler(calcium))
 	hydro.Register(newWorkloadResourceAllocatedHandler(calcium))
 	hydro.Register(newProcessingCreatedHandler(store))
@@ -219,4 +229,12 @@ func enableWAL(config types.Config, calcium cluster.Cluster, store store.Store) 
 
 func getReplayContext(ctx context.Context) (context.Context, context.CancelFunc) {
 	return context.WithTimeout(ctx, replayTimeout)
+}
+
+func getWorkloadIfExists(ctx context.Context, calcium *Calcium, ID string) (*types.Workload, error) {
+	workload, err := calcium.GetWorkload(ctx, ID)
+	if err != nil && calcium.store.NotFound(err) {
+		return nil, nil
+	}
+	return workload, err
 }

--- a/cluster/calcium/wal_test.go
+++ b/cluster/calcium/wal_test.go
@@ -179,6 +179,47 @@ func TestHandleCreateWorkloadHandled(t *testing.T) {
 	c.wal.Recover(context.Background())
 }
 
+func TestHandleReplaceWorkload(t *testing.T) {
+	c := NewTestCluster()
+	wal, err := enableWAL(c.config, c, c.store)
+	require.NoError(t, err)
+	c.wal = wal
+
+	_, err = c.wal.Log(eventWorkloadReplaced, &workloadReplacement{OldID: "old", NewID: "new"})
+	require.NoError(t, err)
+
+	engine := &enginemocks.API{}
+	oldWorkload := &types.Workload{ID: "old", Name: "a_b_c", Nodename: "nodename", Engine: engine}
+	store := c.store.(*storemocks.Store)
+	store.On("GetWorkload", mock.Anything, "new").Return(&types.Workload{ID: "new"}, nil).Once()
+	store.On("GetWorkload", mock.Anything, "old").Return(oldWorkload, nil).Once()
+	store.On("RemoveWorkload", mock.Anything, oldWorkload).Return(nil).Once()
+	engine.On("VirtualizationRemove", mock.Anything, "old", true, true).Return(nil).Once()
+
+	c.wal.Recover(context.Background())
+	store.AssertExpectations(t)
+	engine.AssertExpectations(t)
+
+	c.wal.Recover(context.Background())
+}
+
+func TestHandleReplaceWorkloadKeepsTheOldOneWhenTheNewOneIsGone(t *testing.T) {
+	c := NewTestCluster()
+	wal, err := enableWAL(c.config, c, c.store)
+	require.NoError(t, err)
+	c.wal = wal
+
+	_, err = c.wal.Log(eventWorkloadReplaced, &workloadReplacement{OldID: "old", NewID: "new"})
+	require.NoError(t, err)
+
+	store := c.store.(*storemocks.Store)
+	store.On("GetWorkload", mock.Anything, "new").Return(nil, types.ErrMockError).Once()
+	store.On("NotFound", types.ErrMockError).Return(true).Once()
+
+	c.wal.Recover(context.Background())
+	store.AssertExpectations(t)
+}
+
 func TestHandleCreateLambda(t *testing.T) {
 	c := NewTestCluster()
 	wal, err := enableWAL(c.config, c, c.store)

--- a/cluster/calcium/wal_test.go
+++ b/cluster/calcium/wal_test.go
@@ -220,6 +220,30 @@ func TestHandleReplaceWorkloadKeepsTheOldOneWhenTheNewOneIsGone(t *testing.T) {
 	store.AssertExpectations(t)
 }
 
+func TestHandleReallocWorkload(t *testing.T) {
+	c := NewTestCluster()
+	wal, err := enableWAL(c.config, c, c.store)
+	require.NoError(t, err)
+	c.wal = wal
+
+	_, err = c.wal.Log(eventWorkloadReallocated, "workloadid")
+	require.NoError(t, err)
+
+	engine := &enginemocks.API{}
+	engineParams := resourcetypes.Resources{"cpumem": {"cpu": 2}}
+	store := c.store.(*storemocks.Store)
+	store.On("GetWorkload", mock.Anything, "workloadid").Return(
+		&types.Workload{ID: "workloadid", EngineParams: engineParams, Engine: engine}, nil,
+	).Once()
+	engine.On("VirtualizationUpdateResource", mock.Anything, "workloadid", engineParams).Return(nil).Once()
+
+	c.wal.Recover(context.Background())
+	store.AssertExpectations(t)
+	engine.AssertExpectations(t)
+
+	c.wal.Recover(context.Background())
+}
+
 func TestHandleCreateLambda(t *testing.T) {
 	c := NewTestCluster()
 	wal, err := enableWAL(c.config, c, c.store)

--- a/cluster/calcium/wal_test.go
+++ b/cluster/calcium/wal_test.go
@@ -111,6 +111,7 @@ func TestHandleCreateWorkloadError(t *testing.T) {
 	err = errors.Wrapf(types.ErrInvaildCount, "keys: [%s]", wrkid)
 	store.On("GetWorkload", mock.Anything, mock.Anything).Return(wrk, err).Once()
 	store.On("GetNode", mock.Anything, mock.Anything).Return(nil, err).Once()
+	store.On("NotFound", err).Return(false).Once()
 	c.wal.Recover(context.Background())
 	store.AssertExpectations(t)
 	engine.AssertExpectations(t)
@@ -128,6 +129,18 @@ func TestHandleCreateWorkloadError(t *testing.T) {
 	c.wal.Recover(context.Background())
 	store.AssertExpectations(t)
 	engine.AssertExpectations(t)
+
+	_, err = c.wal.Log(eventWorkloadCreated, &types.Workload{ID: wrkid, Nodename: node.Name})
+	require.NoError(t, err)
+	gone := fmt.Errorf("node gone")
+	store.On("GetWorkload", mock.Anything, wrkid).Return(wrk, gone).Once()
+	store.On("GetNode", mock.Anything, wrk.Nodename).Return(nil, gone).Once()
+	store.On("NotFound", gone).Return(true).Once()
+	c.wal.Recover(context.Background())
+	store.AssertExpectations(t)
+	engine.AssertExpectations(t)
+	c.wal.Recover(context.Background())
+	store.AssertExpectations(t)
 
 	c.wal.Recover(context.Background())
 }

--- a/cluster/calcium/wal_test.go
+++ b/cluster/calcium/wal_test.go
@@ -216,13 +216,6 @@ func TestHandleCreateLambda(t *testing.T) {
 	}
 
 	store := c.store.(*storemocks.Store)
-	store.On("GetWorkload", mock.Anything, mock.Anything).Return(nil, types.ErrMockError).Once()
-	c.wal.Recover(context.Background())
-	time.Sleep(500 * time.Millisecond)
-	store.AssertExpectations(t)
-
-	_, err = c.wal.Log(eventCreateLambda, "workloadid")
-	require.NoError(t, err)
 	store.On("GetWorkload", mock.Anything, mock.Anything).
 		Return(wrk, nil).
 		Once()
@@ -246,8 +239,29 @@ func TestHandleCreateLambda(t *testing.T) {
 	store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
 
 	c.wal.Recover(context.Background())
+	time.Sleep(500 * time.Millisecond)
 	c.wal.Recover(context.Background())
 	time.Sleep(500 * time.Millisecond)
 	store.AssertExpectations(t)
 	eng.AssertExpectations(t)
+}
+
+func TestHandleCreateLambdaKeepsEntryUntilRemoved(t *testing.T) {
+	c := NewTestCluster()
+	wal, err := enableWAL(c.config, c, c.store)
+	require.NoError(t, err)
+	c.wal = wal
+
+	_, err = c.wal.Log(eventCreateLambda, "workloadid")
+	require.NoError(t, err)
+
+	store := c.store.(*storemocks.Store)
+	store.On("GetWorkload", mock.Anything, "workloadid").Return(nil, types.ErrMockError).Twice()
+	store.On("NotFound", types.ErrMockError).Return(false).Twice()
+
+	c.wal.Recover(context.Background())
+	time.Sleep(500 * time.Millisecond)
+	c.wal.Recover(context.Background())
+	time.Sleep(500 * time.Millisecond)
+	store.AssertExpectations(t)
 }

--- a/store/mocks/Store.go
+++ b/store/mocks/Store.go
@@ -1338,6 +1338,57 @@ func (_c *Store_NodeStatusStream_Call) RunAndReturn(run func(ctx context.Context
 	return _c
 }
 
+// NotFound provides a mock function for the type Store
+func (_mock *Store) NotFound(err error) bool {
+	ret := _mock.Called(err)
+
+	if len(ret) == 0 {
+		panic("no return value specified for NotFound")
+	}
+
+	var r0 bool
+	if returnFunc, ok := ret.Get(0).(func(error) bool); ok {
+		r0 = returnFunc(err)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	return r0
+}
+
+// Store_NotFound_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'NotFound'
+type Store_NotFound_Call struct {
+	*mock.Call
+}
+
+// NotFound is a helper method to define mock.On call
+//   - err error
+func (_e *Store_Expecter) NotFound(err any) *Store_NotFound_Call {
+	return &Store_NotFound_Call{Call: _e.mock.On("NotFound", err)}
+}
+
+func (_c *Store_NotFound_Call) Run(run func(err error)) *Store_NotFound_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 error
+		if args[0] != nil {
+			arg0 = args[0].(error)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *Store_NotFound_Call) Return(b bool) *Store_NotFound_Call {
+	_c.Call.Return(b)
+	return _c
+}
+
+func (_c *Store_NotFound_Call) RunAndReturn(run func(err error) bool) *Store_NotFound_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // RegisterService provides a mock function for the type Store
 func (_mock *Store) RegisterService(context1 context.Context, s string, duration time.Duration) (<-chan struct{}, func(), error) {
 	ret := _mock.Called(context1, s, duration)

--- a/store/store.go
+++ b/store/store.go
@@ -10,6 +10,8 @@ import (
 
 // Store persists eru cluster metadata.
 type Store interface {
+	NotFound(err error) bool
+
 	ServiceStatusStream(context.Context) (chan []string, error)
 	RegisterService(context.Context, string, time.Duration) (<-chan struct{}, func(), error)
 

--- a/wal/hydro.go
+++ b/wal/hydro.go
@@ -38,11 +38,16 @@ func (h *Hydro) Register(handler EventHandler) {
 }
 
 func (h *Hydro) Recover(ctx context.Context) {
-	ch, _ := h.store.Scan([]byte(eventPrefix))
 	logger := log.WithFunc("wal.hydro.Recover")
+	ch, abort := h.store.Scan([]byte(eventPrefix))
+	defer abort()
 
 	var events []HydroEvent
 	for scanEntry := range ch {
+		if err := scanEntry.Error(); err != nil {
+			logger.Error(ctx, err, "scan events")
+			return
+		}
 		event, err := h.decodeEvent(scanEntry)
 		if err != nil {
 			logger.Error(ctx, err, "decode event")
@@ -76,22 +81,21 @@ func (h *Hydro) Log(eventyp string, item any) (Commit, error) {
 		return nil, err
 	}
 
-	var ID uint64
-	if ID, err = h.store.NextSequence(); err != nil {
-		return nil, err
-	}
-
-	event := NewHydroEvent(ID, eventyp, bs)
-	if bs, err = event.Encode(); err != nil {
-		return nil, coretypes.ErrInvaildWALEvent
-	}
-
-	if err = h.store.Put(event.Key(), bs); err != nil {
+	var key []byte
+	if err = h.store.PutNext(func(seq uint64) ([]byte, []byte, error) {
+		event := NewHydroEvent(seq, eventyp, bs)
+		value, encodeErr := event.Encode()
+		if encodeErr != nil {
+			return nil, nil, coretypes.ErrInvaildWALEvent
+		}
+		key = event.Key()
+		return key, value, nil
+	}); err != nil {
 		return nil, err
 	}
 
 	return func() error {
-		return h.store.Delete(event.Key())
+		return h.store.Delete(key)
 	}, nil
 }
 
@@ -116,10 +120,6 @@ func (h *Hydro) recover(ctx context.Context, handler EventHandler, event HydroEv
 }
 
 func (h *Hydro) decodeEvent(scanEntry kv.ScanEntry) (event HydroEvent, err error) {
-	if err = scanEntry.Error(); err != nil {
-		return event, err
-	}
-
 	key, value := scanEntry.Pair()
 	if err = json.Unmarshal(value, &event); err != nil {
 		return event, err

--- a/wal/hydro_test.go
+++ b/wal/hydro_test.go
@@ -91,13 +91,21 @@ func TestDecodeEventFailedAsInvalidEventID(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestDecodeEventFailedAsEntryError(t *testing.T) {
+func TestRecoverStopsOnScanError(t *testing.T) {
+	var handled, encoded, decoded bool
+	handler := newTestEventHandler("create", &handled, &encoded, &decoded)
+
 	hydro, _ := NewHydro(path.Join(t.TempDir(), "1"), time.Second)
-	expErr := fmt.Errorf("expects an error")
-	ent := kv.MockedScanEntry{Err: expErr}
-	_, err := hydro.decodeEvent(ent)
-	assert.Error(t, err)
-	assert.Equal(t, expErr.Error(), err.Error())
+	hydro.store = scanErrorKV{MockedKV: kv.NewMockedKV()}
+	hydro.Register(handler)
+
+	commit, err := hydro.Log("create", struct{}{})
+	assert.NoError(t, err)
+	assert.NotNil(t, commit)
+
+	hydro.Recover(context.Background())
+	assert.False(t, decoded)
+	assert.False(t, handled)
 }
 
 func TestRecoverFailedAsDecodeLogError(t *testing.T) {
@@ -209,4 +217,24 @@ func newTestEventHandler(eventype string, handled, encoded, decoded *bool) simpl
 		decode: decode,
 		handle: handle,
 	}
+}
+
+type scanErrorKV struct {
+	*kv.MockedKV
+}
+
+func (k scanErrorKV) Scan(prefix []byte) (<-chan kv.ScanEntry, func()) {
+	scanned, _ := k.MockedKV.Scan(prefix)
+	entries := []kv.ScanEntry{kv.MockedScanEntry{Err: fmt.Errorf("scan error")}}
+	for entry := range scanned {
+		entries = append(entries, entry)
+	}
+
+	ch := make(chan kv.ScanEntry, len(entries))
+	for _, entry := range entries {
+		ch <- entry
+	}
+	close(ch)
+
+	return ch, func() {}
 }

--- a/wal/kv/kv.go
+++ b/wal/kv/kv.go
@@ -10,11 +10,13 @@ type KV interface {
 	Open(path string, mode os.FileMode, timeout time.Duration) error
 	Close() error
 	Put([]byte, []byte) error
+	PutNext(SequencedEntry) error
 	Get([]byte) ([]byte, error)
 	Delete([]byte) error
 	Scan([]byte) (<-chan ScanEntry, func())
-	NextSequence() (ID uint64, err error)
 }
+
+type SequencedEntry func(seq uint64) (key, value []byte, err error)
 
 type ScanEntry interface {
 	Pair() (key, value []byte)

--- a/wal/kv/lithium.go
+++ b/wal/kv/lithium.go
@@ -65,6 +65,20 @@ func (l *Lithium) Put(key, value []byte) (err error) {
 	})
 }
 
+func (l *Lithium) PutNext(entry SequencedEntry) error {
+	return l.update(func(bkt *bbolt.Bucket) error {
+		seq, err := bkt.NextSequence()
+		if err != nil {
+			return err
+		}
+		key, value, err := entry(seq)
+		if err != nil {
+			return err
+		}
+		return bkt.Put(key, value)
+	})
+}
+
 func (l *Lithium) Get(key []byte) (dst []byte, err error) {
 	err = l.update(func(bkt *bbolt.Bucket) error {
 		src := bkt.Get(key)
@@ -114,16 +128,6 @@ func (l *Lithium) Scan(prefix []byte) (<-chan ScanEntry, func()) {
 	}()
 
 	return ch, abort
-}
-
-func (l *Lithium) NextSequence() (uint64, error) {
-	var seq uint64
-	err := l.update(func(bkt *bbolt.Bucket) (ue error) {
-		seq, ue = bkt.NextSequence()
-		return ue
-	})
-
-	return seq, err
 }
 
 func (l *Lithium) open() (err error) {

--- a/wal/kv/lithium_test.go
+++ b/wal/kv/lithium_test.go
@@ -81,23 +81,40 @@ func TestScanAbort(t *testing.T) {
 	}
 }
 
-func TestNextSequence(t *testing.T) {
+func TestPutNextKeepsSequencesGrowing(t *testing.T) {
 	lit, cancel := newTestLithium(t)
 	defer cancel()
 
-	seq0, err := lit.NextSequence()
-	require.NoError(t, err)
-	require.True(t, seq0 > 0)
+	seqs := []uint64{}
+	put := func() {
+		require.NoError(t, lit.PutNext(func(seq uint64) ([]byte, []byte, error) {
+			seqs = append(seqs, seq)
+			return []byte(fmt.Sprintf("/events/%016x", seq)), []byte("v"), nil
+		}))
+	}
 
-	seq1, err := lit.NextSequence()
-	require.NoError(t, err)
-	require.True(t, seq1 > seq0)
-
+	put()
+	put()
 	require.NoError(t, lit.Reopen())
+	put()
 
-	seq2, err := lit.NextSequence()
+	require.Len(t, seqs, 3)
+	require.True(t, seqs[0] > 0)
+	require.True(t, seqs[1] > seqs[0])
+	require.True(t, seqs[2] > seqs[1])
+
+	value, err := lit.Get([]byte(fmt.Sprintf("/events/%016x", seqs[2])))
 	require.NoError(t, err)
-	require.True(t, seq2 > seq1)
+	require.Equal(t, []byte("v"), value)
+}
+
+func TestPutNextFailedAsEntryError(t *testing.T) {
+	lit, cancel := newTestLithium(t)
+	defer cancel()
+
+	require.Error(t, lit.PutNext(func(uint64) ([]byte, []byte, error) {
+		return nil, nil, fmt.Errorf("entry error")
+	}))
 }
 
 func TestScanOrderedByKeys(t *testing.T) {

--- a/wal/kv/mocked.go
+++ b/wal/kv/mocked.go
@@ -31,15 +31,19 @@ func (m *MockedKV) Close() error {
 	return nil
 }
 
-func (m *MockedKV) NextSequence() (uint64, error) {
-	m.Lock()
-	defer m.Unlock()
-	nextSeq := m.nextSeq
-	m.nextSeq++
-	return nextSeq, nil
+func (m *MockedKV) Put(key, value []byte) error {
+	m.pool.Store(string(key), value)
+	return nil
 }
 
-func (m *MockedKV) Put(key, value []byte) error {
+func (m *MockedKV) PutNext(entry SequencedEntry) error {
+	m.Lock()
+	defer m.Unlock()
+	key, value, err := entry(m.nextSeq)
+	if err != nil {
+		return err
+	}
+	m.nextSeq++
 	m.pool.Store(string(key), value)
 	return nil
 }


### PR DESCRIPTION
Part 1 of #658. Each commit closes one gap from the audit there:

- removes journal `allocate-workload` for the node and `create-workload` for the workload, so a crash mid-remove is replayed by the existing handlers;
- the replayed lambda entry is re-logged and committed only after the lambda is removed, so a second restart no longer leaks it;
- `AddNode` drops plugin metadata that a crash between the plugin and the store write left behind, instead of failing forever with `ErrNodeExists`;
- replaces journal a `replace-workload` entry between the new workload's commit and the old one's removal;
- reallocs journal the node and a `realloc-workload` entry whose replay re-applies the stored engine params;
- a journal entry is written in one bbolt transaction, and `Recover` stops on a scan error instead of replaying a partial log.

Entries are committed on every stable outcome, success or reported failure, so only a crash leaves one behind.