### PR TITLE
fix: journal a create by name before the engine creates it

### DIFF
--- a/cluster/calcium/create.go
+++ b/cluster/calcium/create.go
@@ -1,6 +1,7 @@
 package calcium
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"maps"
@@ -379,9 +380,9 @@ func (c *Calcium) doDeployOneWorkload(
 		},
 
 		func(ctx context.Context, _ bool) error {
-			logger.Warnf(ctx, "failed to deploy workload %s, rollback", workload.ID)
+			logger.Warnf(ctx, "failed to deploy workload %s, rollback", cmp.Or(workload.ID, workload.Name))
 			if workload.ID == "" {
-				return nil
+				return removeWorkloadByName(ctx, node, workload.Name)
 			}
 
 			if err := c.store.RemoveWorkload(ctx, workload); err != nil {

--- a/cluster/calcium/create.go
+++ b/cluster/calcium/create.go
@@ -287,14 +287,19 @@ func (c *Calcium) doDeployOneWorkload(
 		CreateTime:   time.Now().Unix(),
 	}
 
-	var commit wal.Commit
+	commit, err := c.wal.Log(eventWorkloadCreated, &types.Workload{
+		Name:     workload.Name,
+		Nodename: workload.Nodename,
+	})
+	if err != nil {
+		return err
+	}
 	defer func() {
-		if commit != nil {
-			if err := commit(); err != nil {
-				logger.Errorf(ctx, err, "commit wal %s failed", eventWorkloadCreated)
-			}
+		if commitErr := commit(); commitErr != nil {
+			logger.Errorf(ctx, commitErr, "commit wal %s failed", eventWorkloadCreated)
 		}
 	}()
+
 	return utils.Txn(
 		ctx,
 		func(ctx context.Context) error {
@@ -305,13 +310,7 @@ func (c *Calcium) doDeployOneWorkload(
 			workload.ID = created.ID
 
 			maps.Copy(workload.Labels, created.Labels)
-
-			// a crash between VirtualizationCreate and this log leaks the workload
-			commit, err = c.wal.Log(eventWorkloadCreated, &types.Workload{
-				ID:       workload.ID,
-				Nodename: workload.Nodename,
-			})
-			return err
+			return nil
 		},
 
 		func(ctx context.Context) (err error) {

--- a/cluster/calcium/create_test.go
+++ b/cluster/calcium/create_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	enginemocks "github.com/projecteru2/core/engine/mocks"
 	enginetypes "github.com/projecteru2/core/engine/types"
@@ -446,6 +447,37 @@ func TestDoDeployWorkloadsOnNodeErrorPerWorkload(t *testing.T) {
 	for m := range ch {
 		assert.Error(t, m.Error)
 	}
+}
+
+func TestDoDeployOneWorkloadJournalsTheNameBeforeTheEngineCreate(t *testing.T) {
+	c := NewTestCluster()
+	ctx := context.Background()
+
+	var logged *types.Workload
+	engineCalled, loggedAfterEngine := false, false
+	mwal := &walmocks.WAL{}
+	mwal.On("Log", mock.Anything, mock.Anything).Return(func(_ string, raw any) (wal.Commit, error) {
+		logged, _ = raw.(*types.Workload)
+		loggedAfterEngine = engineCalled
+		return func() error { return nil }, nil
+	})
+	c.wal = mwal
+
+	engine := &enginemocks.API{}
+	engine.On("VirtualizationCreate", mock.Anything, mock.Anything).
+		Run(func(mock.Arguments) { engineCalled = true }).
+		Return(nil, types.ErrMockError)
+	node := &types.Node{NodeMeta: types.NodeMeta{Name: "n1"}, Engine: engine}
+
+	opts := &types.DeployOptions{Name: "app", Podname: "pod", Entrypoint: &types.Entrypoint{Name: "entry"}}
+	createOpts := &enginetypes.VirtualizationCreateOptions{Name: "app_entry_abcdef"}
+
+	assert.Error(t, c.doDeployOneWorkload(ctx, node, opts, &types.CreateWorkloadMessage{}, createOpts, false))
+	require.NotNil(t, logged, "the create was not journalled")
+	assert.False(t, loggedAfterEngine)
+	assert.Equal(t, createOpts.Name, logged.Name)
+	assert.Equal(t, node.Name, logged.Nodename)
+	assert.Empty(t, logged.ID)
 }
 
 func TestDoMakeWorkloadOptionsEnvIsolation(t *testing.T) {

--- a/cluster/calcium/create_test.go
+++ b/cluster/calcium/create_test.go
@@ -187,6 +187,7 @@ func TestCreateWorkloadTxn(t *testing.T) {
 	engine.On("ImageLocalDigests", mock.Anything, mock.Anything).Return([]string{""}, nil)
 	engine.On("ImageRemoteDigest", mock.Anything, mock.Anything).Return("", nil)
 	engine.On("VirtualizationCreate", mock.Anything, mock.Anything).Return(nil, errors.Wrap(context.DeadlineExceeded, "VirtualizationCreate")).Twice()
+	engine.On("VirtualizationInspect", mock.Anything, mock.Anything).Return(nil, types.ErrWorkloadNotExists).Twice()
 	engine.On("VirtualizationRemove", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	store.On("ListNodeWorkloads", mock.Anything, mock.Anything, mock.Anything).Return(nil, types.ErrMockError)
 	walCommitted.Store(false)
@@ -356,6 +357,7 @@ func TestCreateWorkloadIngorePullTxn(t *testing.T) {
 	store.On("DeleteProcessing", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	engine.On("VirtualizationCreate", mock.Anything, mock.Anything).Return(nil, errors.Wrap(context.DeadlineExceeded, "VirtualizationCreate")).Twice()
+	engine.On("VirtualizationInspect", mock.Anything, mock.Anything).Return(nil, types.ErrWorkloadNotExists).Twice()
 	engine.On("VirtualizationRemove", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	store.On("ListNodeWorkloads", mock.Anything, mock.Anything, mock.Anything).Return(nil, types.ErrMockError)
 	walCommitted.Store(false)
@@ -428,6 +430,7 @@ func TestDoDeployWorkloadsOnNodeErrorPerWorkload(t *testing.T) {
 	lock.On("Unlock", mock.Anything).Return(nil)
 	store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
 	engine.On("VirtualizationCreate", mock.Anything, mock.Anything).Return(nil, types.ErrMockError)
+	engine.On("VirtualizationInspect", mock.Anything, mock.Anything).Return(nil, types.ErrWorkloadNotExists)
 
 	const deploy = 4
 	opts := &types.DeployOptions{
@@ -467,6 +470,7 @@ func TestDoDeployOneWorkloadJournalsTheNameBeforeTheEngineCreate(t *testing.T) {
 	engine.On("VirtualizationCreate", mock.Anything, mock.Anything).
 		Run(func(mock.Arguments) { engineCalled = true }).
 		Return(nil, types.ErrMockError)
+	engine.On("VirtualizationInspect", mock.Anything, mock.Anything).Return(nil, types.ErrWorkloadNotExists)
 	node := &types.Node{NodeMeta: types.NodeMeta{Name: "n1"}, Engine: engine}
 
 	opts := &types.DeployOptions{Name: "app", Podname: "pod", Entrypoint: &types.Entrypoint{Name: "entry"}}
@@ -478,6 +482,24 @@ func TestDoDeployOneWorkloadJournalsTheNameBeforeTheEngineCreate(t *testing.T) {
 	assert.Equal(t, createOpts.Name, logged.Name)
 	assert.Equal(t, node.Name, logged.Nodename)
 	assert.Empty(t, logged.ID)
+}
+
+func TestDoDeployOneWorkloadRollbackRemovesTheContainerTheEngineKept(t *testing.T) {
+	c := NewTestCluster()
+	ctx := context.Background()
+
+	name := "app_entry_abcdef"
+	engine := &enginemocks.API{}
+	engine.On("VirtualizationCreate", mock.Anything, mock.Anything).Return(nil, types.ErrMockError).Once()
+	engine.On("VirtualizationInspect", mock.Anything, name).Return(&enginetypes.VirtualizationInfo{ID: "wrkid"}, nil).Once()
+	engine.On("VirtualizationRemove", mock.Anything, "wrkid", true, true).Return(nil).Once()
+	node := &types.Node{NodeMeta: types.NodeMeta{Name: "n1"}, Engine: engine}
+
+	opts := &types.DeployOptions{Name: "app", Podname: "pod", Entrypoint: &types.Entrypoint{Name: "entry"}}
+	createOpts := &enginetypes.VirtualizationCreateOptions{Name: name}
+
+	assert.Error(t, c.doDeployOneWorkload(ctx, node, opts, &types.CreateWorkloadMessage{}, createOpts, false))
+	engine.AssertExpectations(t)
 }
 
 func TestDoMakeWorkloadOptionsEnvIsolation(t *testing.T) {

--- a/cluster/calcium/remap.go
+++ b/cluster/calcium/remap.go
@@ -3,6 +3,8 @@ package calcium
 import (
 	"context"
 
+	"github.com/cockroachdb/errors"
+
 	"github.com/projecteru2/core/log"
 	"github.com/projecteru2/core/types"
 	"github.com/projecteru2/core/utils"
@@ -25,7 +27,10 @@ func (c *Calcium) RemapResourceAndLog(ctx context.Context, logger *log.Fields, n
 		}
 		for msg := range ch {
 			logger.Infof(ctx, "remap workload ID %+v", msg.ID)
-			if msg.err != nil {
+			switch {
+			case errors.Is(msg.err, types.ErrWorkloadNotExists), errors.Is(msg.err, types.ErrWorkloadRemoving):
+				logger.Warnf(ctx, "skip remap of workload %s: %+v", msg.ID, msg.err)
+			case msg.err != nil:
 				logger.Error(ctx, msg.err)
 			}
 		}

--- a/cluster/calcium/remove.go
+++ b/cluster/calcium/remove.go
@@ -75,7 +75,7 @@ func (c *Calcium) doRemoveOneWorkload(ctx context.Context, node *types.Node, wor
 		}
 	}()
 
-	workloadCommit, err := c.wal.Log(eventWorkloadCreated, &types.Workload{ID: workload.ID, Nodename: workload.Nodename})
+	workloadCommit, err := c.wal.Log(eventWorkloadCreated, &types.Workload{ID: workload.ID, Name: workload.Name, Nodename: workload.Nodename})
 	if err != nil {
 		return err
 	}

--- a/cluster/calcium/replace_test.go
+++ b/cluster/calcium/replace_test.go
@@ -159,6 +159,7 @@ func TestReplaceWorkload(t *testing.T) {
 	engine.AssertExpectations(t)
 
 	engine.On("VirtualizationStop", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	engine.On("VirtualizationRemove", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	engine.On("VirtualizationCreate", mock.Anything, mock.Anything).Return(nil, types.ErrMockError).Once()
 	engine.On("VirtualizationStart", mock.Anything, mock.Anything).Return(types.ErrMockError).Once()
 	ch, err = c.ReplaceWorkload(ctx, opts)
@@ -189,7 +190,6 @@ func TestReplaceWorkload(t *testing.T) {
 	store.AssertExpectations(t)
 	engine.AssertExpectations(t)
 
-	engine.On("VirtualizationRemove", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	store.On("RemoveWorkload", mock.Anything, mock.Anything).Return(nil)
 	store.On("ListNodeWorkloads", mock.Anything, mock.Anything, mock.Anything).Return(nil, types.ErrMockError)
 	ch, err = c.ReplaceWorkload(ctx, opts)

--- a/cluster/calcium/utils.go
+++ b/cluster/calcium/utils.go
@@ -5,6 +5,8 @@ import (
 	"slices"
 	"sync"
 
+	"github.com/cockroachdb/errors"
+
 	"github.com/projecteru2/core/log"
 	"github.com/projecteru2/core/resource/plugins"
 	resourcetypes "github.com/projecteru2/core/resource/types"
@@ -46,6 +48,21 @@ func perNode[T any](c *Calcium, nodes []*types.Node, work func(*types.Node, chan
 		}
 	})
 	return ch
+}
+
+func removeWorkloadByName(ctx context.Context, node *types.Node, name string) error {
+	info, err := node.Engine.VirtualizationInspect(ctx, name)
+	if err != nil {
+		if errors.Is(err, types.ErrWorkloadNotExists) {
+			return nil
+		}
+		return err
+	}
+
+	if err = node.Engine.VirtualizationRemove(ctx, info.ID, true, true); err != nil && !errors.Is(err, types.ErrWorkloadNotExists) {
+		return err
+	}
+	return nil
 }
 
 func distributionInspect(ctx context.Context, node *types.Node, image string, digests []string) bool {

--- a/cluster/calcium/wal.go
+++ b/cluster/calcium/wal.go
@@ -3,6 +3,7 @@ package calcium
 import (
 	"context"
 	"encoding/json"
+	"slices"
 	"sync"
 	"time"
 
@@ -108,15 +109,20 @@ func (h *CreateWorkloadHandler) Typ() string {
 	return eventWorkloadCreated
 }
 
-func (h *CreateWorkloadHandler) Handle(ctx context.Context, raw any) (err error) {
+func (h *CreateWorkloadHandler) Handle(ctx context.Context, raw any) error {
 	wrk, _ := raw.(*types.Workload)
-	logger := log.WithFunc("calcium.CreateWorkloadHandler.Handle").WithField("ID", wrk.ID).WithField("node", wrk.Nodename)
+	logger := log.WithFunc("calcium.CreateWorkloadHandler.Handle").WithField("ID", wrk.ID).WithField("name", wrk.Name).WithField("node", wrk.Nodename)
 
 	ctx, cancel := getReplayContext(ctx)
 	defer cancel()
 
-	if _, err = h.calcium.GetWorkload(ctx, wrk.ID); err == nil {
-		return h.calcium.RemoveWorkloadSync(ctx, []string{wrk.ID})
+	storedID, err := h.storedWorkloadID(ctx, wrk)
+	if err != nil {
+		logger.Error(ctx, err)
+		return err
+	}
+	if storedID != "" {
+		return h.calcium.RemoveWorkloadSync(ctx, []string{storedID})
 	}
 
 	node, err := h.calcium.GetNode(ctx, wrk.Nodename)
@@ -128,13 +134,54 @@ func (h *CreateWorkloadHandler) Handle(ctx context.Context, raw any) (err error)
 		logger.Error(ctx, err)
 		return err
 	}
-	if err = node.Engine.VirtualizationRemove(ctx, wrk.ID, true, true); err != nil && !errors.Is(err, types.ErrWorkloadNotExists) {
+
+	ID, err := h.engineWorkloadID(ctx, node, wrk)
+	switch {
+	case errors.Is(err, types.ErrWorkloadNotExists):
+		logger.Info(ctx, "workload never reached the engine")
+		return nil
+	case err != nil:
+		logger.Error(ctx, err)
+		return err
+	}
+
+	if err = node.Engine.VirtualizationRemove(ctx, ID, true, true); err != nil && !errors.Is(err, types.ErrWorkloadNotExists) {
 		logger.Error(ctx, err)
 		return err
 	}
 
 	logger.Info(ctx, "workload removed")
 	return nil
+}
+
+func (h *CreateWorkloadHandler) storedWorkloadID(ctx context.Context, wrk *types.Workload) (string, error) {
+	if wrk.ID != "" {
+		if _, err := h.calcium.GetWorkload(ctx, wrk.ID); err != nil {
+			return "", nil
+		}
+		return wrk.ID, nil
+	}
+
+	workloads, err := h.calcium.store.ListNodeWorkloads(ctx, wrk.Nodename, nil)
+	if err != nil {
+		return "", err
+	}
+	index := slices.IndexFunc(workloads, func(workload *types.Workload) bool { return workload.Name == wrk.Name })
+	if index < 0 {
+		return "", nil
+	}
+	return workloads[index].ID, nil
+}
+
+func (h *CreateWorkloadHandler) engineWorkloadID(ctx context.Context, node *types.Node, wrk *types.Workload) (string, error) {
+	if wrk.ID != "" {
+		return wrk.ID, nil
+	}
+	info, err := node.Engine.VirtualizationInspect(ctx, wrk.Name)
+	if err != nil {
+		return "", err
+	}
+	return info.ID, nil
 }
 
 type workloadReplacement struct {

--- a/cluster/calcium/wal.go
+++ b/cluster/calcium/wal.go
@@ -135,17 +135,7 @@ func (h *CreateWorkloadHandler) Handle(ctx context.Context, raw any) error {
 		return err
 	}
 
-	ID, err := h.engineWorkloadID(ctx, node, wrk)
-	switch {
-	case errors.Is(err, types.ErrWorkloadNotExists):
-		logger.Info(ctx, "workload never reached the engine")
-		return nil
-	case err != nil:
-		logger.Error(ctx, err)
-		return err
-	}
-
-	if err = node.Engine.VirtualizationRemove(ctx, ID, true, true); err != nil && !errors.Is(err, types.ErrWorkloadNotExists) {
+	if err = h.removeFromEngine(ctx, node, wrk); err != nil {
 		logger.Error(ctx, err)
 		return err
 	}
@@ -173,15 +163,14 @@ func (h *CreateWorkloadHandler) storedWorkloadID(ctx context.Context, wrk *types
 	return workloads[index].ID, nil
 }
 
-func (h *CreateWorkloadHandler) engineWorkloadID(ctx context.Context, node *types.Node, wrk *types.Workload) (string, error) {
-	if wrk.ID != "" {
-		return wrk.ID, nil
+func (h *CreateWorkloadHandler) removeFromEngine(ctx context.Context, node *types.Node, wrk *types.Workload) error {
+	if wrk.ID == "" {
+		return removeWorkloadByName(ctx, node, wrk.Name)
 	}
-	info, err := node.Engine.VirtualizationInspect(ctx, wrk.Name)
-	if err != nil {
-		return "", err
+	if err := node.Engine.VirtualizationRemove(ctx, wrk.ID, true, true); err != nil && !errors.Is(err, types.ErrWorkloadNotExists) {
+		return err
 	}
-	return info.ID, nil
+	return nil
 }
 
 type workloadReplacement struct {

--- a/cluster/calcium/wal_test.go
+++ b/cluster/calcium/wal_test.go
@@ -192,6 +192,87 @@ func TestHandleCreateWorkloadHandled(t *testing.T) {
 	c.wal.Recover(context.Background())
 }
 
+func TestHandleCreateWorkloadByNameFromTheStore(t *testing.T) {
+	c := NewTestCluster()
+	wal, err := enableWAL(c.config, c, c.store)
+	require.NoError(t, err)
+	c.wal = wal
+
+	name := "app_entry_abcdef"
+	_, err = c.wal.Log(eventWorkloadCreated, &types.Workload{Name: name, Nodename: "nodename"})
+	require.NoError(t, err)
+
+	store := c.store.(*storemocks.Store)
+	store.On("ListNodeWorkloads", mock.Anything, "nodename", mock.Anything).Return(
+		[]*types.Workload{{ID: "other", Name: "app_entry_ffffff"}, {ID: "wrkid", Name: name}}, nil,
+	).Once()
+	store.On("GetWorkloads", mock.Anything, []string{"wrkid"}).Return(nil, nil).Once()
+
+	c.wal.Recover(context.Background())
+	store.AssertExpectations(t)
+
+	c.wal.Recover(context.Background())
+}
+
+func TestHandleCreateWorkloadByNameFromTheEngine(t *testing.T) {
+	c := NewTestCluster()
+	wal, err := enableWAL(c.config, c, c.store)
+	require.NoError(t, err)
+	c.wal = wal
+
+	name := "app_entry_abcdef"
+	_, err = c.wal.Log(eventWorkloadCreated, &types.Workload{Name: name, Nodename: "nodename"})
+	require.NoError(t, err)
+
+	rmgr := c.rmgr.(*resourcemocks.Manager)
+	rmgr.On("GetNodeResourceInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+		resourcetypes.Resources{}, resourcetypes.Resources{}, []string{}, nil,
+	)
+
+	engine := &enginemocks.API{}
+	node := &types.Node{NodeMeta: types.NodeMeta{Name: "nodename"}, Engine: engine}
+	store := c.store.(*storemocks.Store)
+	store.On("ListNodeWorkloads", mock.Anything, "nodename", mock.Anything).Return(nil, nil).Once()
+	store.On("GetNode", mock.Anything, "nodename").Return(node, nil).Once()
+	engine.On("VirtualizationInspect", mock.Anything, name).Return(&enginetypes.VirtualizationInfo{ID: "wrkid"}, nil).Once()
+	engine.On("VirtualizationRemove", mock.Anything, "wrkid", true, true).Return(nil).Once()
+
+	c.wal.Recover(context.Background())
+	store.AssertExpectations(t)
+	engine.AssertExpectations(t)
+
+	c.wal.Recover(context.Background())
+}
+
+func TestHandleCreateWorkloadByNameUnknownToBoth(t *testing.T) {
+	c := NewTestCluster()
+	wal, err := enableWAL(c.config, c, c.store)
+	require.NoError(t, err)
+	c.wal = wal
+
+	name := "app_entry_abcdef"
+	_, err = c.wal.Log(eventWorkloadCreated, &types.Workload{Name: name, Nodename: "nodename"})
+	require.NoError(t, err)
+
+	rmgr := c.rmgr.(*resourcemocks.Manager)
+	rmgr.On("GetNodeResourceInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+		resourcetypes.Resources{}, resourcetypes.Resources{}, []string{}, nil,
+	)
+
+	engine := &enginemocks.API{}
+	node := &types.Node{NodeMeta: types.NodeMeta{Name: "nodename"}, Engine: engine}
+	store := c.store.(*storemocks.Store)
+	store.On("ListNodeWorkloads", mock.Anything, "nodename", mock.Anything).Return(nil, nil).Once()
+	store.On("GetNode", mock.Anything, "nodename").Return(node, nil).Once()
+	engine.On("VirtualizationInspect", mock.Anything, name).Return(nil, types.ErrWorkloadNotExists).Once()
+
+	c.wal.Recover(context.Background())
+	store.AssertExpectations(t)
+	engine.AssertExpectations(t)
+
+	c.wal.Recover(context.Background())
+}
+
 func TestHandleReplaceWorkload(t *testing.T) {
 	c := NewTestCluster()
 	wal, err := enableWAL(c.config, c, c.store)

--- a/engine/docker/container.go
+++ b/engine/docker/container.go
@@ -477,6 +477,12 @@ func (e *Engine) VirtualizationUpdateResource(ctx context.Context, ID string, en
 
 	newResource := makeResourceSetting(quota, memory, cpuMap, numaNode, resourceOpts.IOPSOptions, resourceOpts.Remap)
 	_, err := e.client.ContainerUpdate(ctx, ID, dockerapi.ContainerUpdateOptions{Resources: &newResource})
+	switch {
+	case cerrdefs.IsNotFound(err):
+		return coretypes.ErrWorkloadNotExists
+	case cerrdefs.IsConflict(err):
+		return coretypes.ErrWorkloadRemoving
+	}
 	return err
 }
 

--- a/engine/docker/container.go
+++ b/engine/docker/container.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/go-units"
 	dockercontainer "github.com/moby/moby/api/types/container"
 	dockernetwork "github.com/moby/moby/api/types/network"
@@ -332,7 +333,7 @@ func (e *Engine) VirtualizationResume(context.Context, string) error {
 
 func (e *Engine) VirtualizationRemove(ctx context.Context, ID string, removeVolumes, force bool) error {
 	if _, err := e.client.ContainerRemove(ctx, ID, dockerapi.ContainerRemoveOptions{RemoveVolumes: removeVolumes, Force: force}); err != nil {
-		if strings.Contains(err.Error(), "no such") {
+		if cerrdefs.IsNotFound(err) {
 			err = coretypes.ErrWorkloadNotExists
 		}
 		return err
@@ -344,6 +345,9 @@ func (e *Engine) VirtualizationInspect(ctx context.Context, ID string) (*enginet
 	inspected, err := e.client.ContainerInspect(ctx, ID, dockerapi.ContainerInspectOptions{})
 	r := &enginetypes.VirtualizationInfo{}
 	if err != nil {
+		if cerrdefs.IsNotFound(err) {
+			err = coretypes.ErrWorkloadNotExists
+		}
 		return r, err
 	}
 	workloadJSON := inspected.Container

--- a/engine/docker/container_test.go
+++ b/engine/docker/container_test.go
@@ -1,10 +1,36 @@
 package docker
 
 import (
+	"fmt"
 	"testing"
 
+	cerrdefs "github.com/containerd/errdefs"
+	dockerapi "github.com/moby/moby/client"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	dockermocks "github.com/projecteru2/core/engine/docker/mocks"
+	coretypes "github.com/projecteru2/core/types"
 )
+
+func TestVirtualizationRemoveReportsAMissingContainer(t *testing.T) {
+	client := dockermocks.NewAPIClient(t)
+	client.On("ContainerRemove", mock.Anything, "wid", mock.Anything).
+		Return(dockerapi.ContainerRemoveResult{}, daemonNotFound("wid"))
+
+	e := &Engine{client: client}
+	assert.ErrorIs(t, e.VirtualizationRemove(t.Context(), "wid", true, true), coretypes.ErrWorkloadNotExists)
+}
+
+func TestVirtualizationInspectReportsAMissingContainer(t *testing.T) {
+	client := dockermocks.NewAPIClient(t)
+	client.On("ContainerInspect", mock.Anything, "wname", mock.Anything).
+		Return(dockerapi.ContainerInspectResult{}, daemonNotFound("wname"))
+
+	e := &Engine{client: client}
+	_, err := e.VirtualizationInspect(t.Context(), "wname")
+	assert.ErrorIs(t, err, coretypes.ErrWorkloadNotExists)
+}
 
 func TestRawArgs(t *testing.T) {
 	assert := assert.New(t)
@@ -33,4 +59,8 @@ func TestRawArgs(t *testing.T) {
 
 	_, err = loadRawArgs([]byte(`{"storage_opt": null, "cap_add": null, "cap_drop": null, "ulimits"}`))
 	assert.Error(err)
+}
+
+func daemonNotFound(name string) error {
+	return fmt.Errorf("Error response from daemon: No such container: %s: %w", name, cerrdefs.ErrNotFound)
 }

--- a/engine/docker/container_test.go
+++ b/engine/docker/container_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	dockermocks "github.com/projecteru2/core/engine/docker/mocks"
+	resourcetypes "github.com/projecteru2/core/resource/types"
 	coretypes "github.com/projecteru2/core/types"
 )
 
@@ -30,6 +31,24 @@ func TestVirtualizationInspectReportsAMissingContainer(t *testing.T) {
 	e := &Engine{client: client}
 	_, err := e.VirtualizationInspect(t.Context(), "wname")
 	assert.ErrorIs(t, err, coretypes.ErrWorkloadNotExists)
+}
+
+func TestVirtualizationUpdateResourceReportsAMissingContainer(t *testing.T) {
+	client := dockermocks.NewAPIClient(t)
+	client.On("ContainerUpdate", mock.Anything, "wid", mock.Anything).
+		Return(dockerapi.ContainerUpdateResult{}, daemonNotFound("wid"))
+
+	e := &Engine{client: client}
+	assert.ErrorIs(t, e.VirtualizationUpdateResource(t.Context(), "wid", boundEngineParams()), coretypes.ErrWorkloadNotExists)
+}
+
+func TestVirtualizationUpdateResourceReportsAContainerBeingRemoved(t *testing.T) {
+	client := dockermocks.NewAPIClient(t)
+	client.On("ContainerUpdate", mock.Anything, "wid", mock.Anything).
+		Return(dockerapi.ContainerUpdateResult{}, daemonConflict("wid"))
+
+	e := &Engine{client: client}
+	assert.ErrorIs(t, e.VirtualizationUpdateResource(t.Context(), "wid", boundEngineParams()), coretypes.ErrWorkloadRemoving)
 }
 
 func TestRawArgs(t *testing.T) {
@@ -63,4 +82,12 @@ func TestRawArgs(t *testing.T) {
 
 func daemonNotFound(name string) error {
 	return fmt.Errorf("Error response from daemon: No such container: %s: %w", name, cerrdefs.ErrNotFound)
+}
+
+func daemonConflict(name string) error {
+	return fmt.Errorf("Error response from daemon: container %s is marked for removal and cannot be update: %w", name, cerrdefs.ErrConflict)
+}
+
+func boundEngineParams() resourcetypes.Resources {
+	return resourcetypes.Resources{"cpumem": {"cpu": 1.0, "cpu_map": map[string]int64{"0": 100}}}
 }

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/bsm/redislock v0.10.0
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/cockroachdb/errors v1.14.0
+	github.com/containerd/errdefs v1.0.0
 	github.com/distribution/reference v0.6.0
 	github.com/docker/go-connections v0.8.1
 	github.com/docker/go-units v0.5.0
@@ -50,7 +51,6 @@ require (
 	github.com/cloudflare/circl v1.6.5 // indirect
 	github.com/cockroachdb/logtags v0.0.0-20241215232642-bb51bb14a506 // indirect
 	github.com/cockroachdb/redact v1.1.8 // indirect
-	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/coreos/go-semver v0.3.1 // indirect

--- a/types/errors.go
+++ b/types/errors.go
@@ -46,6 +46,7 @@ var (
 	ErrInvalidWorkloadName   = errors.New("invalid workload name")
 	ErrWorkloadIgnored       = errors.New("ignore this workload")
 	ErrWorkloadNotExists     = errors.New("workload not exists")
+	ErrWorkloadRemoving      = errors.New("workload is being removed")
 
 	ErrPodHasNodes = errors.New("pod has nodes")
 	ErrPodNoNodes  = errors.New("pod has no nodes")


### PR DESCRIPTION
Found on the test cluster with `kill -9` during a 60-workload deploy: 20 containers on one node were left in docker state Created with no metadata and no journal entry. `Hydro.Log` serialises on bbolt, so under concurrent creates the window between the engine create and the journal write is tens of milliseconds wide.

- the `create-workload` entry is written before the engine call, keyed by the workload name (unique by its random suffix); replay resolves the name in the store, then on the engine;
- the docker engine maps the client's typed not-found to `ErrWorkloadNotExists` again — moby v29 capitalises "No such container", so the old substring match never fired and replays could not converge;
- a failed create removes the container the daemon may have kept (inspect by name) instead of leaving a journal entry behind;
- remap logs a workload that is being removed (409) or already gone (404) at Warn instead of Error.

Part of #658.