### PR TITLE
fix: drain the scan channel in the wal recover tests

### DIFF
--- a/wal/hydro_test.go
+++ b/wal/hydro_test.go
@@ -150,10 +150,8 @@ func TestHydroRecover(t *testing.T) {
 	assert.True(t, handled)
 
 	ch, _ := hydro.store.Scan([]byte(eventPrefix))
-	select {
-	case <-ch:
+	for range ch {
 		assert.Fail(t, "the events should be deleted")
-	default:
 	}
 }
 
@@ -188,10 +186,8 @@ func TestHydroRecoverWithRealLithium(t *testing.T) {
 	hydro.Recover(context.Background())
 
 	ch, _ := hydro.store.Scan([]byte(eventPrefix))
-	select {
-	case <-ch:
+	for range ch {
 		assert.FailNow(t, "expects no data")
-	default:
 	}
 }
 


### PR DESCRIPTION
`TestHydroRecover` / `TestHydroRecoverWithRealLithium` asserted "no events left" with a `select … default` on the scan channel, which fires on the closed channel as readily as on an entry, so the assertion flipped with scheduling (failed one of two CI runs of #667). Ranging over the channel until it closes checks what the test means.