### PR TITLE
fix: change into the exec workdir without the env binary

### DIFF
--- a/docs/engines.md
+++ b/docs/engines.md
@@ -428,10 +428,11 @@ as stopped rather than missing.
 A scope unit has no exec context, so `Execute` cannot pass `RootDirectory=` or `--uid` as unit
 properties: it execs `chroot --userspec=<user> <merged>` for an overlay workload,
 `setpriv --reuid --regid --init-groups` for a raw one, and enters a working directory other than
-`/` with `env --chdir`, which survives the chroot. `env` resolves *inside* the new root, so only
-an exec that names such a directory requires the image to carry it — the default lands where
-`chroot` already put it and needs nothing. `ImagePush` has nothing left to do — `ImageBuildFromExist` pushes the
-artifact as it builds it.
+`/` by wrapping the command in `sh -c 'cd "$1" && shift && exec "$@"'`, which survives the chroot.
+That shell resolves *inside* the new root, so only an exec that names such a directory requires
+the image to carry one; the default lands where `chroot` already put it and needs nothing. A
+minimal bundle carries `sh` and often not `env`, which is why the shell enters the directory.
+`ImagePush` has nothing left to do — `ImageBuildFromExist` pushes the artifact as it builds it.
 
 Resources land on cgroup v2 unit properties: `AllowedCPUs`, `AllowedMemoryNodes` and `CPUWeight`
 for bound CPUs, `CPUQuota` whenever a quota is set, then `MemoryMax`, `MemoryLow` (half the

--- a/engine/process/exec.go
+++ b/engine/process/exec.go
@@ -4,12 +4,15 @@ import (
 	"cmp"
 	"context"
 	"io"
+	"slices"
 	"strings"
 
 	"github.com/projecteru2/core/engine/sshrunner"
 	enginetypes "github.com/projecteru2/core/engine/types"
 	"github.com/projecteru2/core/utils"
 )
+
+const chdirScript = `cd "$1" && shift && exec "$@"`
 
 func (e *Engine) Execute(ctx context.Context, ID string, config *enginetypes.ExecConfig) (execID string, stdout, stderr io.ReadCloser, stdin io.WriteCloser, err error) {
 	record, _, err := e.workloadMeta(ctx, ID)
@@ -57,8 +60,8 @@ func scopeArgv(record *meta, config *enginetypes.ExecConfig) []string {
 		user, group, _ := strings.Cut(config.User, ":")
 		argv = append(argv, "setpriv", "--reuid="+user, "--regid="+cmp.Or(group, user), "--init-groups", "--")
 	}
-	if config.WorkingDir != "" && config.WorkingDir != "/" {
-		argv = append(argv, "env", "--chdir="+config.WorkingDir)
+	if config.WorkingDir == "" || config.WorkingDir == "/" {
+		return append(argv, config.Cmd...)
 	}
-	return append(argv, config.Cmd...)
+	return append(argv, sshrunner.Shell(chdirScript, slices.Concat([]string{config.WorkingDir}, config.Cmd)...)...)
 }

--- a/engine/process/exec_test.go
+++ b/engine/process/exec_test.go
@@ -66,13 +66,19 @@ func TestScopeArgv(t *testing.T) {
 			[]string{"chroot", testRoot + "/w1/merged", "sh"},
 		},
 		{
-			"a working directory is entered inside the chroot",
+			"a working directory is entered inside the chroot by the shell, not by env",
 			overlay,
-			&enginetypes.ExecConfig{WorkingDir: "/srv", Cmd: []string{"sh"}},
-			[]string{"chroot", testRoot + "/w1/merged", "env", "--chdir=/srv", "sh"},
+			&enginetypes.ExecConfig{WorkingDir: "/srv", Cmd: []string{"ls", "-l"}},
+			[]string{"chroot", testRoot + "/w1/merged", "sh", "-c", chdirScript, "sh", "/srv", "ls", "-l"},
 		},
 		{
-			"the root working directory needs no env, which a minimal bundle may not carry",
+			"a working directory is entered without a chroot too",
+			raw,
+			&enginetypes.ExecConfig{WorkingDir: "/srv", Cmd: []string{"ls", "-l"}},
+			[]string{"sh", "-c", chdirScript, "sh", "/srv", "ls", "-l"},
+		},
+		{
+			"the root working directory needs no wrapper at all",
 			overlay,
 			&enginetypes.ExecConfig{WorkingDir: "/", Cmd: []string{"sh"}},
 			[]string{"chroot", testRoot + "/w1/merged", "sh"},


### PR DESCRIPTION
Remediation P2 from the 2026-08-27 full-functional run.

`workload exec --workdir /www` against a minimal busybox bundle exited 127: the scope rendered `env --chdir=/www` and the bundle carries no `env`. The wrapper is now `sh -c 'cd "$1" && shift && exec "$@"' sh <dir> <cmd…>`, needing only the shell every bundle already has, resolving inside the chroot the same way — the shape cocoon already uses. A default or `/` workdir keeps the unwrapped argv; the environment still rides on `systemd-run --setenv`. docs/engines.md updated.