### PR TITLE
fix: retry an ssh forward the server refused

### DIFF
--- a/engine/sshrunner/ssh.go
+++ b/engine/sshrunner/ssh.go
@@ -25,6 +25,9 @@ const (
 	ptyWidth  = 80
 	// sshd's default MaxSessions is 10; queue past that instead of being refused.
 	maxSessions = 8
+
+	dialRetries       = 2
+	dialRetryInterval = 100 * time.Millisecond
 )
 
 var _ Runner = (*sshRunner)(nil)
@@ -132,7 +135,9 @@ func (r *sshRunner) Files(ctx context.Context) (Files, error) {
 
 // Dial forwards a node socket; a forward is not a session, so MaxSessions does not bound it.
 func (r *sshRunner) Dial(ctx context.Context, network, addr string) (net.Conn, error) {
-	return retry(ctx, r, func(client *ssh.Client) (net.Conn, error) { return client.Dial(network, addr) })
+	return retryRefused(ctx, func() (net.Conn, error) {
+		return retry(ctx, r, func(client *ssh.Client) (net.Conn, error) { return client.Dial(network, addr) })
+	})
 }
 
 func (r *sshRunner) Close() error {
@@ -295,15 +300,35 @@ func retry[T any](ctx context.Context, r *sshRunner, f func(*ssh.Client) (T, err
 	return f(client)
 }
 
+func retryRefused(ctx context.Context, dial func() (net.Conn, error)) (net.Conn, error) {
+	conn, err := dial()
+	for range dialRetries {
+		if err == nil || !isChannelRefused(err) {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(dialRetryInterval):
+		}
+		conn, err = dial()
+	}
+	return conn, err
+}
+
 // isTransportError separates a dead connection from sshd refusing one more channel.
 func isTransportError(err error) bool {
-	var openErr *ssh.OpenChannelError
-	if errors.As(err, &openErr) {
+	if isChannelRefused(err) {
 		return false
 	}
 	var netErr net.Error
 	return errors.Is(err, io.EOF) || errors.Is(err, net.ErrClosed) ||
 		errors.Is(err, syscall.EPIPE) || errors.Is(err, syscall.ECONNRESET) || errors.As(err, &netErr)
+}
+
+func isChannelRefused(err error) bool {
+	var openErr *ssh.OpenChannelError
+	return errors.As(err, &openErr)
 }
 
 func exitStatus(err error) (int, error) {

--- a/engine/sshrunner/ssh_test.go
+++ b/engine/sshrunner/ssh_test.go
@@ -1,14 +1,18 @@
 package sshrunner
 
 import (
+	"context"
 	"io"
 	"net"
 	"syscall"
 	"testing"
+	"testing/synctest"
 
 	"github.com/cockroachdb/errors"
 	"golang.org/x/crypto/ssh"
 )
+
+var refusedChannel = &ssh.OpenChannelError{Reason: ssh.ConnectionFailed, Message: "open failed"}
 
 func TestIsTransportError(t *testing.T) {
 	tests := []struct {
@@ -30,6 +34,54 @@ func TestIsTransportError(t *testing.T) {
 				t.Errorf("got %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestRetryRefused(t *testing.T) {
+	tests := []struct {
+		name     string
+		dials    []error
+		want     error
+		attempts int
+	}{
+		{"an accepted forward is dialled once", []error{nil}, nil, 1},
+		{"a forward the node accepts on the second try succeeds", []error{refusedChannel, nil}, nil, 2},
+		{"a forward the node keeps refusing gives up", []error{refusedChannel, refusedChannel, refusedChannel}, refusedChannel, 3},
+		{"a dead transport is not a refusal", []error{io.EOF}, io.EOF, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				attempts := 0
+				_, err := retryRefused(t.Context(), func() (net.Conn, error) {
+					attempts++
+					return nil, tt.dials[attempts-1]
+				})
+				if !errors.Is(err, tt.want) {
+					t.Errorf("got %v, want %v", err, tt.want)
+				}
+				if attempts != tt.attempts {
+					t.Errorf("got %d dials, want %d", attempts, tt.attempts)
+				}
+			})
+		})
+	}
+}
+
+func TestRetryRefusedStopsOnADoneContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	attempts := 0
+	_, err := retryRefused(ctx, func() (net.Conn, error) {
+		attempts++
+		return nil, refusedChannel
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("got %v, want a cancelled context", err)
+	}
+	if attempts != 1 {
+		t.Errorf("got %d dials, want 1", attempts)
 	}
 }
 


### PR DESCRIPTION
Fixes #680.

One create in a 100-count fan-out failed with `ssh: rejected: connect failed ("open failed")` on the containerd socket forward, and the same node accepted the next forward immediately: sshd refused one more channel under pressure while the link stayed alive. A refusal is not a transport error, so the redial path never covered it. The forward now waits 100ms and dials again, twice at most, bounded by the caller's context. Session limits stay out of scope (#670).