### PR TITLE
fix: close whole-repo recovery gaps

### DIFF
--- a/cluster/calcium/calcium_test.go
+++ b/cluster/calcium/calcium_test.go
@@ -84,6 +84,7 @@ func NewTestCluster() *Calcium {
 			ShareBase: 100,
 		},
 		GRPCConfig: types.GRPCConfig{
+			MaxRecvMsgSize:               20971520,
 			ServiceDiscoveryPushInterval: 15 * time.Second,
 		},
 		MaxConcurrency:      100000,

--- a/cluster/calcium/create.go
+++ b/cluster/calcium/create.go
@@ -48,7 +48,6 @@ func (c *Calcium) doCreateWorkloads(ctx context.Context, opts *types.DeployOptio
 		rollbackMap          map[string][]int
 		engineParamsMap      = map[string][]resourcetypes.Resources{}
 		workloadResourcesMap = map[string][]resourcetypes.Resources{}
-		rollbackComplete     bool
 	)
 
 	_ = c.pool.Invoke(func() {
@@ -70,7 +69,7 @@ func (c *Calcium) doCreateWorkloads(ctx context.Context, opts *types.DeployOptio
 			cancel()
 		}()
 
-		txnErr := utils.Txn(
+		settled, _ := utils.Txn(
 			ctx,
 
 			func(ctx context.Context) (err error) {
@@ -140,13 +139,12 @@ func (c *Calcium) doCreateWorkloads(ctx context.Context, opts *types.DeployOptio
 						err = errors.Join(err, e)
 					}
 				}
-				rollbackComplete = err == nil
 				return err
 			},
 
 			c.config.GlobalTimeout,
 		)
-		if resourceCommit != nil && (txnErr == nil || rollbackComplete) {
+		if resourceCommit != nil && settled {
 			resourceCommit()
 		}
 	})
@@ -292,9 +290,8 @@ func (c *Calcium) doDeployOneWorkload(
 	if err != nil {
 		return err
 	}
-	var rollbackComplete bool
 
-	txnErr := utils.Txn(
+	settled, txnErr := utils.Txn(
 		ctx,
 		func(ctx context.Context) error {
 			created, err := node.Engine.VirtualizationCreate(ctx, createOpts)
@@ -375,9 +372,7 @@ func (c *Calcium) doDeployOneWorkload(
 		func(ctx context.Context, _ bool) (rollbackErr error) {
 			logger.Warnf(ctx, "failed to deploy workload %s, rollback", cmp.Or(workload.ID, workload.Name))
 			if workload.ID == "" {
-				rollbackErr = removeWorkloadByName(ctx, node, workload.Name)
-				rollbackComplete = rollbackErr == nil
-				return rollbackErr
+				return removeWorkloadByName(ctx, node, workload.Name)
 			}
 
 			if removeErr := c.store.RemoveWorkload(ctx, workload); removeErr != nil {
@@ -385,13 +380,11 @@ func (c *Calcium) doDeployOneWorkload(
 				rollbackErr = errors.Join(rollbackErr, removeErr)
 			}
 
-			rollbackErr = errors.Join(rollbackErr, workload.Remove(ctx, true))
-			rollbackComplete = rollbackErr == nil
-			return rollbackErr
+			return errors.Join(rollbackErr, workload.Remove(ctx, true))
 		},
 		c.config.GlobalTimeout,
 	)
-	if txnErr == nil || rollbackComplete {
+	if settled {
 		commit()
 	}
 	return txnErr

--- a/cluster/calcium/create.go
+++ b/cluster/calcium/create.go
@@ -48,36 +48,29 @@ func (c *Calcium) doCreateWorkloads(ctx context.Context, opts *types.DeployOptio
 		rollbackMap          map[string][]int
 		engineParamsMap      = map[string][]resourcetypes.Resources{}
 		workloadResourcesMap = map[string][]resourcetypes.Resources{}
+		rollbackComplete     bool
 	)
 
 	_ = c.pool.Invoke(func() {
+		var resourceCommit func()
+		var processingCommits map[string]func()
 		defer func() {
 			cctx, cancel := context.WithTimeout(utils.NewInheritCtx(ctx), c.config.GlobalTimeout)
 			for nodename := range deployMap {
 				processing := opts.GetProcessing(nodename)
 				if err := c.store.DeleteProcessing(cctx, processing); err != nil {
 					logger.Errorf(ctx, err, "delete processing failed for %s", nodename)
+					continue
+				}
+				if commit := processingCommits[nodename]; commit != nil {
+					commit()
 				}
 			}
 			close(ch)
 			cancel()
 		}()
 
-		var resourceCommit func()
-		defer func() {
-			if resourceCommit != nil {
-				resourceCommit()
-			}
-		}()
-
-		var processingCommits map[string]func()
-		defer func() {
-			for _, commit := range processingCommits {
-				commit()
-			}
-		}()
-
-		_ = utils.Txn(
+		txnErr := utils.Txn(
 			ctx,
 
 			func(ctx context.Context) (err error) {
@@ -105,9 +98,12 @@ func (c *Calcium) doCreateWorkloads(ctx context.Context, opts *types.DeployOptio
 
 					processingCommits = make(map[string]func())
 					for nodename, deploy := range deployMap {
-						if workloadResourcesMap[nodename], engineParamsMap[nodename], err = c.rmgr.Alloc(ctx, nodename, deploy, opts.Resources); err != nil {
-							return err
+						workloadResources, engineParams, allocErr := c.rmgr.Alloc(ctx, nodename, deploy, opts.Resources)
+						if allocErr != nil {
+							return allocErr
 						}
+						workloadResourcesMap[nodename] = workloadResources
+						engineParamsMap[nodename] = engineParams
 						processing := opts.GetProcessing(nodename)
 						if processingCommits[nodename], err = c.journal(ctx, logger, eventProcessingCreated, processing); err != nil {
 							return err
@@ -126,25 +122,33 @@ func (c *Calcium) doCreateWorkloads(ctx context.Context, opts *types.DeployOptio
 			},
 
 			func(ctx context.Context, failedOnCond bool) (err error) {
+				resourcesToRollback := map[string][]resourcetypes.Resources{}
 				if failedOnCond {
-					return err
-				}
-				for nodename, rollbackIndices := range rollbackMap {
-					if e := c.withNodePodLocked(ctx, nodename, func(ctx context.Context, _ *types.Node) error {
-						rollbackResources := utils.Map(rollbackIndices, func(idx int) resourcetypes.Resources {
+					resourcesToRollback = workloadResourcesMap
+				} else {
+					for nodename, rollbackIndices := range rollbackMap {
+						resourcesToRollback[nodename] = utils.Map(rollbackIndices, func(idx int) resourcetypes.Resources {
 							return workloadResourcesMap[nodename][idx]
 						})
+					}
+				}
+				for nodename, rollbackResources := range resourcesToRollback {
+					if e := c.withNodePodLocked(ctx, nodename, func(ctx context.Context, _ *types.Node) error {
 						return c.rmgr.RollbackAlloc(ctx, nodename, rollbackResources)
 					}); e != nil {
 						logger.Error(ctx, e)
-						err = e
+						err = errors.Join(err, e)
 					}
 				}
+				rollbackComplete = err == nil
 				return err
 			},
 
 			c.config.GlobalTimeout,
 		)
+		if resourceCommit != nil && (txnErr == nil || rollbackComplete) {
+			resourceCommit()
+		}
 	})
 
 	return ch
@@ -288,9 +292,9 @@ func (c *Calcium) doDeployOneWorkload(
 	if err != nil {
 		return err
 	}
-	defer commit()
+	var rollbackComplete bool
 
-	return utils.Txn(
+	txnErr := utils.Txn(
 		ctx,
 		func(ctx context.Context) error {
 			created, err := node.Engine.VirtualizationCreate(ctx, createOpts)
@@ -368,20 +372,29 @@ func (c *Calcium) doDeployOneWorkload(
 			return nil
 		},
 
-		func(ctx context.Context, _ bool) error {
+		func(ctx context.Context, _ bool) (rollbackErr error) {
 			logger.Warnf(ctx, "failed to deploy workload %s, rollback", cmp.Or(workload.ID, workload.Name))
 			if workload.ID == "" {
-				return removeWorkloadByName(ctx, node, workload.Name)
+				rollbackErr = removeWorkloadByName(ctx, node, workload.Name)
+				rollbackComplete = rollbackErr == nil
+				return rollbackErr
 			}
 
-			if err := c.store.RemoveWorkload(ctx, workload); err != nil {
-				logger.Errorf(ctx, err, "failed to remove workload %s", workload.ID)
+			if removeErr := c.store.RemoveWorkload(ctx, workload); removeErr != nil {
+				logger.Errorf(ctx, removeErr, "failed to remove workload %s", workload.ID)
+				rollbackErr = errors.Join(rollbackErr, removeErr)
 			}
 
-			return workload.Remove(ctx, true)
+			rollbackErr = errors.Join(rollbackErr, workload.Remove(ctx, true))
+			rollbackComplete = rollbackErr == nil
+			return rollbackErr
 		},
 		c.config.GlobalTimeout,
 	)
+	if txnErr == nil || rollbackComplete {
+		commit()
+	}
+	return txnErr
 }
 
 func (c *Calcium) doMakeWorkloadOptions(ctx context.Context, no int, msg *types.CreateWorkloadMessage, opts *types.DeployOptions, node *types.Node) *enginetypes.VirtualizationCreateOptions {

--- a/cluster/calcium/create_test.go
+++ b/cluster/calcium/create_test.go
@@ -246,6 +246,78 @@ func TestCreateWorkloadTxn(t *testing.T) {
 	engine.AssertExpectations(t)
 }
 
+func TestCreateWorkloadRollsBackAllocatedResourcesAfterProcessingFailure(t *testing.T) {
+	for _, tc := range []struct {
+		name                string
+		rollbackErr         error
+		deleteProcessingErr error
+		resourceCommitted   bool
+		processingCommitted bool
+	}{
+		{name: "rollback succeeds", resourceCommitted: true, processingCommitted: true},
+		{name: "rollback fails", rollbackErr: types.ErrMockError, processingCommitted: true},
+		{name: "processing cleanup fails", deleteProcessingErr: types.ErrMockError, resourceCommitted: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c, nodes := newCreateWorkloadCluster(t, types.ErrMockError, tc.deleteProcessingErr)
+			ctx := context.Background()
+			opts := &types.DeployOptions{
+				Name:           "zc:name",
+				Count:          1,
+				DeployStrategy: strategy.Auto,
+				Podname:        "p1",
+				Resources:      resourcetypes.Resources{},
+				Image:          "zc:test",
+				Entrypoint:     &types.Entrypoint{Name: "good-entrypoint"},
+				NodeFilter:     &types.NodeFilter{},
+			}
+
+			store := c.store.(*storemocks.Store)
+			rmgr := c.rmgr.(*resourcemocks.Manager)
+			mwal := &walmocks.WAL{}
+			c.wal = mwal
+			var resourceCommitted atomic.Bool
+			var processingCommitted atomic.Bool
+			mwal.On("Log", eventWorkloadResourceAllocated, mock.Anything).Return(wal.Commit(func() error {
+				resourceCommitted.Store(true)
+				return nil
+			}), nil).Once()
+			mwal.On("Log", eventProcessingCreated, mock.Anything).Return(wal.Commit(func() error {
+				processingCommitted.Store(true)
+				return nil
+			}), nil).Once()
+
+			node := nodes[0]
+			rmgr.On("GetNodesDeployCapacity", mock.Anything, mock.Anything, mock.Anything).Return(
+				map[string]*plugintypes.NodeDeployCapacity{
+					node.Name: {Capacity: 1, Weight: 1},
+				},
+				1,
+				nil,
+			).Once()
+			store.On("GetDeployStatus", mock.Anything, mock.Anything, mock.Anything).Return(map[string]int{}, nil).Once()
+			rmgr.On("Alloc", mock.Anything, node.Name, 1, mock.Anything).Return(
+				[]resourcetypes.Resources{{}},
+				[]resourcetypes.Resources{{}},
+				nil,
+			).Once()
+			rmgr.On("RollbackAlloc", mock.Anything, node.Name, []resourcetypes.Resources{{}}).Return(tc.rollbackErr).Once()
+
+			ch, err := c.CreateWorkload(ctx, opts)
+			require.NoError(t, err)
+			messages := []*types.CreateWorkloadMessage{}
+			for message := range ch {
+				messages = append(messages, message)
+			}
+			require.Len(t, messages, 1)
+			assert.ErrorIs(t, messages[0].Error, types.ErrMockError)
+			assert.Equal(t, tc.resourceCommitted, resourceCommitted.Load())
+			assert.Equal(t, tc.processingCommitted, processingCommitted.Load())
+			mwal.AssertExpectations(t)
+		})
+	}
+}
+
 func TestCreateWorkloadIngorePullTxn(t *testing.T) {
 	c, nodes := newCreateWorkloadCluster(t)
 	ctx := context.Background()
@@ -502,6 +574,35 @@ func TestDoDeployOneWorkloadRollbackRemovesTheContainerTheEngineKept(t *testing.
 	engine.AssertExpectations(t)
 }
 
+func TestDoDeployOneWorkloadKeepsJournalWhenRollbackFails(t *testing.T) {
+	c := NewTestCluster()
+	ctx := context.Background()
+	var committed atomic.Bool
+	mwal := &walmocks.WAL{}
+	mwal.On("Log", eventWorkloadCreated, mock.Anything).Return(wal.Commit(func() error {
+		committed.Store(true)
+		return nil
+	}), nil).Once()
+	c.wal = mwal
+
+	store := c.store.(*storemocks.Store)
+	store.On("AddWorkload", mock.Anything, mock.Anything, mock.Anything).Return(types.ErrMockError).Once()
+	store.On("RemoveWorkload", mock.Anything, mock.Anything).Return(nil).Once()
+	engine := &enginemocks.API{}
+	engine.On("VirtualizationCreate", mock.Anything, mock.Anything).Return(&enginetypes.VirtualizationCreated{ID: "wrkid"}, nil).Once()
+	engine.On("VirtualizationRemove", mock.Anything, "wrkid", true, true).Return(types.ErrMockError).Once()
+	node := &types.Node{NodeMeta: types.NodeMeta{Name: "n1"}, Engine: engine}
+
+	opts := &types.DeployOptions{Name: "app", Podname: "pod", Entrypoint: &types.Entrypoint{Name: "entry"}}
+	createOpts := &enginetypes.VirtualizationCreateOptions{Name: "app_entry_abcdef"}
+
+	assert.Error(t, c.doDeployOneWorkload(ctx, node, opts, &types.CreateWorkloadMessage{}, createOpts, false))
+	assert.False(t, committed.Load())
+	mwal.AssertExpectations(t)
+	store.AssertExpectations(t)
+	engine.AssertExpectations(t)
+}
+
 func TestDoMakeWorkloadOptionsEnvIsolation(t *testing.T) {
 	c := NewTestCluster()
 	ctx := context.Background()
@@ -532,7 +633,7 @@ func TestDoMakeWorkloadOptionsEnvIsolation(t *testing.T) {
 	assert.Equal(t, []string{"A=1", "B=2"}, opts.Env)
 }
 
-func newCreateWorkloadCluster(_ *testing.T) (*Calcium, []*types.Node) {
+func newCreateWorkloadCluster(_ *testing.T, processingErrors ...error) (*Calcium, []*types.Node) {
 	c := NewTestCluster()
 
 	engine := &enginemocks.API{}
@@ -551,8 +652,16 @@ func newCreateWorkloadCluster(_ *testing.T) (*Calcium, []*types.Node) {
 	nodes := []*types.Node{node1, node2}
 
 	store := c.store.(*storemocks.Store)
-	store.On("CreateProcessing", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-	store.On("DeleteProcessing", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	var processingErr error
+	if len(processingErrors) > 0 {
+		processingErr = processingErrors[0]
+	}
+	store.On("CreateProcessing", mock.Anything, mock.Anything, mock.Anything).Return(processingErr)
+	var deleteProcessingErr error
+	if len(processingErrors) > 1 {
+		deleteProcessingErr = processingErrors[1]
+	}
+	store.On("DeleteProcessing", mock.Anything, mock.Anything, mock.Anything).Return(deleteProcessingErr)
 
 	lock := &lockmocks.DistributedLock{}
 	lock.On("Lock", mock.Anything).Return(context.Background(), nil)

--- a/cluster/calcium/node.go
+++ b/cluster/calcium/node.go
@@ -36,7 +36,7 @@ func (c *Calcium) AddNode(ctx context.Context, opts *types.AddNodeOptions) (*typ
 		return nil, err
 	}
 
-	return node, utils.Txn(
+	_, txnErr := utils.Txn(
 		ctx,
 		func(ctx context.Context) error {
 			res, err = c.rmgr.AddNode(ctx, opts.Nodename, opts.Resources, nodeInfo)
@@ -71,6 +71,7 @@ func (c *Calcium) AddNode(ctx context.Context, opts *types.AddNodeOptions) (*typ
 		},
 		c.config.GlobalTimeout,
 	)
+	return node, txnErr
 }
 
 func (c *Calcium) RemoveNode(ctx context.Context, nodename string) error {
@@ -90,7 +91,7 @@ func (c *Calcium) RemoveNode(ctx context.Context, nodename string) error {
 			return types.ErrNodeNotEmpty
 		}
 
-		return utils.Txn(ctx,
+		_, txnErr := utils.Txn(ctx,
 			func(ctx context.Context) error {
 				// a down node has no status key, so peers miss the removal unless one is written first
 				if err = c.store.SetNodeStatus(ctx, node, 90); err != nil {
@@ -115,6 +116,7 @@ func (c *Calcium) RemoveNode(ctx context.Context, nodename string) error {
 				return nil
 			},
 			c.config.GlobalTimeout)
+		return txnErr
 	})
 }
 
@@ -209,7 +211,7 @@ func (c *Calcium) SetNode(ctx context.Context, opts *types.SetNodeOptions) (*typ
 		}
 
 		var origin resourcetypes.Resources
-		return utils.Txn(ctx,
+		_, txnErr := utils.Txn(ctx,
 			func(ctx context.Context) error {
 				if len(opts.Resources) == 0 {
 					return nil
@@ -239,6 +241,7 @@ func (c *Calcium) SetNode(ctx context.Context, opts *types.SetNodeOptions) (*typ
 				return err
 			},
 			c.config.GlobalTimeout)
+		return txnErr
 	})
 }
 

--- a/cluster/calcium/realloc.go
+++ b/cluster/calcium/realloc.go
@@ -34,7 +34,6 @@ func (c *Calcium) doReallocOnNode(ctx context.Context, node *types.Node, workloa
 	var engineParams resourcetypes.Resources
 	var err error
 	var reallocated bool
-	var rollbackComplete bool
 
 	logger := log.WithFunc("calcium.doReallocOnNode").WithField("opts", opts)
 	nodeCommit, err := c.journal(ctx, logger, eventWorkloadResourceAllocated, []*types.Node{node})
@@ -47,7 +46,7 @@ func (c *Calcium) doReallocOnNode(ctx context.Context, node *types.Node, workloa
 		return err
 	}
 
-	err = utils.Txn(
+	settled, err := utils.Txn(
 		ctx,
 		func(ctx context.Context) error {
 			// Realloc mutates node resource meta in the resource plugin
@@ -66,7 +65,6 @@ func (c *Calcium) doReallocOnNode(ctx context.Context, node *types.Node, workloa
 		},
 		func(ctx context.Context, _ bool) error {
 			if !reallocated {
-				rollbackComplete = true
 				return nil
 			}
 			var rollbackErr error
@@ -74,13 +72,11 @@ func (c *Calcium) doReallocOnNode(ctx context.Context, node *types.Node, workloa
 				rollbackErr = errors.Join(rollbackErr, resourceErr)
 				logger.Errorf(ctx, rollbackErr, "failed to rollback workload %+v, resource args %+v, engine args %+v", workload.ID, litter.Sdump(resources), litter.Sdump(engineParams))
 			}
-			rollbackErr = errors.Join(rollbackErr, c.store.UpdateWorkload(ctx, &originWorkload))
-			rollbackComplete = rollbackErr == nil
-			return rollbackErr
+			return errors.Join(rollbackErr, c.store.UpdateWorkload(ctx, &originWorkload))
 		},
 		c.config.GlobalTimeout,
 	)
-	if err == nil || rollbackComplete {
+	if settled {
 		nodeCommit()
 		workloadCommit()
 	}

--- a/cluster/calcium/realloc.go
+++ b/cluster/calcium/realloc.go
@@ -3,6 +3,7 @@ package calcium
 import (
 	"context"
 
+	"github.com/cockroachdb/errors"
 	"github.com/sanity-io/litter"
 
 	"github.com/projecteru2/core/log"
@@ -32,18 +33,19 @@ func (c *Calcium) doReallocOnNode(ctx context.Context, node *types.Node, workloa
 	var deltaResources resourcetypes.Resources
 	var engineParams resourcetypes.Resources
 	var err error
+	var reallocated bool
+	var rollbackComplete bool
 
 	logger := log.WithFunc("calcium.doReallocOnNode").WithField("opts", opts)
 	nodeCommit, err := c.journal(ctx, logger, eventWorkloadResourceAllocated, []*types.Node{node})
 	if err != nil {
 		return err
 	}
-	defer nodeCommit()
 	workloadCommit, err := c.journal(ctx, logger, eventWorkloadReallocated, workload.ID)
 	if err != nil {
+		nodeCommit()
 		return err
 	}
-	defer workloadCommit()
 
 	err = utils.Txn(
 		ctx,
@@ -53,6 +55,7 @@ func (c *Calcium) doReallocOnNode(ctx context.Context, node *types.Node, workloa
 			if err != nil {
 				return err
 			}
+			reallocated = true
 			logger.Debugf(ctx, "realloc workload %+v, resource args %+v, engine args %+v", workload.ID, litter.Sdump(resources), litter.Sdump(engineParams))
 			workload.EngineParams = engineParams
 			workload.Resources = resources
@@ -61,18 +64,26 @@ func (c *Calcium) doReallocOnNode(ctx context.Context, node *types.Node, workloa
 		func(ctx context.Context) error {
 			return node.Engine.VirtualizationUpdateResource(ctx, opts.ID, engineParams)
 		},
-		func(ctx context.Context, failureByCond bool) error {
-			if failureByCond {
+		func(ctx context.Context, _ bool) error {
+			if !reallocated {
+				rollbackComplete = true
 				return nil
 			}
-			if rollbackErr := c.rmgr.RollbackRealloc(ctx, workload.Nodename, deltaResources); rollbackErr != nil {
+			var rollbackErr error
+			if resourceErr := c.rmgr.RollbackRealloc(ctx, workload.Nodename, deltaResources); resourceErr != nil {
+				rollbackErr = errors.Join(rollbackErr, resourceErr)
 				logger.Errorf(ctx, rollbackErr, "failed to rollback workload %+v, resource args %+v, engine args %+v", workload.ID, litter.Sdump(resources), litter.Sdump(engineParams))
-				// don't return here, so the node resource can still be fixed
 			}
-			return c.store.UpdateWorkload(ctx, &originWorkload)
+			rollbackErr = errors.Join(rollbackErr, c.store.UpdateWorkload(ctx, &originWorkload))
+			rollbackComplete = rollbackErr == nil
+			return rollbackErr
 		},
 		c.config.GlobalTimeout,
 	)
+	if err == nil || rollbackComplete {
+		nodeCommit()
+		workloadCommit()
+	}
 	if err != nil {
 		return err
 	}

--- a/cluster/calcium/realloc_test.go
+++ b/cluster/calcium/realloc_test.go
@@ -89,6 +89,7 @@ func TestRealloc(t *testing.T) {
 	rmgr.On("RollbackRealloc", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	store.On("UpdateWorkload", mock.Anything, mock.Anything).Return(types.ErrMockError).Once()
+	store.On("UpdateWorkload", mock.Anything, mock.Anything).Return(nil).Once()
 	err = c.ReallocResource(ctx, opts)
 	assert.True(t, errors.Is(err, types.ErrMockError))
 	store.AssertExpectations(t)
@@ -138,4 +139,45 @@ func TestReallocJournalsRepairEntries(t *testing.T) {
 	assert.NoError(t, c.doReallocOnNode(ctx, node, workload, *workload, opts))
 	assert.Equal(t, []string{eventWorkloadResourceAllocated, eventWorkloadReallocated}, logged)
 	assert.Equal(t, 2, committed)
+}
+
+func TestReallocKeepsRepairEntriesUntilRollbackCompletes(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		rollback  error
+		committed int
+	}{
+		{name: "rollback succeeds", committed: 2},
+		{name: "rollback fails", rollback: types.ErrMockError},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := NewTestCluster()
+			ctx := context.Background()
+
+			committed := 0
+			mwal := &walmocks.WAL{}
+			mwal.On("Log", mock.Anything, mock.Anything).Return(func(_ string, _ any) (wal.Commit, error) {
+				return func() error { committed++; return nil }, nil
+			})
+			c.wal = mwal
+
+			engine := &enginemocks.API{}
+			node := &types.Node{NodeMeta: types.NodeMeta{Name: "node1"}, Engine: engine}
+			workload := &types.Workload{ID: "c1", Nodename: node.Name, Engine: engine, Resources: resourcetypes.Resources{}}
+
+			store := c.store.(*storemocks.Store)
+			store.On("UpdateWorkload", mock.Anything, workload).Return(types.ErrMockError).Once()
+			store.On("UpdateWorkload", mock.Anything, mock.Anything).Return(nil).Once()
+			rmgr := c.rmgr.(*resourcemocks.Manager)
+			rmgr.On("Realloc", mock.Anything, node.Name, mock.Anything, mock.Anything).Return(
+				resourcetypes.Resources{}, resourcetypes.Resources{}, resourcetypes.Resources{}, nil,
+			).Once()
+			rmgr.On("RollbackRealloc", mock.Anything, node.Name, mock.Anything).Return(tc.rollback).Once()
+
+			opts := &types.ReallocOptions{ID: workload.ID, Resources: resourcetypes.Resources{}}
+			assert.ErrorIs(t, c.doReallocOnNode(ctx, node, workload, *workload, opts), types.ErrMockError)
+			assert.Equal(t, tc.committed, committed)
+			mwal.AssertExpectations(t)
+		})
+	}
 }

--- a/cluster/calcium/remap.go
+++ b/cluster/calcium/remap.go
@@ -63,7 +63,7 @@ func (c *Calcium) computeRemap(ctx context.Context, node *types.Node) (map[strin
 }
 
 func (c *Calcium) applyRemap(ctx context.Context, logger *log.Fields, workloads []*types.Workload, engineParamsMap map[string]resourcetypes.Resources) error {
-	errList := make([]error, 0, len(engineParamsMap))
+	var errList []error
 	for _, workload := range workloads {
 		engineParams, ok := engineParamsMap[workload.ID]
 		if !ok {

--- a/cluster/calcium/remap.go
+++ b/cluster/calcium/remap.go
@@ -35,14 +35,43 @@ func (c *Calcium) doRemapResource(ctx context.Context, logger *log.Fields, node 
 		return err
 	}
 
+	errList := make([]error, 0, len(engineParamsMap))
 	for workloadID, engineParams := range engineParamsMap {
-		logger.Infof(ctx, "remap workload ID %+v", workloadID)
-		switch updateErr := node.Engine.VirtualizationUpdateResource(ctx, workloadID, engineParams); {
-		case errors.Is(updateErr, types.ErrWorkloadNotExists):
-			logger.Warnf(ctx, "skip remap of workload %s: %+v", workloadID, updateErr)
-		case updateErr != nil:
-			logger.Error(ctx, updateErr)
+		remap := &workloadRemap{ID: workloadID, EngineParams: engineParams}
+		commit, journalErr := c.journal(ctx, logger, eventWorkloadRemapped, remap)
+		if journalErr != nil {
+			errList = append(errList, journalErr)
+			continue
 		}
+		if remapErr := c.applyWorkloadRemap(ctx, logger, remap); remapErr != nil {
+			errList = append(errList, remapErr)
+			continue
+		}
+		commit()
+	}
+	return errors.Join(errList...)
+}
+
+func (c *Calcium) applyWorkloadRemap(ctx context.Context, logger *log.Fields, remap *workloadRemap) error {
+	workload, err := getWorkloadIfExists(ctx, c, remap.ID)
+	if err != nil || workload == nil {
+		return err
+	}
+
+	updatedWorkload := *workload
+	updatedWorkload.EngineParams = remap.EngineParams
+	if err = c.store.UpdateWorkload(ctx, &updatedWorkload); err != nil {
+		return err
+	}
+
+	logger.Infof(ctx, "remap workload ID %+v", remap.ID)
+	switch err = workload.Engine.VirtualizationUpdateResource(ctx, remap.ID, remap.EngineParams); {
+	case errors.Is(err, types.ErrWorkloadNotExists), errors.Is(err, types.ErrEngineNotImplemented):
+		logger.Warnf(ctx, "skip remap of workload %s: %+v", remap.ID, err)
+		return nil
+	case err != nil:
+		logger.Error(ctx, err)
+		return err
 	}
 	return nil
 }

--- a/cluster/calcium/remap.go
+++ b/cluster/calcium/remap.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cockroachdb/errors"
 
 	"github.com/projecteru2/core/log"
+	resourcetypes "github.com/projecteru2/core/resource/types"
 	"github.com/projecteru2/core/types"
 	"github.com/projecteru2/core/utils"
 )
@@ -25,53 +26,57 @@ func (c *Calcium) RemapResourceAndLog(ctx context.Context, logger *log.Fields, n
 
 // the caller must hold the node lock
 func (c *Calcium) doRemapResource(ctx context.Context, logger *log.Fields, node *types.Node) error {
-	workloads, err := c.store.ListNodeWorkloads(ctx, node.Name, nil)
-	if err != nil {
+	engineParamsMap, workloads, err := c.computeRemap(ctx, node)
+	if err != nil || len(engineParamsMap) == 0 {
 		return err
 	}
 
-	engineParamsMap, err := c.rmgr.Remap(ctx, node.Name, workloads)
+	commit, err := c.journal(ctx, logger, eventNodeRemapped, node.Name)
 	if err != nil {
 		return err
 	}
-
-	errList := make([]error, 0, len(engineParamsMap))
-	for workloadID, engineParams := range engineParamsMap {
-		remap := &workloadRemap{ID: workloadID, EngineParams: engineParams}
-		commit, journalErr := c.journal(ctx, logger, eventWorkloadRemapped, remap)
-		if journalErr != nil {
-			errList = append(errList, journalErr)
-			continue
-		}
-		if remapErr := c.applyWorkloadRemap(ctx, logger, remap); remapErr != nil {
-			errList = append(errList, remapErr)
-			continue
-		}
-		commit()
+	if err = c.applyRemap(ctx, logger, workloads, engineParamsMap); err != nil {
+		return err
 	}
-	return errors.Join(errList...)
+	commit()
+	return nil
 }
 
-func (c *Calcium) applyWorkloadRemap(ctx context.Context, logger *log.Fields, remap *workloadRemap) error {
-	workload, err := getWorkloadIfExists(ctx, c, remap.ID)
-	if err != nil || workload == nil {
+func (c *Calcium) remapNodeWorkloads(ctx context.Context, logger *log.Fields, node *types.Node) error {
+	engineParamsMap, workloads, err := c.computeRemap(ctx, node)
+	if err != nil {
 		return err
 	}
+	return c.applyRemap(ctx, logger, workloads, engineParamsMap)
+}
 
-	updatedWorkload := *workload
-	updatedWorkload.EngineParams = remap.EngineParams
-	if err = c.store.UpdateWorkload(ctx, &updatedWorkload); err != nil {
-		return err
+func (c *Calcium) computeRemap(ctx context.Context, node *types.Node) (map[string]resourcetypes.Resources, []*types.Workload, error) {
+	workloads, err := c.store.ListNodeWorkloads(ctx, node.Name, nil)
+	if err != nil {
+		return nil, nil, err
 	}
+	engineParamsMap, err := c.rmgr.Remap(ctx, node.Name, workloads)
+	if err != nil {
+		return nil, nil, err
+	}
+	return engineParamsMap, workloads, nil
+}
 
-	logger.Infof(ctx, "remap workload ID %+v", remap.ID)
-	switch err = workload.Engine.VirtualizationUpdateResource(ctx, remap.ID, remap.EngineParams); {
-	case errors.Is(err, types.ErrWorkloadNotExists), errors.Is(err, types.ErrEngineNotImplemented):
-		logger.Warnf(ctx, "skip remap of workload %s: %+v", remap.ID, err)
-		return nil
-	case err != nil:
-		logger.Error(ctx, err)
-		return err
+func (c *Calcium) applyRemap(ctx context.Context, logger *log.Fields, workloads []*types.Workload, engineParamsMap map[string]resourcetypes.Resources) error {
+	errList := make([]error, 0, len(engineParamsMap))
+	for _, workload := range workloads {
+		engineParams, ok := engineParamsMap[workload.ID]
+		if !ok {
+			continue
+		}
+		logger.Infof(ctx, "remap workload ID %+v", workload.ID)
+		switch err := workload.Engine.VirtualizationUpdateResource(ctx, workload.ID, engineParams); {
+		case errors.Is(err, types.ErrWorkloadNotExists), errors.Is(err, types.ErrEngineNotImplemented):
+			logger.Warnf(ctx, "skip remap of workload %s: %+v", workload.ID, err)
+		case err != nil:
+			logger.Error(ctx, err)
+			errList = append(errList, err)
+		}
 	}
-	return nil
+	return errors.Join(errList...)
 }

--- a/cluster/calcium/remap_test.go
+++ b/cluster/calcium/remap_test.go
@@ -2,10 +2,12 @@ package calcium
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	enginemocks "github.com/projecteru2/core/engine/mocks"
 	lockmocks "github.com/projecteru2/core/lock/mocks"
@@ -14,6 +16,8 @@ import (
 	resourcetypes "github.com/projecteru2/core/resource/types"
 	storemocks "github.com/projecteru2/core/store/mocks"
 	"github.com/projecteru2/core/types"
+	"github.com/projecteru2/core/wal"
+	walmocks "github.com/projecteru2/core/wal/mocks"
 )
 
 func TestRemapResource(t *testing.T) {
@@ -45,4 +49,87 @@ func TestRemapResource(t *testing.T) {
 	lock.On("Unlock", mock.Anything).Return(nil)
 	store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
 	c.RemapResourceAndLog(context.Background(), log.WithField("test", "zc"), node)
+}
+
+func TestRemapResourcePersistsDesiredParamsBeforeEngineUpdate(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		storeErr  error
+		engineErr error
+		committed bool
+	}{
+		{name: "success", committed: true},
+		{name: "store failure", storeErr: types.ErrMockError},
+		{name: "engine failure", engineErr: types.ErrMockError},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := NewTestCluster()
+			ctx := context.Background()
+			params := resourcetypes.Resources{"cpumem": {"cpu": 2}}
+
+			engine := &enginemocks.API{}
+			node := &types.Node{NodeMeta: types.NodeMeta{Name: "node1"}, Engine: engine}
+			workload := &types.Workload{ID: "workload1", Nodename: node.Name, Engine: engine}
+			store := c.store.(*storemocks.Store)
+			store.On("ListNodeWorkloads", mock.Anything, node.Name, mock.Anything).Return([]*types.Workload{workload}, nil).Once()
+			store.On("GetWorkload", mock.Anything, workload.ID).Return(workload, nil).Once()
+			var updated *types.Workload
+			store.On("UpdateWorkload", mock.Anything, mock.Anything).
+				Run(func(args mock.Arguments) { updated = args.Get(1).(*types.Workload) }).
+				Return(tc.storeErr).
+				Once()
+
+			rmgr := c.rmgr.(*resourcemocks.Manager)
+			rmgr.On("Remap", mock.Anything, node.Name, mock.Anything).Return(
+				map[string]resourcetypes.Resources{workload.ID: params}, nil,
+			).Once()
+			if tc.storeErr == nil {
+				engine.On("VirtualizationUpdateResource", mock.Anything, workload.ID, params).Return(tc.engineErr).Once()
+			}
+
+			var committed atomic.Bool
+			mwal := &walmocks.WAL{}
+			mwal.On("Log", eventWorkloadRemapped, &workloadRemap{ID: workload.ID, EngineParams: params}).Return(wal.Commit(func() error {
+				committed.Store(true)
+				return nil
+			}), nil).Once()
+			c.wal = mwal
+
+			err := c.doRemapResource(ctx, log.WithField("test", tc.name), node)
+			if tc.storeErr == nil && tc.engineErr == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorIs(t, err, types.ErrMockError)
+			}
+			require.NotNil(t, updated)
+			assert.Equal(t, params, updated.EngineParams)
+			assert.Equal(t, tc.committed, committed.Load())
+			mwal.AssertExpectations(t)
+		})
+	}
+}
+
+func TestRemapWorkloadJournalRetriesEngineFailure(t *testing.T) {
+	c := NewTestCluster()
+	enableTestWAL(t, c)
+	ctx := context.Background()
+	params := resourcetypes.Resources{"cpumem": {"cpu": 2}}
+	engine := &enginemocks.API{}
+	workload := &types.Workload{ID: "workload1", Engine: engine}
+
+	store := c.store.(*storemocks.Store)
+	store.On("GetWorkload", mock.Anything, workload.ID).Return(workload, nil).Twice()
+	store.On("UpdateWorkload", mock.Anything, mock.Anything).Return(nil).Twice()
+	remappedParams := mock.MatchedBy(func(params resourcetypes.Resources) bool {
+		return params["cpumem"].Int("cpu") == 2
+	})
+	engine.On("VirtualizationUpdateResource", mock.Anything, workload.ID, remappedParams).Return(types.ErrMockError).Once()
+	engine.On("VirtualizationUpdateResource", mock.Anything, workload.ID, remappedParams).Return(nil).Once()
+
+	_, err := c.wal.Log(eventWorkloadRemapped, &workloadRemap{ID: workload.ID, EngineParams: params})
+	require.NoError(t, err)
+	c.wal.Recover(ctx)
+	c.wal.Recover(ctx)
+	store.AssertExpectations(t)
+	engine.AssertExpectations(t)
 }

--- a/cluster/calcium/remap_test.go
+++ b/cluster/calcium/remap_test.go
@@ -62,7 +62,7 @@ func TestRemapJournalRetainsUntilEngineSuccess(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			c := NewTestCluster()
-			ctx := context.Background()
+			ctx := t.Context()
 			params := resourcetypes.Resources{"cpumem": {"cpu": 2}}
 
 			engine := &enginemocks.API{}
@@ -102,7 +102,7 @@ func TestRemapJournalRetainsUntilEngineSuccess(t *testing.T) {
 func TestRemapReplayRecomputesFromLiveState(t *testing.T) {
 	c := NewTestCluster()
 	enableTestWAL(t, c)
-	ctx := context.Background()
+	ctx := t.Context()
 	staleParams := resourcetypes.Resources{"cpumem": {"cpu": 1}}
 	freshParams := resourcetypes.Resources{"cpumem": {"cpu": 2}}
 	engine := &enginemocks.API{}

--- a/cluster/calcium/remap_test.go
+++ b/cluster/calcium/remap_test.go
@@ -51,15 +51,13 @@ func TestRemapResource(t *testing.T) {
 	c.RemapResourceAndLog(context.Background(), log.WithField("test", "zc"), node)
 }
 
-func TestRemapResourcePersistsDesiredParamsBeforeEngineUpdate(t *testing.T) {
+func TestRemapJournalRetainsUntilEngineSuccess(t *testing.T) {
 	for _, tc := range []struct {
 		name      string
-		storeErr  error
 		engineErr error
 		committed bool
 	}{
 		{name: "success", committed: true},
-		{name: "store failure", storeErr: types.ErrMockError},
 		{name: "engine failure", engineErr: types.ErrMockError},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -72,64 +70,70 @@ func TestRemapResourcePersistsDesiredParamsBeforeEngineUpdate(t *testing.T) {
 			workload := &types.Workload{ID: "workload1", Nodename: node.Name, Engine: engine}
 			store := c.store.(*storemocks.Store)
 			store.On("ListNodeWorkloads", mock.Anything, node.Name, mock.Anything).Return([]*types.Workload{workload}, nil).Once()
-			store.On("GetWorkload", mock.Anything, workload.ID).Return(workload, nil).Once()
-			var updated *types.Workload
-			store.On("UpdateWorkload", mock.Anything, mock.Anything).
-				Run(func(args mock.Arguments) { updated = args.Get(1).(*types.Workload) }).
-				Return(tc.storeErr).
-				Once()
 
 			rmgr := c.rmgr.(*resourcemocks.Manager)
 			rmgr.On("Remap", mock.Anything, node.Name, mock.Anything).Return(
 				map[string]resourcetypes.Resources{workload.ID: params}, nil,
 			).Once()
-			if tc.storeErr == nil {
-				engine.On("VirtualizationUpdateResource", mock.Anything, workload.ID, params).Return(tc.engineErr).Once()
-			}
+			engine.On("VirtualizationUpdateResource", mock.Anything, workload.ID, params).Return(tc.engineErr).Once()
 
 			var committed atomic.Bool
 			mwal := &walmocks.WAL{}
-			mwal.On("Log", eventWorkloadRemapped, &workloadRemap{ID: workload.ID, EngineParams: params}).Return(wal.Commit(func() error {
+			mwal.On("Log", eventNodeRemapped, node.Name).Return(wal.Commit(func() error {
 				committed.Store(true)
 				return nil
 			}), nil).Once()
 			c.wal = mwal
 
 			err := c.doRemapResource(ctx, log.WithField("test", tc.name), node)
-			if tc.storeErr == nil && tc.engineErr == nil {
+			if tc.engineErr == nil {
 				assert.NoError(t, err)
 			} else {
 				assert.ErrorIs(t, err, types.ErrMockError)
 			}
-			require.NotNil(t, updated)
-			assert.Equal(t, params, updated.EngineParams)
 			assert.Equal(t, tc.committed, committed.Load())
+			store.AssertExpectations(t)
+			engine.AssertExpectations(t)
 			mwal.AssertExpectations(t)
 		})
 	}
 }
 
-func TestRemapWorkloadJournalRetriesEngineFailure(t *testing.T) {
+func TestRemapReplayRecomputesFromLiveState(t *testing.T) {
 	c := NewTestCluster()
 	enableTestWAL(t, c)
 	ctx := context.Background()
-	params := resourcetypes.Resources{"cpumem": {"cpu": 2}}
+	staleParams := resourcetypes.Resources{"cpumem": {"cpu": 1}}
+	freshParams := resourcetypes.Resources{"cpumem": {"cpu": 2}}
 	engine := &enginemocks.API{}
-	workload := &types.Workload{ID: "workload1", Engine: engine}
+	node := &types.Node{NodeMeta: types.NodeMeta{Name: "node1"}, Engine: engine}
+	workload := &types.Workload{ID: "workload1", Nodename: node.Name, Engine: engine}
 
 	store := c.store.(*storemocks.Store)
-	store.On("GetWorkload", mock.Anything, workload.ID).Return(workload, nil).Twice()
-	store.On("UpdateWorkload", mock.Anything, mock.Anything).Return(nil).Twice()
-	remappedParams := mock.MatchedBy(func(params resourcetypes.Resources) bool {
-		return params["cpumem"].Int("cpu") == 2
-	})
-	engine.On("VirtualizationUpdateResource", mock.Anything, workload.ID, remappedParams).Return(types.ErrMockError).Once()
-	engine.On("VirtualizationUpdateResource", mock.Anything, workload.ID, remappedParams).Return(nil).Once()
+	lock := &lockmocks.DistributedLock{}
+	lock.On("Lock", mock.Anything).Return(context.Background(), nil)
+	lock.On("Unlock", mock.Anything).Return(nil)
+	store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
+	store.On("GetNode", mock.Anything, node.Name).Return(node, nil)
+	store.On("NotFound", mock.Anything).Return(false)
+	store.On("ListNodeWorkloads", mock.Anything, node.Name, mock.Anything).Return([]*types.Workload{workload}, nil).Twice()
 
-	_, err := c.wal.Log(eventWorkloadRemapped, &workloadRemap{ID: workload.ID, EngineParams: params})
+	rmgr := c.rmgr.(*resourcemocks.Manager)
+	rmgr.On("Remap", mock.Anything, node.Name, mock.Anything).Return(
+		map[string]resourcetypes.Resources{workload.ID: staleParams}, nil,
+	).Once()
+	rmgr.On("Remap", mock.Anything, node.Name, mock.Anything).Return(
+		map[string]resourcetypes.Resources{workload.ID: freshParams}, nil,
+	).Once()
+	engine.On("VirtualizationUpdateResource", mock.Anything, workload.ID, staleParams).Return(types.ErrMockError).Once()
+	engine.On("VirtualizationUpdateResource", mock.Anything, workload.ID, freshParams).Return(nil).Once()
+
+	_, err := c.wal.Log(eventNodeRemapped, node.Name)
 	require.NoError(t, err)
 	c.wal.Recover(ctx)
 	c.wal.Recover(ctx)
+	c.wal.Recover(ctx)
 	store.AssertExpectations(t)
+	rmgr.AssertExpectations(t)
 	engine.AssertExpectations(t)
 }

--- a/cluster/calcium/remove.go
+++ b/cluster/calcium/remove.go
@@ -79,7 +79,7 @@ func (c *Calcium) doRemoveOneWorkload(ctx context.Context, node *types.Node, wor
 }
 
 func (c *Calcium) doRemoveWorkload(ctx context.Context, workload *types.Workload, force bool) error {
-	return utils.Txn(
+	_, err := utils.Txn(
 		ctx,
 		func(ctx context.Context) error {
 			return c.store.RemoveWorkload(ctx, workload)
@@ -95,6 +95,7 @@ func (c *Calcium) doRemoveWorkload(ctx context.Context, workload *types.Workload
 		},
 		c.config.GlobalTimeout,
 	)
+	return err
 }
 
 func (c *Calcium) doRemoveWorkloadSync(ctx context.Context, IDs []string) error {

--- a/cluster/calcium/replace.go
+++ b/cluster/calcium/replace.go
@@ -143,11 +143,11 @@ func (c *Calcium) doReplaceWorkload(
 					if err != nil {
 						return err
 					}
-					defer commit()
 					if err = c.doRemoveWorkload(ctx, workload, true); err != nil {
 						logger.Error(ctx, err, "the new started but the old failed to stop")
 						return err
 					}
+					commit()
 					removeMessage.Success = true
 					return nil
 				},

--- a/cluster/calcium/replace.go
+++ b/cluster/calcium/replace.go
@@ -124,14 +124,14 @@ func (c *Calcium) doReplaceWorkload(
 		EngineParams: workload.EngineParams,
 	}
 
-	if err = utils.Txn(
+	if _, err = utils.Txn(
 		ctx,
 		func(ctx context.Context) (err error) {
 			removeMessage.Hook, err = c.doStopWorkload(ctx, workload, opts.IgnoreHook)
 			return err
 		},
 		func(ctx context.Context) error {
-			return utils.Txn(
+			_, txnErr := utils.Txn(
 				ctx,
 				func(ctx context.Context) error {
 					vco := c.doMakeWorkloadOptions(ctx, index, createMessage, &opts.DeployOptions, node)
@@ -154,6 +154,7 @@ func (c *Calcium) doReplaceWorkload(
 				nil,
 				c.config.GlobalTimeout,
 			)
+			return txnErr
 		},
 		func(ctx context.Context, _ bool) (err error) {
 			messages, err := c.doStartWorkload(ctx, workload, opts.IgnoreHook)

--- a/cluster/calcium/replace_test.go
+++ b/cluster/calcium/replace_test.go
@@ -2,6 +2,7 @@ package calcium
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,6 +14,8 @@ import (
 	resourcemocks "github.com/projecteru2/core/resource/mocks"
 	storemocks "github.com/projecteru2/core/store/mocks"
 	"github.com/projecteru2/core/types"
+	"github.com/projecteru2/core/wal"
+	walmocks "github.com/projecteru2/core/wal/mocks"
 )
 
 func TestReplaceWorkload(t *testing.T) {
@@ -177,6 +180,17 @@ func TestReplaceWorkload(t *testing.T) {
 	engine.On("VirtualizationCopyChunkTo", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	engine.On("VirtualizationInspect", mock.Anything, mock.Anything).Return(&enginetypes.VirtualizationInfo{User: "test"}, nil)
 	store.On("AddWorkload", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	var replacementCommitted atomic.Bool
+	mwal := &walmocks.WAL{}
+	mwal.On("Log", mock.Anything, mock.Anything).Return(func(event string, _ any) (wal.Commit, error) {
+		return func() error {
+			if event == eventWorkloadReplaced {
+				replacementCommitted.Store(true)
+			}
+			return nil
+		}, nil
+	})
+	c.wal = mwal
 	store.On("RemoveWorkload", mock.Anything, mock.Anything).Return(types.ErrMockError).Once()
 	ch, err = c.ReplaceWorkload(ctx, opts)
 	assert.NoError(t, err)
@@ -187,6 +201,7 @@ func TestReplaceWorkload(t *testing.T) {
 		assert.False(t, r.Remove.Success)
 		assert.Nil(t, r.Create.Error)
 	}
+	assert.False(t, replacementCommitted.Load())
 	store.AssertExpectations(t)
 	engine.AssertExpectations(t)
 
@@ -201,4 +216,5 @@ func TestReplaceWorkload(t *testing.T) {
 		assert.True(t, r.Remove.Success)
 		assert.Nil(t, r.Create.Error)
 	}
+	assert.True(t, replacementCommitted.Load())
 }

--- a/cluster/calcium/stream.go
+++ b/cluster/calcium/stream.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"math"
 	"slices"
 	"sync"
 
@@ -128,6 +129,7 @@ func (c *Calcium) processVirtualizationOutStream(
 			_ = outStream.Close()
 		}()
 		scanner := bufio.NewScanner(outStream)
+		scanner.Buffer(nil, math.MaxInt)
 		scanner.Split(splitFunc)
 		for scanner.Scan() {
 			bs := slices.Clone(scanner.Bytes())

--- a/cluster/calcium/stream.go
+++ b/cluster/calcium/stream.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"math"
 	"slices"
 	"sync"
 
@@ -129,7 +128,7 @@ func (c *Calcium) processVirtualizationOutStream(
 			_ = outStream.Close()
 		}()
 		scanner := bufio.NewScanner(outStream)
-		scanner.Buffer(nil, math.MaxInt)
+		scanner.Buffer(nil, c.config.GRPCConfig.MaxRecvMsgSize)
 		scanner.Split(splitFunc)
 		for scanner.Scan() {
 			bs := slices.Clone(scanner.Bytes())

--- a/cluster/calcium/stream_test.go
+++ b/cluster/calcium/stream_test.go
@@ -29,3 +29,16 @@ func TestProcessVirtualizationOutStreamCopiesTokens(t *testing.T) {
 		require.Equal(t, fmt.Sprintf("line-%06d\n", i), string(bs))
 	}
 }
+
+func TestProcessVirtualizationOutStreamReadsLongLines(t *testing.T) {
+	c := NewTestCluster()
+	line := bytes.Repeat([]byte("x"), 128*1024)
+	reader := bytes.NewReader(append(line, '\n'))
+
+	got := [][]byte{}
+	for bs := range c.processVirtualizationOutStream(context.Background(), io.NopCloser(reader), bufio.ScanLines, byte('\n')) {
+		got = append(got, bs)
+	}
+
+	require.Equal(t, [][]byte{append(line, '\n')}, got)
+}

--- a/cluster/calcium/stream_test.go
+++ b/cluster/calcium/stream_test.go
@@ -3,7 +3,6 @@ package calcium
 import (
 	"bufio"
 	"bytes"
-	"context"
 	"fmt"
 	"io"
 	"testing"
@@ -20,7 +19,7 @@ func TestProcessVirtualizationOutStreamCopiesTokens(t *testing.T) {
 	}
 
 	got := [][]byte{}
-	for bs := range c.processVirtualizationOutStream(context.Background(), io.NopCloser(&buf), bufio.ScanLines, byte('\n')) {
+	for bs := range c.processVirtualizationOutStream(t.Context(), io.NopCloser(&buf), bufio.ScanLines, byte('\n')) {
 		got = append(got, bs)
 	}
 
@@ -36,7 +35,7 @@ func TestProcessVirtualizationOutStreamReadsLongLines(t *testing.T) {
 	reader := bytes.NewReader(append(line, '\n'))
 
 	got := [][]byte{}
-	for bs := range c.processVirtualizationOutStream(context.Background(), io.NopCloser(reader), bufio.ScanLines, byte('\n')) {
+	for bs := range c.processVirtualizationOutStream(t.Context(), io.NopCloser(reader), bufio.ScanLines, byte('\n')) {
 		got = append(got, bs)
 	}
 
@@ -49,7 +48,7 @@ func TestProcessVirtualizationOutStreamBoundsTokens(t *testing.T) {
 	blob := bytes.Repeat([]byte("x"), 4096)
 
 	got := [][]byte{}
-	for bs := range c.processVirtualizationOutStream(context.Background(), io.NopCloser(bytes.NewReader(blob)), bufio.ScanLines, byte('\n')) {
+	for bs := range c.processVirtualizationOutStream(t.Context(), io.NopCloser(bytes.NewReader(blob)), bufio.ScanLines, byte('\n')) {
 		got = append(got, bs)
 	}
 

--- a/cluster/calcium/stream_test.go
+++ b/cluster/calcium/stream_test.go
@@ -42,3 +42,16 @@ func TestProcessVirtualizationOutStreamReadsLongLines(t *testing.T) {
 
 	require.Equal(t, [][]byte{append(line, '\n')}, got)
 }
+
+func TestProcessVirtualizationOutStreamBoundsTokens(t *testing.T) {
+	c := NewTestCluster()
+	c.config.GRPCConfig.MaxRecvMsgSize = 1024
+	blob := bytes.Repeat([]byte("x"), 4096)
+
+	got := [][]byte{}
+	for bs := range c.processVirtualizationOutStream(context.Background(), io.NopCloser(bytes.NewReader(blob)), bufio.ScanLines, byte('\n')) {
+		got = append(got, bs)
+	}
+
+	require.Empty(t, got)
+}

--- a/cluster/calcium/utils.go
+++ b/cluster/calcium/utils.go
@@ -15,7 +15,7 @@ import (
 )
 
 func (c *Calcium) withResourceReleased(ctx context.Context, node *types.Node, workload *types.Workload, then func(context.Context) error) error {
-	return utils.Txn(
+	_, err := utils.Txn(
 		ctx,
 		func(ctx context.Context) (err error) {
 			_, _, err = c.rmgr.SetNodeResourceUsage(ctx, node.Name, nil, nil, []resourcetypes.Resources{workload.Resources}, true, plugins.Decr)
@@ -31,6 +31,7 @@ func (c *Calcium) withResourceReleased(ctx context.Context, node *types.Node, wo
 		},
 		c.config.GlobalTimeout,
 	)
+	return err
 }
 
 func perNode[T any](c *Calcium, nodes []*types.Node, work func(*types.Node, chan<- T)) chan T {

--- a/cluster/calcium/wal.go
+++ b/cluster/calcium/wal.go
@@ -10,7 +10,6 @@ import (
 	"github.com/cockroachdb/errors"
 
 	"github.com/projecteru2/core/log"
-	resourcetypes "github.com/projecteru2/core/resource/types"
 	"github.com/projecteru2/core/store"
 	"github.com/projecteru2/core/types"
 	"github.com/projecteru2/core/wal"
@@ -21,7 +20,7 @@ const (
 	eventWorkloadCreated           = "create-workload" // created but yet to start
 	eventWorkloadReplaced          = "replace-workload"
 	eventWorkloadReallocated       = "realloc-workload"
-	eventWorkloadRemapped          = "remap-workload"
+	eventNodeRemapped              = "remap-node"
 	eventWorkloadResourceAllocated = "allocate-workload" // resource updated in node meta but yet to create all workloads
 	eventProcessingCreated         = "create-processing" // processing created but yet to delete
 
@@ -178,11 +177,6 @@ type workloadReplacement struct {
 	NewID string `json:"new_id"`
 }
 
-type workloadRemap struct {
-	ID           string                  `json:"id"`
-	EngineParams resourcetypes.Resources `json:"engine_params"`
-}
-
 // ReplaceWorkloadHandler removes the workload an interrupted replace left behind.
 type ReplaceWorkloadHandler struct {
 	walBase[*workloadReplacement]
@@ -262,28 +256,35 @@ func (h *ReallocWorkloadHandler) Handle(ctx context.Context, raw any) error {
 	return nil
 }
 
-type remapWorkloadHandler struct {
-	walBase[*workloadRemap]
+type remapNodeHandler struct {
+	walBase[string]
 
 	calcium *Calcium
 }
 
-func newRemapWorkloadHandler(calcium *Calcium) *remapWorkloadHandler {
-	return &remapWorkloadHandler{calcium: calcium}
+func newRemapNodeHandler(calcium *Calcium) *remapNodeHandler {
+	return &remapNodeHandler{calcium: calcium}
 }
 
-func (h *remapWorkloadHandler) Typ() string {
-	return eventWorkloadRemapped
+func (h *remapNodeHandler) Typ() string {
+	return eventNodeRemapped
 }
 
-func (h *remapWorkloadHandler) Handle(ctx context.Context, raw any) error {
-	remap, _ := raw.(*workloadRemap)
-	logger := log.WithFunc("calcium.RemapWorkloadHandler.Handle").WithField("ID", remap.ID)
+func (h *remapNodeHandler) Handle(ctx context.Context, raw any) error {
+	nodename, _ := raw.(string)
+	logger := log.WithFunc("calcium.remapNodeHandler.Handle").WithField("node", nodename)
 
 	ctx, cancel := getReplayContext(ctx)
 	defer cancel()
 
-	return h.calcium.applyWorkloadRemap(ctx, logger, remap)
+	err := h.calcium.withNodeOperationLocked(ctx, nodename, func(ctx context.Context, node *types.Node) error {
+		return h.calcium.remapNodeWorkloads(ctx, logger, node)
+	})
+	if err != nil && (errors.Is(err, types.ErrNodeNotExists) || h.calcium.store.NotFound(err)) {
+		logger.Info(ctx, "node is gone, nothing to remap")
+		return nil
+	}
+	return err
 }
 
 // WorkloadResourceAllocatedHandler replays a dangling resource allocation by refreshing node resources.
@@ -381,7 +382,7 @@ func enableWAL(ctx context.Context, config types.Config, calcium *Calcium, store
 	hydro.Register(newCreateWorkloadHandler(calcium))
 	hydro.Register(newReplaceWorkloadHandler(calcium))
 	hydro.Register(newReallocWorkloadHandler(calcium))
-	hydro.Register(newRemapWorkloadHandler(calcium))
+	hydro.Register(newRemapNodeHandler(calcium))
 	hydro.Register(newWorkloadResourceAllocatedHandler(calcium))
 	hydro.Register(newProcessingCreatedHandler(store))
 	return hydro, nil

--- a/cluster/calcium/wal.go
+++ b/cluster/calcium/wal.go
@@ -143,8 +143,9 @@ func (h *CreateWorkloadHandler) Handle(ctx context.Context, raw any) error {
 
 func (h *CreateWorkloadHandler) storedWorkloadID(ctx context.Context, wrk *types.Workload) (string, error) {
 	if wrk.ID != "" {
-		if _, err := h.calcium.GetWorkload(ctx, wrk.ID); err != nil {
-			return "", nil
+		workload, err := getWorkloadIfExists(ctx, h.calcium, wrk.ID)
+		if err != nil || workload == nil {
+			return "", err
 		}
 		return wrk.ID, nil
 	}

--- a/cluster/calcium/wal.go
+++ b/cluster/calcium/wal.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cockroachdb/errors"
 
 	"github.com/projecteru2/core/log"
+	resourcetypes "github.com/projecteru2/core/resource/types"
 	"github.com/projecteru2/core/store"
 	"github.com/projecteru2/core/types"
 	"github.com/projecteru2/core/wal"
@@ -20,6 +21,7 @@ const (
 	eventWorkloadCreated           = "create-workload" // created but yet to start
 	eventWorkloadReplaced          = "replace-workload"
 	eventWorkloadReallocated       = "realloc-workload"
+	eventWorkloadRemapped          = "remap-workload"
 	eventWorkloadResourceAllocated = "allocate-workload" // resource updated in node meta but yet to create all workloads
 	eventProcessingCreated         = "create-processing" // processing created but yet to delete
 
@@ -176,6 +178,11 @@ type workloadReplacement struct {
 	NewID string `json:"new_id"`
 }
 
+type workloadRemap struct {
+	ID           string                  `json:"id"`
+	EngineParams resourcetypes.Resources `json:"engine_params"`
+}
+
 // ReplaceWorkloadHandler removes the workload an interrupted replace left behind.
 type ReplaceWorkloadHandler struct {
 	walBase[*workloadReplacement]
@@ -253,6 +260,30 @@ func (h *ReallocWorkloadHandler) Handle(ctx context.Context, raw any) error {
 	}
 	logger.Info(ctx, "engine params reapplied")
 	return nil
+}
+
+type remapWorkloadHandler struct {
+	walBase[*workloadRemap]
+
+	calcium *Calcium
+}
+
+func newRemapWorkloadHandler(calcium *Calcium) *remapWorkloadHandler {
+	return &remapWorkloadHandler{calcium: calcium}
+}
+
+func (h *remapWorkloadHandler) Typ() string {
+	return eventWorkloadRemapped
+}
+
+func (h *remapWorkloadHandler) Handle(ctx context.Context, raw any) error {
+	remap, _ := raw.(*workloadRemap)
+	logger := log.WithFunc("calcium.RemapWorkloadHandler.Handle").WithField("ID", remap.ID)
+
+	ctx, cancel := getReplayContext(ctx)
+	defer cancel()
+
+	return h.calcium.applyWorkloadRemap(ctx, logger, remap)
 }
 
 // WorkloadResourceAllocatedHandler replays a dangling resource allocation by refreshing node resources.
@@ -350,6 +381,7 @@ func enableWAL(ctx context.Context, config types.Config, calcium *Calcium, store
 	hydro.Register(newCreateWorkloadHandler(calcium))
 	hydro.Register(newReplaceWorkloadHandler(calcium))
 	hydro.Register(newReallocWorkloadHandler(calcium))
+	hydro.Register(newRemapWorkloadHandler(calcium))
 	hydro.Register(newWorkloadResourceAllocatedHandler(calcium))
 	hydro.Register(newProcessingCreatedHandler(store))
 	return hydro, nil

--- a/cluster/calcium/wal_test.go
+++ b/cluster/calcium/wal_test.go
@@ -2,7 +2,6 @@ package calcium
 
 import (
 	"context"
-	"fmt"
 	"maps"
 	"strings"
 	"sync"
@@ -99,68 +98,19 @@ func TestHandleCreateWorkloadNoHandle(t *testing.T) {
 	c.wal.Recover(context.Background())
 }
 
-func TestHandleCreateWorkloadError(t *testing.T) {
+func TestHandleCreateWorkloadKeepsEntryOnStoreReadError(t *testing.T) {
 	c := NewTestCluster()
 	enableTestWAL(t, c)
-	rmgr := c.rmgr.(*resourcemocks.Manager)
-	rmgr.On("GetNodeResourceInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
-		resourcetypes.Resources{},
-		resourcetypes.Resources{},
-		[]string{},
-		nil,
-	)
-
-	engine := &enginemocks.API{}
-	node := &types.Node{
-		NodeMeta: types.NodeMeta{Name: "nodename"},
-		Engine:   engine,
-	}
 	wrkid := "workload-id"
-	_, err := c.wal.Log(eventWorkloadCreated, &types.Workload{ID: wrkid, Nodename: node.Name})
+	_, err := c.wal.Log(eventWorkloadCreated, &types.Workload{ID: wrkid, Nodename: "nodename"})
 	require.NoError(t, err)
-
-	wrk := &types.Workload{
-		ID:       wrkid,
-		Nodename: node.Name,
-	}
 
 	store := c.store.(*storemocks.Store)
-
-	err = errors.Wrapf(types.ErrInvaildCount, "keys: [%s]", wrkid)
-	store.On("GetWorkload", mock.Anything, mock.Anything).Return(wrk, err).Once()
-	store.On("GetNode", mock.Anything, mock.Anything).Return(nil, err).Once()
-	store.On("NotFound", err).Return(false).Once()
+	store.On("GetWorkload", mock.Anything, wrkid).Return(nil, types.ErrMockError).Twice()
+	store.On("NotFound", types.ErrMockError).Return(false).Twice()
+	c.wal.Recover(context.Background())
 	c.wal.Recover(context.Background())
 	store.AssertExpectations(t)
-	engine.AssertExpectations(t)
-
-	store.On("GetWorkload", mock.Anything, mock.Anything).Return(wrk, err).Once()
-	store.On("GetNode", mock.Anything, wrk.Nodename).Return(node, nil).Once()
-	engine.On("VirtualizationRemove", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(err).Once()
-	c.wal.Recover(context.Background())
-	store.AssertExpectations(t)
-	engine.AssertExpectations(t)
-
-	store.On("GetWorkload", mock.Anything, wrkid).Return(wrk, fmt.Errorf("err")).Once()
-	store.On("GetNode", mock.Anything, mock.Anything).Return(node, nil).Once()
-	engine.On("VirtualizationRemove", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(types.ErrWorkloadNotExists).Once()
-	c.wal.Recover(context.Background())
-	store.AssertExpectations(t)
-	engine.AssertExpectations(t)
-
-	_, err = c.wal.Log(eventWorkloadCreated, &types.Workload{ID: wrkid, Nodename: node.Name})
-	require.NoError(t, err)
-	gone := fmt.Errorf("node gone")
-	store.On("GetWorkload", mock.Anything, wrkid).Return(wrk, gone).Once()
-	store.On("GetNode", mock.Anything, wrk.Nodename).Return(nil, gone).Once()
-	store.On("NotFound", gone).Return(true).Once()
-	c.wal.Recover(context.Background())
-	store.AssertExpectations(t)
-	engine.AssertExpectations(t)
-	c.wal.Recover(context.Background())
-	store.AssertExpectations(t)
-
-	c.wal.Recover(context.Background())
 }
 
 func TestHandleCreateWorkloadHandled(t *testing.T) {
@@ -193,6 +143,7 @@ func TestHandleCreateWorkloadHandled(t *testing.T) {
 
 	err = errors.Wrapf(types.ErrInvaildCount, "keys: [%s]", wrkid)
 	store.On("GetWorkload", mock.Anything, wrkid).Return(nil, err).Once()
+	store.On("NotFound", err).Return(true).Once()
 	store.On("GetNode", mock.Anything, wrk.Nodename).Return(node, nil)
 
 	eng, ok := node.Engine.(*enginemocks.API)

--- a/cluster/mocks/Cluster.go
+++ b/cluster/mocks/Cluster.go
@@ -7,10 +7,9 @@ package mocks
 import (
 	"context"
 
-	mock "github.com/stretchr/testify/mock"
-
 	types0 "github.com/projecteru2/core/engine/types"
 	"github.com/projecteru2/core/types"
+	mock "github.com/stretchr/testify/mock"
 )
 
 // NewCluster creates a new instance of Cluster. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.

--- a/engine/containerd/build_test.go
+++ b/engine/containerd/build_test.go
@@ -2,6 +2,8 @@ package containerd
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -134,6 +136,20 @@ func TestMakeUserPartCreatesTheDeployUser(t *testing.T) {
 	}
 	if !strings.Contains(got, "USER eru") || !strings.Contains(got, "eru::1023:1023:") {
 		t.Errorf("got %q, want the user added and selected", got)
+	}
+}
+
+func TestRecreateDirCreatesATraversableDirectory(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "repo")
+	if err := recreateDir(path); err != nil {
+		t.Fatalf("recreate directory: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat directory: %v", err)
+	}
+	if info.Mode().Perm()&0o700 != 0o700 {
+		t.Fatalf("got permissions %#o, want owner access", info.Mode().Perm())
 	}
 }
 

--- a/engine/containerd/dockerfile.go
+++ b/engine/containerd/dockerfile.go
@@ -168,7 +168,7 @@ func recreateDir(path string) error {
 	if err := os.RemoveAll(path); err != nil {
 		return err
 	}
-	return os.MkdirAll(path, os.ModeDir)
+	return os.MkdirAll(path, 0o750)
 }
 
 func writeDockerfile(dockerfile, buildDir string) (err error) {

--- a/engine/containerd/image.go
+++ b/engine/containerd/image.go
@@ -173,7 +173,7 @@ func (e *Engine) ImageBuildFromExist(ctx context.Context, ID string, refs []stri
 		return "", err
 	}
 	for _, ref := range refs {
-		if _, err = e.client.ImageService().Create(ctx, images.Image{Name: ref, Target: target}); err != nil && !cerrdefs.IsAlreadyExists(err) {
+		if err = createImageReference(ctx, e.client.ImageService(), images.Image{Name: ref, Target: target}); err != nil {
 			return "", err
 		}
 	}
@@ -250,6 +250,17 @@ func (e *Engine) resolver() remotes.Resolver {
 			}),
 		),
 	})
+}
+
+func createImageReference(ctx context.Context, store images.Store, image images.Image) error {
+	if _, err := store.Create(ctx, image); err != nil {
+		if !cerrdefs.IsAlreadyExists(err) {
+			return err
+		}
+		_, err = store.Update(ctx, image, "target")
+		return err
+	}
+	return nil
 }
 
 func uncompressedDigest(ctx context.Context, store content.Store, layer ocispec.Descriptor) (digest.Digest, error) {

--- a/engine/containerd/image_test.go
+++ b/engine/containerd/image_test.go
@@ -1,8 +1,12 @@
 package containerd
 
 import (
+	"context"
 	"testing"
 
+	"github.com/containerd/containerd/v2/core/images"
+	cerrdefs "github.com/containerd/errdefs"
+	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	coretypes "github.com/projecteru2/core/types"
@@ -60,4 +64,48 @@ func TestGCRefsRootEveryBlobTheManifestOwns(t *testing.T) {
 			t.Errorf("got %q for %s, want %q", refs[key], key, want)
 		}
 	}
+}
+
+func TestCreateImageReferenceUpdatesAnExistingTarget(t *testing.T) {
+	ref := "docker.io/projecteru2/core:latest"
+	oldTarget := ocispec.Descriptor{Digest: digest.FromString("old")}
+	newTarget := ocispec.Descriptor{Digest: digest.FromString("new")}
+	store := &existingImageStore{image: images.Image{Name: ref, Target: oldTarget}}
+
+	if err := createImageReference(t.Context(), store, images.Image{Name: ref, Target: newTarget}); err != nil {
+		t.Fatalf("create image reference: %v", err)
+	}
+	if store.image.Target.Digest != newTarget.Digest {
+		t.Fatalf("got target %s, want %s", store.image.Target.Digest, newTarget.Digest)
+	}
+	if len(store.updatedFields) != 1 || store.updatedFields[0] != "target" {
+		t.Fatalf("got updated fields %v, want target", store.updatedFields)
+	}
+}
+
+type existingImageStore struct {
+	image         images.Image
+	updatedFields []string
+}
+
+func (s *existingImageStore) Get(context.Context, string) (images.Image, error) {
+	return s.image, nil
+}
+
+func (s *existingImageStore) List(context.Context, ...string) ([]images.Image, error) {
+	return []images.Image{s.image}, nil
+}
+
+func (s *existingImageStore) Create(context.Context, images.Image) (images.Image, error) {
+	return images.Image{}, cerrdefs.ErrAlreadyExists
+}
+
+func (s *existingImageStore) Update(_ context.Context, image images.Image, fields ...string) (images.Image, error) {
+	s.image = image
+	s.updatedFields = fields
+	return image, nil
+}
+
+func (s *existingImageStore) Delete(context.Context, string, ...images.DeleteOpt) error {
+	return nil
 }

--- a/engine/mocks/API.go
+++ b/engine/mocks/API.go
@@ -9,11 +9,10 @@ import (
 	"io"
 	"time"
 
-	mock "github.com/stretchr/testify/mock"
-
 	"github.com/projecteru2/core/engine/types"
 	types0 "github.com/projecteru2/core/resource/types"
 	"github.com/projecteru2/core/source"
+	mock "github.com/stretchr/testify/mock"
 )
 
 // NewAPI creates a new instance of API. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.

--- a/lock/redis/lock.go
+++ b/lock/redis/lock.go
@@ -2,6 +2,7 @@ package redislock
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/bsm/redislock"
@@ -20,6 +21,8 @@ type RedisLock struct {
 	ttl     time.Duration
 	lc      *redislock.Client
 	l       *redislock.Lock
+	cancel  context.CancelFunc
+	wg      sync.WaitGroup
 }
 
 // New creates a lock on key, waiting at most waitTimeout to acquire it and holding it for lockTTL.
@@ -45,7 +48,28 @@ func (r *RedisLock) Lock(ctx context.Context) (context.Context, error) {
 	if err != nil {
 		return nil, err
 	}
+	ctx, cancel = context.WithCancel(ctx)
 	r.l = l
+	r.cancel = cancel
+	interval := r.ttl / 3
+	r.wg.Go(func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				refreshCtx, refreshCancel := context.WithTimeout(ctx, interval)
+				err := l.Refresh(refreshCtx, r.ttl, nil)
+				refreshCancel()
+				if err != nil {
+					cancel()
+					return
+				}
+			}
+		}
+	})
 	return ctx, nil
 }
 
@@ -53,8 +77,12 @@ func (r *RedisLock) Unlock(ctx context.Context) error {
 	if r.l == nil {
 		return redislock.ErrLockNotHeld
 	}
+	if r.cancel != nil {
+		r.cancel()
+		r.wg.Wait()
+	}
 
-	lockCtx, cancel := context.WithTimeout(ctx, r.ttl)
+	lockCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), r.ttl)
 	defer cancel()
 	return r.l.Release(lockCtx)
 }

--- a/lock/redis/lock.go
+++ b/lock/redis/lock.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/projecteru2/core/lock"
 	"github.com/projecteru2/core/log"
+	"github.com/projecteru2/core/utils"
 )
 
 var opts = &redislock.Options{
@@ -55,24 +56,18 @@ func (r *RedisLock) Lock(ctx context.Context) (context.Context, error) {
 	r.cancel = cancel
 	interval := r.ttl / 3
 	r.wg.Go(func() {
-		ticker := time.NewTicker(interval)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				refreshCtx, refreshCancel := context.WithTimeout(ctx, interval)
-				err := l.Refresh(refreshCtx, r.ttl, opts)
-				refreshCancel()
-				switch {
-				case errors.Is(err, redislock.ErrNotObtained):
-					cancel()
-					return
-				case err != nil && ctx.Err() == nil:
-					log.WithFunc("redislock.Lock").Warnf(ctx, "refresh lock %s failed: %+v", r.key, err)
-				}
+		err := utils.KeepAlive(ctx, interval, func(ctx context.Context) error {
+			refreshCtx, refreshCancel := context.WithTimeout(ctx, interval)
+			defer refreshCancel()
+			err := l.Refresh(refreshCtx, r.ttl, opts)
+			if err != nil && !errors.Is(err, redislock.ErrNotObtained) && ctx.Err() == nil {
+				log.WithFunc("redislock.Lock").Warnf(ctx, "refresh lock %s failed: %+v", r.key, err)
+				return nil
 			}
+			return err
+		})
+		if err != nil {
+			cancel()
 		}
 	})
 	return ctx, nil

--- a/lock/redis/lock.go
+++ b/lock/redis/lock.go
@@ -55,16 +55,22 @@ func (r *RedisLock) Lock(ctx context.Context) (context.Context, error) {
 	r.l = l
 	r.cancel = cancel
 	interval := r.ttl / 3
+	logger := log.WithFunc("redislock.RedisLock.Lock")
 	r.wg.Go(func() {
+		lastOK := time.Now()
 		err := utils.KeepAlive(ctx, interval, func(ctx context.Context) error {
 			refreshCtx, refreshCancel := context.WithTimeout(ctx, interval)
 			defer refreshCancel()
 			err := l.Refresh(refreshCtx, r.ttl, opts)
-			if err != nil && !errors.Is(err, redislock.ErrNotObtained) && ctx.Err() == nil {
-				log.WithFunc("redislock.Lock").Warnf(ctx, "refresh lock %s failed: %+v", r.key, err)
-				return nil
+			switch {
+			case err == nil:
+				lastOK = time.Now()
+			case errors.Is(err, redislock.ErrNotObtained), time.Since(lastOK) >= r.ttl, ctx.Err() != nil:
+				return err
+			default:
+				logger.Warnf(ctx, "refresh lock %s failed: %+v", r.key, err)
 			}
-			return err
+			return nil
 		})
 		if err != nil {
 			cancel()

--- a/lock/redis/lock.go
+++ b/lock/redis/lock.go
@@ -6,8 +6,10 @@ import (
 	"time"
 
 	"github.com/bsm/redislock"
+	"github.com/cockroachdb/errors"
 
 	"github.com/projecteru2/core/lock"
+	"github.com/projecteru2/core/log"
 )
 
 var opts = &redislock.Options{
@@ -61,11 +63,14 @@ func (r *RedisLock) Lock(ctx context.Context) (context.Context, error) {
 				return
 			case <-ticker.C:
 				refreshCtx, refreshCancel := context.WithTimeout(ctx, interval)
-				err := l.Refresh(refreshCtx, r.ttl, nil)
+				err := l.Refresh(refreshCtx, r.ttl, opts)
 				refreshCancel()
-				if err != nil {
+				switch {
+				case errors.Is(err, redislock.ErrNotObtained):
 					cancel()
 					return
+				case err != nil && ctx.Err() == nil:
+					log.WithFunc("redislock.Lock").Warnf(ctx, "refresh lock %s failed: %+v", r.key, err)
 				}
 			}
 		}

--- a/lock/redis/lock_test.go
+++ b/lock/redis/lock_test.go
@@ -23,14 +23,16 @@ func TestRedisLock(t *testing.T) {
 	})
 	defer cli.Close()
 	suite.Run(t, &RedisLockTestSuite{
-		cli: cli,
+		cli:    cli,
+		server: s,
 	})
 }
 
 type RedisLockTestSuite struct {
 	suite.Suite
 
-	cli *redis.Client
+	cli    *redis.Client
+	server *miniredis.Miniredis
 }
 
 func (s *RedisLockTestSuite) SetupTest() {
@@ -54,4 +56,20 @@ func (s *RedisLockTestSuite) TestMutex() {
 
 	err = l.Unlock(ctx)
 	s.NoError(err)
+}
+
+func (s *RedisLockTestSuite) TestLostLeaseCancelsContext() {
+	l, err := New(s.cli, "test", time.Second, 90*time.Millisecond)
+	s.Require().NoError(err)
+
+	ctx, err := l.Lock(context.Background())
+	s.Require().NoError(err)
+	s.server.Del("/test")
+
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		s.FailNow("lock context was not canceled")
+	}
+	s.Error(l.Unlock(context.Background()))
 }

--- a/lock/redis/lock_test.go
+++ b/lock/redis/lock_test.go
@@ -73,3 +73,20 @@ func (s *RedisLockTestSuite) TestLostLeaseCancelsContext() {
 	}
 	s.Error(l.Unlock(context.Background()))
 }
+
+func (s *RedisLockTestSuite) TestTransientRefreshErrorKeepsContext() {
+	l, err := New(s.cli, "test", time.Second, 90*time.Millisecond)
+	s.Require().NoError(err)
+
+	ctx, err := l.Lock(context.Background())
+	s.Require().NoError(err)
+	s.server.SetError("mock outage")
+
+	select {
+	case <-ctx.Done():
+		s.FailNow("transient refresh error canceled the lock context")
+	case <-time.After(200 * time.Millisecond):
+	}
+	s.server.SetError("")
+	s.NoError(l.Unlock(context.Background()))
+}

--- a/lock/redis/lock_test.go
+++ b/lock/redis/lock_test.go
@@ -75,7 +75,7 @@ func (s *RedisLockTestSuite) TestLostLeaseCancelsContext() {
 }
 
 func (s *RedisLockTestSuite) TestTransientRefreshErrorKeepsContext() {
-	l, err := New(s.cli, "test", time.Second, 90*time.Millisecond)
+	l, err := New(s.cli, "test", time.Second, 900*time.Millisecond)
 	s.Require().NoError(err)
 
 	ctx, err := l.Lock(context.Background())
@@ -85,7 +85,24 @@ func (s *RedisLockTestSuite) TestTransientRefreshErrorKeepsContext() {
 	select {
 	case <-ctx.Done():
 		s.FailNow("transient refresh error canceled the lock context")
-	case <-time.After(200 * time.Millisecond):
+	case <-time.After(400 * time.Millisecond):
+	}
+	s.server.SetError("")
+	s.NoError(l.Unlock(context.Background()))
+}
+
+func (s *RedisLockTestSuite) TestUnrefreshedLockCancelsAfterTTL() {
+	l, err := New(s.cli, "test", time.Second, 90*time.Millisecond)
+	s.Require().NoError(err)
+
+	ctx, err := l.Lock(context.Background())
+	s.Require().NoError(err)
+	s.server.SetError("mock outage")
+
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		s.FailNow("lock context outlived an unrefreshed ttl")
 	}
 	s.server.SetError("")
 	s.NoError(l.Unlock(context.Background()))

--- a/resource/cobalt/node.go
+++ b/resource/cobalt/node.go
@@ -251,15 +251,17 @@ func (m Manager) SetNodeResourceCapacity(ctx context.Context, nodename string, n
 				}
 				return resp, err
 			})
-			if err != nil {
-				for plugin, resp := range resps {
-					if resp == nil {
-						continue
-					}
-					rollbackPlugins = append(rollbackPlugins, plugin)
-					before[plugin.Name()] = resp.Before
-					after[plugin.Name()] = resp.After
+			for plugin, resp := range resps {
+				if resp == nil {
+					continue
 				}
+				if err != nil {
+					rollbackPlugins = append(rollbackPlugins, plugin)
+				}
+				before[plugin.Name()] = resp.Before
+				after[plugin.Name()] = resp.After
+			}
+			if err != nil {
 				logger.Errorf(ctx, err, "failed to set node resource for node %+v", nodename)
 				return err
 			}

--- a/resource/cobalt/node_test.go
+++ b/resource/cobalt/node_test.go
@@ -84,6 +84,33 @@ func TestRemoveNodeRollbackRestoresNonWhitelistedPlugins(t *testing.T) {
 	assert.Equal(t, capacity, <-restored)
 }
 
+func TestSetNodeResourceCapacityReturnsSuccessfulChange(t *testing.T) {
+	beforeResource := plugintypes.NodeResource{"memory": int64(1024)}
+	afterResource := plugintypes.NodeResource{"memory": int64(2048)}
+
+	plugin := pluginmocks.NewPlugin(t)
+	plugin.On("Name").Return("cpumem").Maybe()
+	plugin.On("SetNodeResourceCapacity", mock.Anything, "n1", mock.Anything, afterResource, false, true).
+		Return(&plugintypes.SetNodeResourceCapacityResponse{Before: beforeResource, After: afterResource}, nil).
+		Once()
+
+	m, err := New(coretypes.Config{GlobalTimeout: time.Minute})
+	assert.NoError(t, err)
+	m.AddPlugins(plugin)
+
+	before, after, err := m.SetNodeResourceCapacity(
+		t.Context(),
+		"n1",
+		resourcetypes.Resources{},
+		resourcetypes.Resources{"cpumem": afterResource},
+		false,
+		true,
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, beforeResource, before["cpumem"])
+	assert.Equal(t, afterResource, after["cpumem"])
+}
+
 func newCapacityPlugin(t *testing.T, name string, capacities map[string]*plugintypes.NodeDeployCapacity) *pluginmocks.Plugin {
 	p := pluginmocks.NewPlugin(t)
 	p.On("Name").Return(name).Maybe()

--- a/rpc/errors.go
+++ b/rpc/errors.go
@@ -36,6 +36,7 @@ const (
 	RawEngineStatus    codes.Code = 1057
 
 	Copy          codes.Code = 1061
+	Send          codes.Code = 1062
 	SendLargeFile codes.Code = 1063
 
 	BuildImage  codes.Code = 1071

--- a/rpc/errors_test.go
+++ b/rpc/errors_test.go
@@ -47,6 +47,7 @@ func allStatusCodes() map[string]codes.Code {
 		"SetWorkloadsStatus": SetWorkloadsStatus,
 		"RawEngineStatus":    RawEngineStatus,
 		"Copy":               Copy,
+		"Send":               Send,
 		"SendLargeFile":      SendLargeFile,
 		"BuildImage":         BuildImage,
 		"CacheImage":         CacheImage,

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -525,6 +525,9 @@ func (v *Vibranium) Send(opts *pb.SendOptions, stream pb.CoreRPC_SendServer) err
 	defer task.done()
 
 	sendOpts := toCoreSendOptions(opts)
+	if err := sendOpts.Validate(); err != nil {
+		return grpcstatus.Error(Send, err.Error())
+	}
 	for _, file := range sendOpts.Files {
 		dc := make(chan *types.SendLargeFileOptions)
 		ch := v.cluster.SendLargeFile(task.context, dc)

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -278,7 +278,10 @@ func (v *Vibranium) NodeStatusStream(_ *pb.Empty, stream pb.CoreRPC_NodeStatusSt
 		select {
 		case m, ok := <-ch:
 			if !ok {
-				return nil
+				if task.context.Err() != nil {
+					return nil
+				}
+				return types.ErrMessageChanClosed
 			}
 			r := &pb.NodeStatusStreamMessage{
 				Nodename: m.Nodename,
@@ -353,7 +356,10 @@ func (v *Vibranium) WorkloadStatusStream(opts *pb.WorkloadStatusStreamOptions, s
 		select {
 		case m, ok := <-ch:
 			if !ok {
-				return nil
+				if task.context.Err() != nil {
+					return nil
+				}
+				return types.ErrMessageChanClosed
 			}
 			r := &pb.WorkloadStatusStreamMessage{Id: m.ID, Delete: m.Delete}
 			if m.Error != nil {

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -223,6 +223,14 @@ func TestSendLargeFileReportsItsOwnStatusCode(t *testing.T) {
 	assert.Equal(t, SendLargeFile, grpcstatus.Code(err))
 }
 
+func TestSendRejectsInvalidOptions(t *testing.T) {
+	v := newVibranium()
+
+	err := v.Send(&pb.SendOptions{}, &sendWorkloadStream{})
+	assert.Error(t, err)
+	assert.Equal(t, Send, grpcstatus.Code(err))
+}
+
 func TestReallocResourceStatusHidesStackTrace(t *testing.T) {
 	v := newVibranium()
 
@@ -245,3 +253,11 @@ type removeWorkloadStream struct {
 func (s *removeWorkloadStream) Send(*pb.RemoveWorkloadMessage) error { return nil }
 
 func (s *removeWorkloadStream) Context() context.Context { return context.Background() }
+
+type sendWorkloadStream struct {
+	grpc.ServerStream
+}
+
+func (s *sendWorkloadStream) Send(*pb.SendMessage) error { return nil }
+
+func (s *sendWorkloadStream) Context() context.Context { return context.Background() }

--- a/rpc/transform.go
+++ b/rpc/transform.go
@@ -607,19 +607,26 @@ func toSendLargeFileOptions(opts *pb.FileOptions) (*types.SendLargeFileOptions, 
 
 func toSendLargeFileChunks(file types.LinuxFile, ids []string) []*types.SendLargeFileOptions {
 	maxChunkSize := types.SendLargeFileChunkSize
+	if len(file.Content) == 0 {
+		return []*types.SendLargeFileOptions{toSendLargeFileChunk(file, ids, nil)}
+	}
 	ret := make([]*types.SendLargeFileOptions, 0, (len(file.Content)+maxChunkSize-1)/maxChunkSize)
 	for chunk := range slices.Chunk(file.Content, maxChunkSize) {
-		ret = append(ret, &types.SendLargeFileOptions{
-			IDs:   ids,
-			Dst:   file.Filename,
-			Size:  int64(len(file.Content)),
-			Mode:  file.Mode,
-			UID:   file.UID,
-			GID:   file.GID,
-			Chunk: chunk,
-		})
+		ret = append(ret, toSendLargeFileChunk(file, ids, chunk))
 	}
 	return ret
+}
+
+func toSendLargeFileChunk(file types.LinuxFile, ids []string, chunk []byte) *types.SendLargeFileOptions {
+	return &types.SendLargeFileOptions{
+		IDs:   ids,
+		Dst:   file.Filename,
+		Size:  int64(len(file.Content)),
+		Mode:  file.Mode,
+		UID:   file.UID,
+		GID:   file.GID,
+		Chunk: chunk,
+	}
 }
 
 func toCoreRawEngineOptions(d *pb.RawEngineOptions) (*types.RawEngineOptions, error) {

--- a/rpc/transform_test.go
+++ b/rpc/transform_test.go
@@ -1,0 +1,24 @@
+package rpc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/projecteru2/core/types"
+)
+
+func TestToSendLargeFileChunksIncludesAnEmptyFile(t *testing.T) {
+	file := types.LinuxFile{Filename: "/tmp/empty", Mode: 0o644, UID: 1, GID: 2}
+	chunks := toSendLargeFileChunks(file, []string{"workload1"})
+
+	require.Len(t, chunks, 1)
+	assert.Equal(t, []string{"workload1"}, chunks[0].IDs)
+	assert.Equal(t, file.Filename, chunks[0].Dst)
+	assert.Zero(t, chunks[0].Size)
+	assert.Empty(t, chunks[0].Chunk)
+	assert.Equal(t, file.Mode, chunks[0].Mode)
+	assert.Equal(t, file.UID, chunks[0].UID)
+	assert.Equal(t, file.GID, chunks[0].GID)
+}

--- a/selfmon/selfmon.go
+++ b/selfmon/selfmon.go
@@ -108,30 +108,20 @@ func (n *NodeStatusWatcher) withActiveLock(parentCtx context.Context, f func(ctx
 // replayDeadJournals hands the journals of unregistered instances to this one, for as long as it stays active.
 func (n *NodeStatusWatcher) replayDeadJournals(ctx context.Context) {
 	logger := log.WithFunc("selfmon.replayDeadJournals").WithField("ID", n.ID)
-	services, err := n.store.ServiceStatusStream(ctx)
-	if err != nil {
-		logger.Error(ctx, err, "failed to watch service status")
-		return
-	}
-
 	ticker := time.NewTicker(n.config.GRPCConfig.ServiceHeartbeatInterval)
 	defer ticker.Stop()
 
-	var live []string
-	var known bool
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case addresses, ok := <-services:
-			if !ok {
-				return
-			}
-			live, known = addresses, true
 		case <-ticker.C:
-			if known {
-				n.wal.Takeover(ctx, live)
+			live, err := n.store.GetServiceStatus(ctx)
+			if err != nil {
+				logger.Error(ctx, err, "failed to read service status")
+				continue
 			}
+			n.wal.Takeover(ctx, live)
 		}
 	}
 }

--- a/selfmon/selfmon.go
+++ b/selfmon/selfmon.go
@@ -108,22 +108,18 @@ func (n *NodeStatusWatcher) withActiveLock(parentCtx context.Context, f func(ctx
 // replayDeadJournals hands the journals of unregistered instances to this one, for as long as it stays active.
 func (n *NodeStatusWatcher) replayDeadJournals(ctx context.Context) {
 	logger := log.WithFunc("selfmon.replayDeadJournals").WithField("ID", n.ID)
-	ticker := time.NewTicker(n.config.GRPCConfig.ServiceHeartbeatInterval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-			live, err := n.store.GetServiceStatus(ctx)
-			if err != nil {
-				logger.Error(ctx, err, "failed to read service status")
-				continue
-			}
-			n.wal.Takeover(ctx, live)
+	_ = utils.KeepAlive(ctx, n.config.GRPCConfig.ServiceHeartbeatInterval, func(ctx context.Context) error {
+		live, err := n.store.GetServiceStatus(ctx)
+		if err != nil {
+			logger.Error(ctx, err, "failed to read service status")
+			return nil
 		}
-	}
+		if len(live) == 0 {
+			return nil
+		}
+		n.wal.Takeover(ctx, live)
+		return nil
+	})
 }
 
 func (n *NodeStatusWatcher) initNodeStatus(ctx context.Context) {

--- a/selfmon/selfmon_test.go
+++ b/selfmon/selfmon_test.go
@@ -1,0 +1,45 @@
+package selfmon
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+
+	storemocks "github.com/projecteru2/core/store/mocks"
+	"github.com/projecteru2/core/types"
+	walmocks "github.com/projecteru2/core/wal/mocks"
+)
+
+func TestReplayDeadJournalsUsesFreshServiceList(t *testing.T) {
+	store := &storemocks.Store{}
+	mwal := &walmocks.WAL{}
+	n := &NodeStatusWatcher{
+		config: types.Config{GRPCConfig: types.GRPCConfig{ServiceHeartbeatInterval: 10 * time.Millisecond}},
+		store:  store,
+		wal:    mwal,
+	}
+
+	store.On("GetServiceStatus", mock.Anything).Return(nil, types.ErrMockError).Once()
+	store.On("GetServiceStatus", mock.Anything).Return([]string{"127.0.0.1:5001"}, nil)
+	var takeovers atomic.Int32
+	done := make(chan struct{})
+	mwal.On("Takeover", mock.Anything, []string{"127.0.0.1:5001"}).Run(func(mock.Arguments) {
+		if takeovers.Add(1) == 2 {
+			close(done)
+		}
+	}).Return()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go n.replayDeadJournals(ctx)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("takeover did not run with the fresh service list")
+	}
+	store.AssertExpectations(t)
+}

--- a/selfmon/selfmon_test.go
+++ b/selfmon/selfmon_test.go
@@ -32,7 +32,7 @@ func TestReplayDeadJournalsUsesFreshServiceList(t *testing.T) {
 		}
 	}).Return()
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	go n.replayDeadJournals(ctx)
 

--- a/store/common/kv.go
+++ b/store/common/kv.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"cmp"
 	"context"
 	"iter"
 	"time"
@@ -9,7 +8,6 @@ import (
 	"github.com/panjf2000/ants/v2"
 
 	"github.com/projecteru2/core/lock"
-	"github.com/projecteru2/core/log"
 	"github.com/projecteru2/core/types"
 )
 
@@ -59,23 +57,4 @@ type Store struct {
 
 func New(kv KV, config types.Config, pool *ants.PoolWithFunc) *Store {
 	return &Store{KV: kv, Config: config, Pool: pool}
-}
-
-func (s *Store) watchRetry(ctx context.Context, logger *log.Fields, body func(context.Context) error) {
-	retryInterval := cmp.Or(s.Config.ConnectionTimeout, time.Second)
-	for ctx.Err() == nil {
-		if err := body(ctx); err != nil && ctx.Err() == nil {
-			logger.Error(ctx, err, "status stream interrupted")
-		}
-		if ctx.Err() != nil {
-			return
-		}
-		timer := time.NewTimer(retryInterval)
-		select {
-		case <-ctx.Done():
-			timer.Stop()
-			return
-		case <-timer.C:
-		}
-	}
 }

--- a/store/common/kv.go
+++ b/store/common/kv.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"cmp"
 	"context"
 	"iter"
 	"time"
@@ -8,6 +9,7 @@ import (
 	"github.com/panjf2000/ants/v2"
 
 	"github.com/projecteru2/core/lock"
+	"github.com/projecteru2/core/log"
 	"github.com/projecteru2/core/types"
 )
 
@@ -57,4 +59,23 @@ type Store struct {
 
 func New(kv KV, config types.Config, pool *ants.PoolWithFunc) *Store {
 	return &Store{KV: kv, Config: config, Pool: pool}
+}
+
+func (s *Store) watchRetry(ctx context.Context, logger *log.Fields, body func(context.Context) error) {
+	retryInterval := cmp.Or(s.Config.ConnectionTimeout, time.Second)
+	for ctx.Err() == nil {
+		if err := body(ctx); err != nil && ctx.Err() == nil {
+			logger.Error(ctx, err, "status stream interrupted")
+		}
+		if ctx.Err() != nil {
+			return
+		}
+		timer := time.NewTimer(retryInterval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return
+		case <-timer.C:
+		}
+	}
 }

--- a/store/common/node.go
+++ b/store/common/node.go
@@ -177,9 +177,9 @@ func (s *Store) NodeStatusStream(ctx context.Context) chan *types.NodeStatus {
 			logger.Info(ctx, "close NodeStatusStream channel")
 			close(ch)
 		}()
-		s.watchRetry(ctx, logger, func(ctx context.Context) error {
-			return s.nodeStatusStream(ctx, logger, ch)
-		})
+		if err := s.nodeStatusStream(ctx, logger, ch); err != nil && ctx.Err() == nil {
+			logger.Error(ctx, err, "node status stream interrupted")
+		}
 	})
 	return ch
 }

--- a/store/common/node.go
+++ b/store/common/node.go
@@ -177,22 +177,9 @@ func (s *Store) NodeStatusStream(ctx context.Context) chan *types.NodeStatus {
 			logger.Info(ctx, "close NodeStatusStream channel")
 			close(ch)
 		}()
-
-		logger.Infof(ctx, "watch on %s", NodeStatusPrefix)
-		for event := range s.Watch(ctx, NodeStatusPrefix) {
-			nodename := utils.Tail(event.Key)
-			status := &types.NodeStatus{
-				Nodename: nodename,
-				Alive:    event.Type == EventPut,
-			}
-			node, err := s.GetNode(ctx, nodename)
-			if err != nil {
-				status.Error = err
-			} else {
-				status.Podname = node.Podname
-			}
-			ch <- status
-		}
+		s.watchRetry(ctx, logger, func(ctx context.Context) error {
+			return s.nodeStatusStream(ctx, logger, ch)
+		})
 	})
 	return ch
 }
@@ -208,6 +195,29 @@ func (s *Store) MakeClient(ctx context.Context, node *types.Node) (engine.API, e
 		return nil, err
 	}
 	return enginefactory.GetEngine(ctx, s.Config, node.Name, node.Endpoint, ca, cert, key)
+}
+
+func (s *Store) nodeStatusStream(ctx context.Context, logger *log.Fields, ch chan<- *types.NodeStatus) error {
+	logger.Infof(ctx, "watch on %s", NodeStatusPrefix)
+	for event := range s.Watch(ctx, NodeStatusPrefix) {
+		nodename := utils.Tail(event.Key)
+		status := &types.NodeStatus{
+			Nodename: nodename,
+			Alive:    event.Type == EventPut,
+		}
+		node, err := s.GetNode(ctx, nodename)
+		if err != nil {
+			status.Error = err
+		} else {
+			status.Podname = node.Podname
+		}
+		select {
+		case ch <- status:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return types.ErrMessageChanClosed
 }
 
 func (s *Store) loadCert(ctx context.Context, nodename string) (ca, cert, key string, err error) {

--- a/store/common/node_test.go
+++ b/store/common/node_test.go
@@ -3,7 +3,6 @@ package common
 import (
 	"context"
 	"iter"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -14,54 +13,45 @@ import (
 	"github.com/projecteru2/core/utils"
 )
 
-func TestNodeStatusStreamRecoversAfterWatchFailure(t *testing.T) {
+func TestNodeStatusStreamClosesWhenWatchBreaks(t *testing.T) {
 	pool, err := utils.NewPool(1)
 	require.NoError(t, err)
 	defer pool.Release()
-	ctx, cancel := context.WithCancel(context.Background())
-	store := New(&recoveringWatchKV{key: "node1"}, types.Config{ConnectionTimeout: time.Millisecond}, pool)
+	store := New(&brokenWatchKV{key: "node1"}, types.Config{ConnectionTimeout: time.Millisecond}, pool)
 
-	ch := store.NodeStatusStream(ctx)
+	ch := store.NodeStatusStream(t.Context())
 	select {
 	case status, ok := <-ch:
 		require.True(t, ok)
 		assert.Equal(t, "node1", status.Nodename)
 		assert.True(t, status.Alive)
 	case <-time.After(time.Second):
-		t.Fatal("node status stream did not recover")
+		t.Fatal("node status stream delivered nothing")
 	}
-	cancel()
 	select {
 	case _, ok := <-ch:
 		assert.False(t, ok)
 	case <-time.After(time.Second):
-		t.Fatal("node status stream did not stop")
+		t.Fatal("node status stream did not close after the watch broke")
 	}
 }
 
-type recoveringWatchKV struct {
+type brokenWatchKV struct {
 	KV
 
-	watches atomic.Int32
-	key     string
+	key string
 }
 
-func (k *recoveringWatchKV) GetOne(context.Context, string) (string, error) {
+func (k *brokenWatchKV) GetOne(context.Context, string) (string, error) {
 	return "", types.ErrMockError
 }
 
-func (k *recoveringWatchKV) GetMulti(context.Context, []string) (map[string]string, error) {
+func (k *brokenWatchKV) GetMulti(context.Context, []string) (map[string]string, error) {
 	return nil, types.ErrMockError
 }
 
-func (k *recoveringWatchKV) Watch(ctx context.Context, prefix string) iter.Seq[Event] {
+func (k *brokenWatchKV) Watch(_ context.Context, prefix string) iter.Seq[Event] {
 	return func(yield func(Event) bool) {
-		if k.watches.Add(1) == 1 {
-			return
-		}
-		if !yield(Event{Key: prefix + k.key, Type: EventPut}) {
-			return
-		}
-		<-ctx.Done()
+		yield(Event{Key: prefix + k.key, Type: EventPut})
 	}
 }

--- a/store/common/node_test.go
+++ b/store/common/node_test.go
@@ -1,0 +1,67 @@
+package common
+
+import (
+	"context"
+	"iter"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/projecteru2/core/types"
+	"github.com/projecteru2/core/utils"
+)
+
+func TestNodeStatusStreamRecoversAfterWatchFailure(t *testing.T) {
+	pool, err := utils.NewPool(1)
+	require.NoError(t, err)
+	defer pool.Release()
+	ctx, cancel := context.WithCancel(context.Background())
+	store := New(&recoveringWatchKV{key: "node1"}, types.Config{ConnectionTimeout: time.Millisecond}, pool)
+
+	ch := store.NodeStatusStream(ctx)
+	select {
+	case status, ok := <-ch:
+		require.True(t, ok)
+		assert.Equal(t, "node1", status.Nodename)
+		assert.True(t, status.Alive)
+	case <-time.After(time.Second):
+		t.Fatal("node status stream did not recover")
+	}
+	cancel()
+	select {
+	case _, ok := <-ch:
+		assert.False(t, ok)
+	case <-time.After(time.Second):
+		t.Fatal("node status stream did not stop")
+	}
+}
+
+type recoveringWatchKV struct {
+	KV
+
+	watches atomic.Int32
+	key     string
+}
+
+func (k *recoveringWatchKV) GetOne(context.Context, string) (string, error) {
+	return "", types.ErrMockError
+}
+
+func (k *recoveringWatchKV) GetMulti(context.Context, []string) (map[string]string, error) {
+	return nil, types.ErrMockError
+}
+
+func (k *recoveringWatchKV) Watch(ctx context.Context, prefix string) iter.Seq[Event] {
+	return func(yield func(Event) bool) {
+		if k.watches.Add(1) == 1 {
+			return
+		}
+		if !yield(Event{Key: prefix + k.key, Type: EventPut}) {
+			return
+		}
+		<-ctx.Done()
+	}
+}

--- a/store/common/service.go
+++ b/store/common/service.go
@@ -12,6 +12,14 @@ import (
 	"github.com/projecteru2/core/utils"
 )
 
+func (s *Store) GetServiceStatus(ctx context.Context) ([]string, error) {
+	eps, err := s.getServiceEndpoints(ctx, fmt.Sprintf(ServiceStatusKey, ""))
+	if err != nil {
+		return nil, err
+	}
+	return eps.ToSlice(), nil
+}
+
 func (s *Store) ServiceStatusStream(ctx context.Context) (chan []string, error) {
 	ch := make(chan []string)
 	logger := log.WithFunc("store.common.ServiceStatusStream")
@@ -36,13 +44,9 @@ func (s *Store) serviceStatusStream(ctx context.Context, prefix string, ch chan<
 	defer cancel()
 	watch := s.Watch(watchCtx, prefix)
 
-	data, err := s.GetPrefix(ctx, prefix, 0)
+	eps, err := s.getServiceEndpoints(ctx, prefix)
 	if err != nil {
 		return err
-	}
-	eps := Endpoints{}
-	for key := range data {
-		eps.Add(utils.Tail(key))
 	}
 	select {
 	case ch <- eps.ToSlice():
@@ -67,6 +71,18 @@ func (s *Store) serviceStatusStream(ctx context.Context, prefix string, ch chan<
 		}
 	}
 	return types.ErrMessageChanClosed
+}
+
+func (s *Store) getServiceEndpoints(ctx context.Context, prefix string) (Endpoints, error) {
+	data, err := s.GetPrefix(ctx, prefix, 0)
+	if err != nil {
+		return nil, err
+	}
+	eps := Endpoints{}
+	for key := range data {
+		eps.Add(utils.Tail(key))
+	}
+	return eps, nil
 }
 
 type Endpoints map[string]struct{}

--- a/store/common/service.go
+++ b/store/common/service.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"maps"
@@ -8,6 +9,7 @@ import (
 	"time"
 
 	"github.com/projecteru2/core/log"
+	"github.com/projecteru2/core/types"
 	"github.com/projecteru2/core/utils"
 )
 
@@ -17,30 +19,20 @@ func (s *Store) ServiceStatusStream(ctx context.Context) (chan []string, error) 
 	prefix := fmt.Sprintf(ServiceStatusKey, "")
 	if err := s.Pool.Invoke(func() {
 		defer close(ch)
-
-		watch := s.Watch(ctx, prefix)
-
-		data, err := s.GetPrefix(ctx, prefix, 0)
-		if err != nil {
-			logger.Error(ctx, err, "failed to get current services")
-			return
-		}
-		eps := Endpoints{}
-		for key := range data {
-			eps.Add(utils.Tail(key))
-		}
-		ch <- eps.ToSlice()
-
-		for event := range watch {
-			endpoint := utils.Tail(event.Key)
-			var changed bool
-			if event.Type == EventPut {
-				changed = eps.Add(endpoint)
-			} else {
-				changed = eps.Remove(endpoint)
+		retryInterval := cmp.Or(s.Config.ConnectionTimeout, time.Second)
+		for ctx.Err() == nil {
+			if err := s.serviceStatusStream(ctx, prefix, ch); err != nil && ctx.Err() == nil {
+				logger.Error(ctx, err, "service status stream interrupted")
 			}
-			if changed {
-				ch <- eps.ToSlice()
+			if ctx.Err() != nil {
+				return
+			}
+			timer := time.NewTimer(retryInterval)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return
+			case <-timer.C:
 			}
 		}
 	}); err != nil {
@@ -51,6 +43,44 @@ func (s *Store) ServiceStatusStream(ctx context.Context) (chan []string, error) 
 
 func (s *Store) RegisterService(ctx context.Context, serviceAddress string, expire time.Duration) (<-chan struct{}, func(), error) {
 	return s.StartEphemeral(ctx, fmt.Sprintf(ServiceStatusKey, serviceAddress), expire)
+}
+
+func (s *Store) serviceStatusStream(ctx context.Context, prefix string, ch chan<- []string) error {
+	watchCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	watch := s.Watch(watchCtx, prefix)
+
+	data, err := s.GetPrefix(ctx, prefix, 0)
+	if err != nil {
+		return err
+	}
+	eps := Endpoints{}
+	for key := range data {
+		eps.Add(utils.Tail(key))
+	}
+	select {
+	case ch <- eps.ToSlice():
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	for event := range watch {
+		endpoint := utils.Tail(event.Key)
+		var changed bool
+		if event.Type == EventPut {
+			changed = eps.Add(endpoint)
+		} else {
+			changed = eps.Remove(endpoint)
+		}
+		if changed {
+			select {
+			case ch <- eps.ToSlice():
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+	}
+	return types.ErrMessageChanClosed
 }
 
 type Endpoints map[string]struct{}

--- a/store/common/service.go
+++ b/store/common/service.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"cmp"
 	"context"
 	"fmt"
 	"maps"
@@ -19,22 +18,9 @@ func (s *Store) ServiceStatusStream(ctx context.Context) (chan []string, error) 
 	prefix := fmt.Sprintf(ServiceStatusKey, "")
 	if err := s.Pool.Invoke(func() {
 		defer close(ch)
-		retryInterval := cmp.Or(s.Config.ConnectionTimeout, time.Second)
-		for ctx.Err() == nil {
-			if err := s.serviceStatusStream(ctx, prefix, ch); err != nil && ctx.Err() == nil {
-				logger.Error(ctx, err, "service status stream interrupted")
-			}
-			if ctx.Err() != nil {
-				return
-			}
-			timer := time.NewTimer(retryInterval)
-			select {
-			case <-ctx.Done():
-				timer.Stop()
-				return
-			case <-timer.C:
-			}
-		}
+		s.watchRetry(ctx, logger, func(ctx context.Context) error {
+			return s.serviceStatusStream(ctx, prefix, ch)
+		})
 	}); err != nil {
 		return nil, err
 	}

--- a/store/common/service.go
+++ b/store/common/service.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"maps"
@@ -26,9 +27,17 @@ func (s *Store) ServiceStatusStream(ctx context.Context) (chan []string, error) 
 	prefix := fmt.Sprintf(ServiceStatusKey, "")
 	if err := s.Pool.Invoke(func() {
 		defer close(ch)
-		s.watchRetry(ctx, logger, func(ctx context.Context) error {
-			return s.serviceStatusStream(ctx, prefix, ch)
-		})
+		retryInterval := cmp.Or(s.Config.ConnectionTimeout, time.Second)
+		for ctx.Err() == nil {
+			if err := s.serviceStatusStream(ctx, prefix, ch); err != nil && ctx.Err() == nil {
+				logger.Error(ctx, err, "service status stream interrupted")
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(retryInterval):
+			}
+		}
 	}); err != nil {
 		return nil, err
 	}
@@ -73,18 +82,6 @@ func (s *Store) serviceStatusStream(ctx context.Context, prefix string, ch chan<
 	return types.ErrMessageChanClosed
 }
 
-func (s *Store) getServiceEndpoints(ctx context.Context, prefix string) (Endpoints, error) {
-	data, err := s.GetPrefix(ctx, prefix, 0)
-	if err != nil {
-		return nil, err
-	}
-	eps := Endpoints{}
-	for key := range data {
-		eps.Add(utils.Tail(key))
-	}
-	return eps, nil
-}
-
 type Endpoints map[string]struct{}
 
 func (e Endpoints) Add(endpoint string) (changed bool) {
@@ -105,4 +102,16 @@ func (e Endpoints) Remove(endpoint string) (changed bool) {
 
 func (e Endpoints) ToSlice() []string {
 	return slices.Collect(maps.Keys(e))
+}
+
+func (s *Store) getServiceEndpoints(ctx context.Context, prefix string) (Endpoints, error) {
+	data, err := s.GetPrefix(ctx, prefix, 0)
+	if err != nil {
+		return nil, err
+	}
+	eps := Endpoints{}
+	for key := range data {
+		eps.Add(utils.Tail(key))
+	}
+	return eps, nil
 }

--- a/store/common/service_test.go
+++ b/store/common/service_test.go
@@ -1,0 +1,59 @@
+package common
+
+import (
+	"context"
+	"iter"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/projecteru2/core/types"
+	"github.com/projecteru2/core/utils"
+)
+
+func TestServiceStatusStreamRecoversAfterSnapshotFailure(t *testing.T) {
+	pool, err := utils.NewPool(1)
+	require.NoError(t, err)
+	defer pool.Release()
+	ctx, cancel := context.WithCancel(context.Background())
+	store := New(&recoveringServiceKV{}, types.Config{ConnectionTimeout: time.Millisecond}, pool)
+
+	ch, err := store.ServiceStatusStream(ctx)
+	require.NoError(t, err)
+	select {
+	case endpoints, ok := <-ch:
+		require.True(t, ok)
+		assert.Equal(t, []string{"127.0.0.1:5001"}, endpoints)
+	case <-time.After(time.Second):
+		t.Fatal("service status stream did not recover")
+	}
+	cancel()
+	select {
+	case _, ok := <-ch:
+		assert.False(t, ok)
+	case <-time.After(time.Second):
+		t.Fatal("service status stream did not stop")
+	}
+}
+
+type recoveringServiceKV struct {
+	KV
+
+	reads atomic.Int32
+}
+
+func (k *recoveringServiceKV) GetPrefix(context.Context, string, int64) (map[string]string, error) {
+	if k.reads.Add(1) == 1 {
+		return nil, types.ErrMockError
+	}
+	return map[string]string{"/services/127.0.0.1:5001": ""}, nil
+}
+
+func (k *recoveringServiceKV) Watch(ctx context.Context, _ string) iter.Seq[Event] {
+	return func(func(Event) bool) {
+		<-ctx.Done()
+	}
+}

--- a/store/common/workload.go
+++ b/store/common/workload.go
@@ -128,25 +128,35 @@ func (s *Store) WorkloadStatusStream(ctx context.Context, appname, entrypoint, n
 			logger.Info(ctx, "close WorkloadStatus channel")
 			close(ch)
 		}()
-
-		logger.Infof(ctx, "watch on %s", statusKey)
-		for event := range s.Watch(ctx, statusKey) {
-			_, _, _, ID := ParseStatusKey(event.Key)
-			msg := &types.WorkloadStatus{ID: ID, Delete: event.Type != EventPut}
-			workload, err := s.GetWorkload(ctx, ID)
-			switch {
-			case err != nil:
-				msg.Error = err
-			case utils.LabelsFilter(workload.Labels, labels):
-				logger.Debugf(ctx, "workload %s status changed", workload.ID)
-				msg.Workload = workload
-			default:
-				continue
-			}
-			ch <- msg
-		}
+		s.watchRetry(ctx, logger, func(ctx context.Context) error {
+			return s.workloadStatusStream(ctx, logger, statusKey, labels, ch)
+		})
 	})
 	return ch
+}
+
+func (s *Store) workloadStatusStream(ctx context.Context, logger *log.Fields, statusKey string, labels map[string]string, ch chan<- *types.WorkloadStatus) error {
+	logger.Infof(ctx, "watch on %s", statusKey)
+	for event := range s.Watch(ctx, statusKey) {
+		_, _, _, ID := ParseStatusKey(event.Key)
+		msg := &types.WorkloadStatus{ID: ID, Delete: event.Type != EventPut}
+		workload, err := s.GetWorkload(ctx, ID)
+		switch {
+		case err != nil:
+			msg.Error = err
+		case utils.LabelsFilter(workload.Labels, labels):
+			logger.Debugf(ctx, "workload %s status changed", workload.ID)
+			msg.Workload = workload
+		default:
+			continue
+		}
+		select {
+		case ch <- msg:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return types.ErrMessageChanClosed
 }
 
 func (s *Store) filterWorkloads(ctx context.Context, data, labels map[string]string) ([]*types.Workload, error) {

--- a/store/common/workload.go
+++ b/store/common/workload.go
@@ -128,9 +128,9 @@ func (s *Store) WorkloadStatusStream(ctx context.Context, appname, entrypoint, n
 			logger.Info(ctx, "close WorkloadStatus channel")
 			close(ch)
 		}()
-		s.watchRetry(ctx, logger, func(ctx context.Context) error {
-			return s.workloadStatusStream(ctx, logger, statusKey, labels, ch)
-		})
+		if err := s.workloadStatusStream(ctx, logger, statusKey, labels, ch); err != nil && ctx.Err() == nil {
+			logger.Error(ctx, err, "workload status stream interrupted")
+		}
 	})
 	return ch
 }

--- a/store/common/workload_test.go
+++ b/store/common/workload_test.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -12,27 +11,25 @@ import (
 	"github.com/projecteru2/core/utils"
 )
 
-func TestWorkloadStatusStreamRecoversAfterWatchFailure(t *testing.T) {
+func TestWorkloadStatusStreamClosesWhenWatchBreaks(t *testing.T) {
 	pool, err := utils.NewPool(1)
 	require.NoError(t, err)
 	defer pool.Release()
-	ctx, cancel := context.WithCancel(context.Background())
-	store := New(&recoveringWatchKV{key: "wid1"}, types.Config{ConnectionTimeout: time.Millisecond}, pool)
+	store := New(&brokenWatchKV{key: "wid1"}, types.Config{ConnectionTimeout: time.Millisecond}, pool)
 
-	ch := store.WorkloadStatusStream(ctx, "app", "entry", "node1", nil)
+	ch := store.WorkloadStatusStream(t.Context(), "app", "entry", "node1", nil)
 	select {
 	case msg, ok := <-ch:
 		require.True(t, ok)
 		assert.Equal(t, "wid1", msg.ID)
 		assert.Error(t, msg.Error)
 	case <-time.After(time.Second):
-		t.Fatal("workload status stream did not recover")
+		t.Fatal("workload status stream delivered nothing")
 	}
-	cancel()
 	select {
 	case _, ok := <-ch:
 		assert.False(t, ok)
 	case <-time.After(time.Second):
-		t.Fatal("workload status stream did not stop")
+		t.Fatal("workload status stream did not close after the watch broke")
 	}
 }

--- a/store/common/workload_test.go
+++ b/store/common/workload_test.go
@@ -1,0 +1,38 @@
+package common
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/projecteru2/core/types"
+	"github.com/projecteru2/core/utils"
+)
+
+func TestWorkloadStatusStreamRecoversAfterWatchFailure(t *testing.T) {
+	pool, err := utils.NewPool(1)
+	require.NoError(t, err)
+	defer pool.Release()
+	ctx, cancel := context.WithCancel(context.Background())
+	store := New(&recoveringWatchKV{key: "wid1"}, types.Config{ConnectionTimeout: time.Millisecond}, pool)
+
+	ch := store.WorkloadStatusStream(ctx, "app", "entry", "node1", nil)
+	select {
+	case msg, ok := <-ch:
+		require.True(t, ok)
+		assert.Equal(t, "wid1", msg.ID)
+		assert.Error(t, msg.Error)
+	case <-time.After(time.Second):
+		t.Fatal("workload status stream did not recover")
+	}
+	cancel()
+	select {
+	case _, ok := <-ch:
+		assert.False(t, ok)
+	case <-time.After(time.Second):
+		t.Fatal("workload status stream did not stop")
+	}
+}

--- a/store/etcdv3/meta/ephemeral.go
+++ b/store/etcdv3/meta/ephemeral.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/projecteru2/core/log"
 	"github.com/projecteru2/core/types"
+	"github.com/projecteru2/core/utils"
 )
 
 func (e *ETCD) StartEphemeral(ctx context.Context, path string, heartbeat time.Duration) (<-chan struct{}, func(), error) {
@@ -36,9 +37,6 @@ func (e *ETCD) StartEphemeral(ctx context.Context, path string, heartbeat time.D
 	wg.Go(func() {
 		defer close(expiry)
 
-		tick := time.NewTicker(heartbeat / 3)
-		defer tick.Stop()
-
 		defer func() {
 			revokeCtx, revokeCancel := context.WithTimeout(context.WithoutCancel(ctx), time.Minute)
 			defer revokeCancel()
@@ -47,17 +45,13 @@ func (e *ETCD) StartEphemeral(ctx context.Context, path string, heartbeat time.D
 			}
 		}()
 
-		for {
-			select {
-			case <-tick.C:
-				if _, err := e.cliv3.KeepAliveOnce(ctx, lease.ID); err != nil {
-					logger.Errorf(ctx, err, "keepalive %d with %s failed", lease.ID, path)
-					return
-				}
-			case <-ctx.Done():
-				return
+		_ = utils.KeepAlive(ctx, heartbeat/3, func(ctx context.Context) error {
+			if _, err := e.cliv3.KeepAliveOnce(ctx, lease.ID); err != nil {
+				logger.Errorf(ctx, err, "keepalive %d with %s failed", lease.ID, path)
+				return err
 			}
-		}
+			return nil
+		})
 	})
 
 	return expiry, func() {

--- a/store/mocks/Store.go
+++ b/store/mocks/Store.go
@@ -1046,6 +1046,68 @@ func (_c *Store_GetPrefix_Call) RunAndReturn(run func(ctx context.Context, prefi
 	return _c
 }
 
+// GetServiceStatus provides a mock function for the type Store
+func (_mock *Store) GetServiceStatus(context1 context.Context) ([]string, error) {
+	ret := _mock.Called(context1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetServiceStatus")
+	}
+
+	var r0 []string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) ([]string, error)); ok {
+		return returnFunc(context1)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) []string); ok {
+		r0 = returnFunc(context1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(context1)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Store_GetServiceStatus_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetServiceStatus'
+type Store_GetServiceStatus_Call struct {
+	*mock.Call
+}
+
+// GetServiceStatus is a helper method to define mock.On call
+//   - context1 context.Context
+func (_e *Store_Expecter) GetServiceStatus(context1 any) *Store_GetServiceStatus_Call {
+	return &Store_GetServiceStatus_Call{Call: _e.mock.On("GetServiceStatus", context1)}
+}
+
+func (_c *Store_GetServiceStatus_Call) Run(run func(context1 context.Context)) *Store_GetServiceStatus_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *Store_GetServiceStatus_Call) Return(strings []string, err error) *Store_GetServiceStatus_Call {
+	_c.Call.Return(strings, err)
+	return _c
+}
+
+func (_c *Store_GetServiceStatus_Call) RunAndReturn(run func(context1 context.Context) ([]string, error)) *Store_GetServiceStatus_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetWorkload provides a mock function for the type Store
 func (_mock *Store) GetWorkload(ctx context.Context, ID string) (*types.Workload, error) {
 	ret := _mock.Called(ctx, ID)

--- a/store/redis/ephemeral.go
+++ b/store/redis/ephemeral.go
@@ -6,15 +6,29 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
+	goredis "github.com/redis/go-redis/v9"
 
 	"github.com/projecteru2/core/log"
 	"github.com/projecteru2/core/types"
+	"github.com/projecteru2/core/utils"
 )
 
-const ephemeralValue = "__aaron__"
+var (
+	refreshEphemeralScript = goredis.NewScript(`
+if redis.call("get", KEYS[1]) == ARGV[1] then
+    return redis.call("pexpire", KEYS[1], ARGV[2])
+end
+return 0`)
+	revokeEphemeralScript = goredis.NewScript(`
+if redis.call("get", KEYS[1]) == ARGV[1] then
+    return redis.call("del", KEYS[1])
+end
+return 0`)
+)
 
 func (r *Rediaron) StartEphemeral(ctx context.Context, path string, heartbeat time.Duration) (<-chan struct{}, func(), error) {
-	set, err := r.cli.SetNX(ctx, path, ephemeralValue, heartbeat).Result()
+	token := utils.RandomID()
+	set, err := r.cli.SetNX(ctx, path, token, heartbeat).Result()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -37,19 +51,19 @@ func (r *Rediaron) StartEphemeral(ctx context.Context, path string, heartbeat ti
 		for {
 			select {
 			case <-tick.C:
-				if err := r.refreshEphemeral(ctx, path, heartbeat); err != nil {
-					r.revokeEphemeral(ctx, path)
+				if err := r.refreshEphemeral(ctx, path, token, heartbeat); err != nil {
+					r.revokeEphemeral(ctx, path, token)
 					return
 				}
 			case <-ctx.Done():
-				r.revokeEphemeral(ctx, path)
+				r.revokeEphemeral(ctx, path, token)
 				return
 			}
 		}
 	}); err != nil {
 		wg.Done()
 		cancel()
-		r.revokeEphemeral(ctx, path)
+		r.revokeEphemeral(ctx, path, token)
 		return nil, nil, err
 	}
 
@@ -59,17 +73,23 @@ func (r *Rediaron) StartEphemeral(ctx context.Context, path string, heartbeat ti
 	}, nil
 }
 
-func (r *Rediaron) revokeEphemeral(ctx context.Context, path string) {
+func (r *Rediaron) revokeEphemeral(ctx context.Context, path, token string) {
 	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Second)
 	defer cancel()
-	if _, err := r.cli.Del(ctx, path).Result(); err != nil {
+	if _, err := revokeEphemeralScript.Run(ctx, r.cli, []string{path}, token).Result(); err != nil {
 		log.WithFunc("store.redis.revokeEphemeral").Errorf(ctx, err, "revoke %s failed", path)
 	}
 }
 
-func (r *Rediaron) refreshEphemeral(ctx context.Context, path string, ttl time.Duration) error {
+func (r *Rediaron) refreshEphemeral(ctx context.Context, path, token string, ttl time.Duration) error {
 	ctx, cancel := context.WithTimeout(ctx, time.Second)
 	defer cancel()
-	_, err := r.cli.Expire(ctx, path, ttl).Result()
-	return err
+	refreshed, err := refreshEphemeralScript.Run(ctx, r.cli, []string{path}, token, max(ttl.Milliseconds(), int64(1))).Int()
+	if err != nil {
+		return err
+	}
+	if refreshed == 0 {
+		return errors.Wrap(types.ErrKeyNotExists, path)
+	}
+	return nil
 }

--- a/store/redis/ephemeral.go
+++ b/store/redis/ephemeral.go
@@ -44,22 +44,10 @@ func (r *Rediaron) StartEphemeral(ctx context.Context, path string, heartbeat ti
 	if err := r.Pool.Invoke(func() {
 		defer wg.Done()
 		defer close(expiry)
-
-		tick := time.NewTicker(heartbeat / 3)
-		defer tick.Stop()
-
-		for {
-			select {
-			case <-tick.C:
-				if err := r.refreshEphemeral(ctx, path, token, heartbeat); err != nil {
-					r.revokeEphemeral(ctx, path, token)
-					return
-				}
-			case <-ctx.Done():
-				r.revokeEphemeral(ctx, path, token)
-				return
-			}
-		}
+		defer r.revokeEphemeral(ctx, path, token)
+		_ = utils.KeepAlive(ctx, heartbeat/3, func(ctx context.Context) error {
+			return r.refreshEphemeral(ctx, path, token, heartbeat)
+		})
 	}); err != nil {
 		wg.Done()
 		cancel()

--- a/store/redis/ephemeral_test.go
+++ b/store/redis/ephemeral_test.go
@@ -60,7 +60,7 @@ func (s *RediaronTestSuite) TestEphemeralDeregister() {
 
 	v, err := s.rediaron.GetOne(ctx, path)
 	s.NoError(err)
-	s.Equal(ephemeralValue, v)
+	s.NotEmpty(v)
 
 	stop()
 	v, err = s.rediaron.GetOne(ctx, path)
@@ -79,12 +79,12 @@ func (s *RediaronTestSuite) TestEphemeral() {
 
 	v, err := s.rediaron.GetOne(ctx, path)
 	s.NoError(err)
-	s.Equal(ephemeralValue, v)
+	s.NotEmpty(v)
 
 	time.Sleep(heartbeat * 2)
 	v, err = s.rediaron.GetOne(ctx, path)
 	s.NoError(err)
-	s.Equal(ephemeralValue, v)
+	s.NotEmpty(v)
 
 	select {
 	case <-expiry:
@@ -118,4 +118,26 @@ func (s *RediaronTestSuite) TestEphemeralFailedAsPutAlready() {
 
 	_, _, err = s.rediaron.StartEphemeral(ctx, path, heartbeat)
 	s.Error(err)
+}
+
+func (s *RediaronTestSuite) TestEphemeralStopsAfterOwnershipChanges() {
+	ctx := context.Background()
+	path := "/ident"
+	heartbeat := 90 * time.Millisecond
+	expiry, stop, err := s.rediaron.StartEphemeral(ctx, path, heartbeat)
+	s.Require().NoError(err)
+
+	replacement := utils.RandomID()
+	s.Require().NoError(s.rediaron.cli.Set(ctx, path, replacement, time.Second).Err())
+
+	select {
+	case <-expiry:
+	case <-time.After(time.Second):
+		s.FailNow("lease ownership loss was not reported")
+	}
+	stop()
+
+	value, err := s.rediaron.GetOne(ctx, path)
+	s.NoError(err)
+	s.Equal(replacement, value)
 }

--- a/store/redis/rediaron.go
+++ b/store/redis/rediaron.go
@@ -73,13 +73,14 @@ func (r *Rediaron) KNotify(ctx context.Context, pattern string) chan *KNotifyMes
 	prefix := fmt.Sprintf(keyNotifyPrefix, r.Config.Redis.DB, "")
 	channel := fmt.Sprintf(keyNotifyPrefix, r.Config.Redis.DB, pattern)
 	pubsub := r.cli.PSubscribe(ctx, channel)
-	subC := pubsub.Channel()
+	subC := pubsub.ChannelWithSubscriptions()
 	_ = r.Pool.Invoke(func() {
 		defer close(ch)
 		defer func() {
 			_ = pubsub.Close()
 		}()
 
+		subscribed := false
 		for {
 			select {
 			case <-ctx.Done():
@@ -89,14 +90,22 @@ func (r *Rediaron) KNotify(ctx context.Context, pattern string) chan *KNotifyMes
 					logger.Warn(ctx, "channel closed, knotify returns")
 					return
 				}
-				message := &KNotifyMessage{
-					Key:    strings.TrimPrefix(v.Channel, prefix),
-					Action: strings.ToLower(v.Payload),
-				}
-				select {
-				case ch <- message:
-				case <-ctx.Done():
-					return
+				switch v := v.(type) {
+				case *redis.Subscription:
+					if subscribed {
+						return
+					}
+					subscribed = true
+				case *redis.Message:
+					message := &KNotifyMessage{
+						Key:    strings.TrimPrefix(v.Channel, prefix),
+						Action: strings.ToLower(v.Payload),
+					}
+					select {
+					case ch <- message:
+					case <-ctx.Done():
+						return
+					}
 				}
 			}
 		}

--- a/store/redis/rediaron.go
+++ b/store/redis/rediaron.go
@@ -89,9 +89,14 @@ func (r *Rediaron) KNotify(ctx context.Context, pattern string) chan *KNotifyMes
 					logger.Warn(ctx, "channel closed, knotify returns")
 					return
 				}
-				ch <- &KNotifyMessage{
+				message := &KNotifyMessage{
 					Key:    strings.TrimPrefix(v.Channel, prefix),
 					Action: strings.ToLower(v.Payload),
+				}
+				select {
+				case ch <- message:
+				case <-ctx.Done():
+					return
 				}
 			}
 		}

--- a/store/redis/rediaron_test.go
+++ b/store/redis/rediaron_test.go
@@ -111,6 +111,30 @@ func (s *RediaronTestSuite) TestKeyNotify() {
 	s.Equal(messages[2].Action, "del")
 }
 
+func (s *RediaronTestSuite) TestKeyNotifyCancellationUnblocksPendingMessage() {
+	ctx, cancel := context.WithCancel(context.Background())
+	ch := s.rediaron.KNotify(ctx, "a*")
+	s.Require().Eventually(func() bool {
+		count, err := s.rediaron.cli.PubSubNumPat(context.Background()).Result()
+		return err == nil && count > 0
+	}, time.Second, 10*time.Millisecond)
+
+	triggerMockedKeyspaceNotification(s.rediaron.cli, "aaa", actionSet)
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	s.Require().Eventually(func() bool {
+		count, err := s.rediaron.cli.PubSubNumPat(context.Background()).Result()
+		return err == nil && count == 0
+	}, time.Second, 10*time.Millisecond)
+
+	select {
+	case _, ok := <-ch:
+		s.False(ok)
+	case <-time.After(time.Second):
+		s.FailNow("key notification did not stop")
+	}
+}
+
 func triggerMockedKeyspaceNotification(cli *redis.Client, key, action string) {
 	channel := fmt.Sprintf(keyNotifyPrefix, 0, key)
 	cli.Publish(context.Background(), channel, action).Result()

--- a/store/redis/service_test.go
+++ b/store/redis/service_test.go
@@ -19,7 +19,7 @@ func (s *RediaronTestSuite) TestRegisterServiceWithDeregister() {
 
 	v, err := m.GetOne(ctx, path)
 	s.NoError(err)
-	s.Equal(ephemeralValue, v)
+	s.NotEmpty(v)
 
 	deregister()
 	v, err = m.GetOne(ctx, path)

--- a/store/redis/service_test.go
+++ b/store/redis/service_test.go
@@ -61,3 +61,34 @@ func (s *RediaronTestSuite) TestServiceStatusStream() {
 	s.rediserver.FastForward(time.Second)
 	s.Equal(<-ch, []string{"127.0.0.1:5002"})
 }
+
+func (s *RediaronTestSuite) TestServiceStatusStreamResnapshotsAfterReconnect() {
+	ctx, cancel := context.WithCancel(s.T().Context())
+	defer cancel()
+	key := fmt.Sprintf(common.ServiceStatusKey, "127.0.0.1:5001")
+	s.Require().NoError(s.rediserver.Set(key, "token"))
+
+	ch, err := s.rediaron.ServiceStatusStream(ctx)
+	s.Require().NoError(err)
+	select {
+	case endpoints := <-ch:
+		s.Equal([]string{"127.0.0.1:5001"}, endpoints)
+	case <-time.After(time.Second):
+		s.FailNow("service status stream did not start")
+	}
+
+	s.Require().Eventually(func() bool {
+		count, err := s.rediaron.cli.PubSubNumPat(ctx).Result()
+		return err == nil && count > 0
+	}, time.Second, 10*time.Millisecond)
+	s.rediserver.Close()
+	s.True(s.rediserver.Del(key))
+	s.Require().NoError(s.rediserver.Restart())
+
+	select {
+	case endpoints := <-ch:
+		s.Empty(endpoints)
+	case <-time.After(5 * time.Second):
+		s.FailNow("service status stream did not resnapshot")
+	}
+}

--- a/store/store.go
+++ b/store/store.go
@@ -16,6 +16,7 @@ type Store interface {
 	GetPrefix(ctx context.Context, prefix string, limit int64) (map[string]string, error)
 	ListPrefix(ctx context.Context, prefix string) ([]string, error)
 
+	GetServiceStatus(context.Context) ([]string, error)
 	ServiceStatusStream(context.Context) (chan []string, error)
 	RegisterService(context.Context, string, time.Duration) (<-chan struct{}, func(), error)
 

--- a/types/errors.go
+++ b/types/errors.go
@@ -90,6 +90,7 @@ var (
 
 	ErrNoFilesToSend = errors.New("no files to send")
 	ErrNoFilesToCopy = errors.New("no files to copy")
+	ErrEmptyFileDst  = errors.New("empty file destination")
 
 	ErrMockError = errors.New("mock error")
 

--- a/types/options.go
+++ b/types/options.go
@@ -277,7 +277,7 @@ func (o *SendLargeFileOptions) Validate() error {
 	if len(o.IDs) == 0 {
 		return ErrNoWorkloadIDs
 	}
-	if len(o.Chunk) == 0 {
+	if o.Dst == "" {
 		return ErrNoFilesToSend
 	}
 	if o.UID == 0 && o.GID == 0 && o.Mode == 0 {

--- a/types/options.go
+++ b/types/options.go
@@ -278,7 +278,7 @@ func (o *SendLargeFileOptions) Validate() error {
 		return ErrNoWorkloadIDs
 	}
 	if o.Dst == "" {
-		return ErrNoFilesToSend
+		return ErrEmptyFileDst
 	}
 	if o.UID == 0 && o.GID == 0 && o.Mode == 0 {
 		o.Mode = 0o755

--- a/types/options_test.go
+++ b/types/options_test.go
@@ -94,6 +94,20 @@ func TestSendOptions(t *testing.T) {
 	assert.NoError(o.Validate())
 }
 
+func TestSendLargeFileOptions(t *testing.T) {
+	assert := assert.New(t)
+
+	o := &SendLargeFileOptions{}
+	assert.Equal(ErrNoWorkloadIDs, o.Validate())
+
+	o.IDs = []string{"workload_id1"}
+	assert.Equal(ErrNoFilesToSend, o.Validate())
+
+	o.Dst = "/tmp/empty"
+	assert.NoError(o.Validate())
+	assert.EqualValues(0o755, o.Mode)
+}
+
 func TestReplaceOptions(t *testing.T) {
 	assert := assert.New(t)
 

--- a/types/options_test.go
+++ b/types/options_test.go
@@ -101,7 +101,7 @@ func TestSendLargeFileOptions(t *testing.T) {
 	assert.Equal(ErrNoWorkloadIDs, o.Validate())
 
 	o.IDs = []string{"workload_id1"}
-	assert.Equal(ErrNoFilesToSend, o.Validate())
+	assert.Equal(ErrEmptyFileDst, o.Validate())
 
 	o.Dst = "/tmp/empty"
 	assert.NoError(o.Validate())

--- a/utils/context.go
+++ b/utils/context.go
@@ -2,7 +2,24 @@ package utils
 
 import (
 	"context"
+	"time"
 )
+
+// KeepAlive calls refresh every interval until ctx ends or refresh fails, returning the failure.
+func KeepAlive(ctx context.Context, interval time.Duration, refresh func(context.Context) error) error {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			if err := refresh(ctx); err != nil {
+				return err
+			}
+		}
+	}
+}
 
 // NewInheritCtx returns ctx with its values but without its cancellation.
 func NewInheritCtx(ctx context.Context) context.Context {

--- a/utils/transaction.go
+++ b/utils/transaction.go
@@ -13,7 +13,7 @@ type (
 	rollbackFunc func(context.Context, bool) error
 )
 
-// Txn runs cond then then; on any error it runs rollback under a fresh ttl-bounded context, and settled reports full compensation.
+// Txn runs cond then then, rolling back under a fresh ttl-bounded context on error; settled reports full compensation.
 func Txn(ctx context.Context, cond, then contextFunc, rollback rollbackFunc, ttl time.Duration) (settled bool, txnErr error) {
 	var condErr, thenErr error
 	txnCtx, txnCancel := context.WithTimeout(ctx, ttl)

--- a/utils/transaction.go
+++ b/utils/transaction.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"cmp"
 	"context"
 	"time"
 
@@ -12,18 +13,16 @@ type (
 	rollbackFunc func(context.Context, bool) error
 )
 
-// Txn runs cond then then; on any error it runs rollback under a fresh ttl-bounded context.
-func Txn(ctx context.Context, cond, then contextFunc, rollback rollbackFunc, ttl time.Duration) (txnErr error) {
+// Txn runs cond then then; on any error it runs rollback under a fresh ttl-bounded context, and settled reports full compensation.
+func Txn(ctx context.Context, cond, then contextFunc, rollback rollbackFunc, ttl time.Duration) (settled bool, txnErr error) {
 	var condErr, thenErr error
 	txnCtx, txnCancel := context.WithTimeout(ctx, ttl)
 	defer txnCancel()
 	logger := log.WithFunc("utils.Txn")
 	defer func() {
-		txnErr = condErr
+		txnErr = cmp.Or(condErr, thenErr)
 		if txnErr == nil {
-			txnErr = thenErr
-		}
-		if txnErr == nil {
+			settled = true
 			return
 		}
 		if rollback == nil {
@@ -39,7 +38,9 @@ func Txn(ctx context.Context, cond, then contextFunc, rollback rollbackFunc, ttl
 		failureByCond := condErr != nil
 		if err := rollback(rollbackCtx, failureByCond); err != nil {
 			logger.Warnf(ctx, "txn failed but rollback also failed: %+v", err)
+			return
 		}
+		settled = true
 	}()
 
 	if cond != nil {
@@ -56,15 +57,16 @@ func Txn(ctx context.Context, cond, then contextFunc, rollback rollbackFunc, ttl
 		thenErr = then(thenCtx)
 	}
 
-	return txnErr
+	return settled, txnErr
 }
 
 // PCR runs prepare, commit and rollback; prepare must be side-effect free.
 func PCR(ctx context.Context, prepare, commit, rollback contextFunc, ttl time.Duration) error {
-	return Txn(ctx, prepare, commit, func(ctx context.Context, failureByCond bool) error {
+	_, err := Txn(ctx, prepare, commit, func(ctx context.Context, failureByCond bool) error {
 		if !failureByCond && rollback != nil {
 			return rollback(ctx)
 		}
 		return nil
 	}, ttl)
+	return err
 }

--- a/utils/transaction_test.go
+++ b/utils/transaction_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestTxn(t *testing.T) {
 	err1 := errors.New("err1")
-	err := Txn(
+	settled, err := Txn(
 		t.Context(),
 		func(context.Context) error {
 			return err1
@@ -24,7 +24,21 @@ func TestTxn(t *testing.T) {
 		10*time.Second,
 	)
 	assert.Contains(t, err.Error(), err1.Error())
-	err = Txn(
+	assert.False(t, settled)
+	settled, err = Txn(
+		t.Context(),
+		func(context.Context) error {
+			return err1
+		},
+		nil,
+		func(context.Context, bool) error {
+			return nil
+		},
+		10*time.Second,
+	)
+	assert.Contains(t, err.Error(), err1.Error())
+	assert.True(t, settled)
+	settled, err = Txn(
 		t.Context(),
 		func(context.Context) error {
 			return nil
@@ -36,7 +50,8 @@ func TestTxn(t *testing.T) {
 		10*time.Second,
 	)
 	assert.Contains(t, err.Error(), err1.Error())
-	err = Txn(
+	assert.False(t, settled)
+	settled, err = Txn(
 		t.Context(),
 		func(context.Context) error {
 			return nil
@@ -46,6 +61,7 @@ func TestTxn(t *testing.T) {
 		10*time.Second,
 	)
 	assert.NoError(t, err)
+	assert.True(t, settled)
 }
 
 func TestPCR(t *testing.T) {


### PR DESCRIPTION
## Summary

This is the whole-repository closure pass against master 739fb722, in two rounds: thirteen production-reachable recovery fixes, then a multi-angle review of the branch itself whose confirmed findings were closed in thirteen follow-up commits — the remap persistence design was reworked rather than patched.

Round one:

1. Renew Redis distributed locks and cancel the protected context on lease loss.
2. Fence Redis ephemeral refresh and revoke operations with a per-owner token.
3. Keep create recovery journals until the transaction succeeds or rollback fully completes.
4. Return successful node-capacity before and after values.
5. Keep realloc journals until resource and workload-store compensation completes.
6. Retain create journals on transient store reads and retry recovery.
7. Retain replacement journals until the old workload is actually removed.
8. Journal resource remaps and replay them until the runtime converges.
9. Rebuild interrupted service-status watches and make Redis watch cancellation non-blocking.
10. Update existing containerd image references to the new target.
11. Validate Send requests and emit a real zero-length file chunk.
12. Preserve output tokens beyond bufio.Scanner's default limit.
13. Create traversable containerd build directories.

Round two (review closure):

1. Rework remaps: journal only the node name, skip the journal when remap yields nothing, replay by recomputing under the node operation lock, and never persist remap output into the workload record — persisting the plugin subset truncated stored engine params, raced realloc under disjoint locks, and replayed stale snapshots.
2. Bound output-stream tokens by the configured gRPC message cap instead of math.MaxInt.
3. Tolerate transient lock refresh errors within one ttl, then fence; only a genuinely lost lease cancels immediately.
4. Keep status watch breaks visible: node and workload streams close on a broken watch again (their consumers resync on close) and the rpc handlers return an error instead of a clean end; service status keeps its retry since each round re-reads the full snapshot.
5. Take over dead journals from a freshly read service list each heartbeat, skipping empty lists, instead of a cached stream snapshot that goes stale across watch gaps.
6. Accept empty chunks in SendLargeFile so zero-byte files behave the same as through Send, and name the empty-destination error.
7. Txn reports rollback settlement, replacing three hand-rolled completion bools.
8. One keepalive ticker loop shared by the redis lock and both ephemeral registrations.

## Recovery invariants

- A WAL entry is removed only after success or complete compensation.
- Retained entries replay idempotently and treat already-absent terminal objects as converged.
- Remap replay recomputes from live state; the journal carries intent, never computed snapshots.
- Lock and ephemeral ownership loss cannot silently extend or revoke another owner, and a full ttl without a successful refresh fences the holder.
- Event-stream interruptions stay visible to consumers; snapshot streams reconnect and re-read.

## Verification

- GOWORK=off GOOS=darwin asl ./...
- GOWORK=off GOOS=linux asl ./...
- GOWORK=off GOOSES=darwin make fmt-check
- GOWORK=off GOOSES=linux make fmt-check
- GOWORK=off GOOSES=darwin make lint
- GOWORK=off GOOSES=linux make lint
- GOWORK=off GOOSES=darwin make vet
- GOWORK=off GOOSES=linux make vet
- GOWORK=off go test -race -timeout 600s -count=1 ./...
- git diff --check origin/master...HEAD

Production diff: +427/-197 lines. Test diff: +754/-66 lines. Regenerated mocks: +64/-4.
