### PR TITLE
fix: preserve node TLS unless requested

### DIFF
--- a/cluster/calcium/node.go
+++ b/cluster/calcium/node.go
@@ -201,9 +201,11 @@ func (c *Calcium) SetNode(ctx context.Context, opts *types.SetNodeOptions) (*typ
 		if opts.Endpoint != "" {
 			n.Endpoint = opts.Endpoint
 		}
-		n.Ca = opts.Ca
-		n.Cert = opts.Cert
-		n.Key = opts.Key
+		if opts.UpdateTLS {
+			n.Ca = opts.Ca
+			n.Cert = opts.Cert
+			n.Key = opts.Key
+		}
 		if len(opts.Labels) != 0 {
 			n.Labels = opts.Labels
 		}

--- a/cluster/calcium/node_tls_test.go
+++ b/cluster/calcium/node_tls_test.go
@@ -1,0 +1,56 @@
+package calcium
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+
+	lockmocks "github.com/projecteru2/core/lock/mocks"
+	resourcemocks "github.com/projecteru2/core/resource/mocks"
+	storemocks "github.com/projecteru2/core/store/mocks"
+	"github.com/projecteru2/core/types"
+)
+
+func TestSetNodeUpdatesTLSOnlyWhenRequested(t *testing.T) {
+	tests := []struct {
+		name      string
+		updateTLS bool
+		wantCA    string
+		wantCert  string
+		wantKey   string
+	}{
+		{name: "keeps tls", wantCA: "old-ca", wantCert: "old-cert", wantKey: "old-key"},
+		{name: "updates tls", updateTLS: true, wantCA: "new-ca", wantCert: "new-cert", wantKey: "new-key"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+			c := NewTestCluster()
+			store := c.store.(*storemocks.Store)
+			lock := &lockmocks.DistributedLock{}
+			lock.On("Lock", mock.Anything).Return(ctx, nil)
+			lock.On("Unlock", mock.Anything).Return(nil)
+			store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
+			store.On("GetNode", mock.Anything, mock.Anything).Return(&types.Node{
+				NodeMeta: types.NodeMeta{Name: "node1", Ca: "old-ca", Cert: "old-cert", Key: "old-key"},
+			}, nil)
+			store.On("UpdateNodes", mock.Anything, mock.Anything).Return(types.ErrMockError)
+			c.rmgr.(*resourcemocks.Manager).On("GetNodeResourceInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil, nil, nil)
+
+			node, err := c.SetNode(ctx, &types.SetNodeOptions{
+				Nodename:  "node1",
+				UpdateTLS: tt.updateTLS,
+				Ca:        "new-ca",
+				Cert:      "new-cert",
+				Key:       "new-key",
+			})
+			if err == nil {
+				t.Fatal("got nil, want the store failure")
+			}
+			if node.Ca != tt.wantCA || node.Cert != tt.wantCert || node.Key != tt.wantKey {
+				t.Errorf("got ca=%q cert=%q key=%q, want ca=%q cert=%q key=%q", node.Ca, node.Cert, node.Key, tt.wantCA, tt.wantCert, tt.wantKey)
+			}
+		})
+	}
+}

--- a/rpc/gen/core.pb.go
+++ b/rpc/gen/core.pb.go
@@ -1561,6 +1561,7 @@ type SetNodeOptions struct {
 	Delta         bool                   `protobuf:"varint,1008,opt,name=delta,proto3" json:"delta,omitempty"`
 	WorkloadsDown bool                   `protobuf:"varint,1009,opt,name=workloads_down,json=workloadsDown,proto3" json:"workloads_down,omitempty"`
 	Bypass        TriOpt                 `protobuf:"varint,1010,opt,name=bypass,proto3,enum=pb.TriOpt" json:"bypass,omitempty"`
+	UpdateTls     bool                   `protobuf:"varint,1011,opt,name=update_tls,json=updateTls,proto3" json:"update_tls,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1663,6 +1664,13 @@ func (x *SetNodeOptions) GetBypass() TriOpt {
 		return x.Bypass
 	}
 	return TriOpt_KEEP
+}
+
+func (x *SetNodeOptions) GetUpdateTls() bool {
+	if x != nil {
+		return x.UpdateTls
+	}
+	return false
 }
 
 type SetNodeStatusOptions struct {
@@ -5768,7 +5776,7 @@ const file_rpc_gen_core_proto_rawDesc = "" +
 	"\tskip_info\x18\xed\a \x01(\bR\bskipInfo\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xdb\x03\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xfb\x03\n" +
 	"\x0eSetNodeOptions\x12\x1b\n" +
 	"\bnodename\x18\xe9\a \x01(\tR\bnodename\x12\x1b\n" +
 	"\bendpoint\x18\xea\a \x01(\tR\bendpoint\x12\x0f\n" +
@@ -5780,7 +5788,9 @@ const file_rpc_gen_core_proto_rawDesc = "" +
 	"\x05delta\x18\xf0\a \x01(\bR\x05delta\x12&\n" +
 	"\x0eworkloads_down\x18\xf1\a \x01(\bR\rworkloadsDown\x12#\n" +
 	"\x06bypass\x18\xf2\a \x01(\x0e2\n" +
-	".pb.TriOptR\x06bypass\x1a9\n" +
+	".pb.TriOptR\x06bypass\x12\x1e\n" +
+	"\n" +
+	"update_tls\x18\xf3\a \x01(\bR\tupdateTls\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a<\n" +

--- a/rpc/gen/core.proto
+++ b/rpc/gen/core.proto
@@ -205,6 +205,7 @@ message SetNodeOptions {
   bool delta = 1008;
   bool workloads_down = 1009;
   TriOpt bypass = 1010;
+  bool update_tls = 1011;
 }
 
 message SetNodeStatusOptions {

--- a/rpc/transform.go
+++ b/rpc/transform.go
@@ -143,6 +143,7 @@ func toCoreSetNodeOptions(b *pb.SetNodeOptions) (*types.SetNodeOptions, error) {
 	return &types.SetNodeOptions{
 		Nodename:      b.Nodename,
 		Endpoint:      b.Endpoint,
+		UpdateTLS:     b.UpdateTls,
 		Ca:            b.Ca,
 		Cert:          b.Cert,
 		Key:           b.Key,

--- a/types/options.go
+++ b/types/options.go
@@ -207,6 +207,7 @@ type SetNodeOptions struct {
 	Delta         bool
 	Labels        map[string]string
 	Bypass        TriOptions
+	UpdateTLS     bool
 	Ca            string
 	Cert          string
 	Key           string


### PR DESCRIPTION
## Summary

- add an explicit SetNode TLS update intent to the RPC contract
- preserve stored CA, certificate, and key during unrelated node updates
- cover both preserve and replace paths

## Tests

- GOWORK=off go test -race -timeout 600s -count=1 ./...
- GOWORK=off make lint
- GOWORK=off make fmt-check
- GOWORK=off make vet
- GOWORK=off asl ./...
- GOWORK=off GOOS=linux asl ./...