### PR TITLE
fix: quiet remap of vanished workloads and skip unmoved params

### DIFF
--- a/cluster/calcium/calcium.go
+++ b/cluster/calcium/calcium.go
@@ -34,6 +34,7 @@ type Calcium struct {
 	identifier string
 	// serviceAddress is both the key RegisterService publishes and the journal's own prefix
 	serviceAddress string
+	remapped       remapMemo
 }
 
 // New returns a Calcium cluster.

--- a/cluster/calcium/remap.go
+++ b/cluster/calcium/remap.go
@@ -2,6 +2,9 @@ package calcium
 
 import (
 	"context"
+	"fmt"
+	"hash/fnv"
+	"sync"
 
 	"github.com/cockroachdb/errors"
 
@@ -34,7 +37,7 @@ func (c *Calcium) doRemapResource(ctx context.Context, logger *log.Fields, node 
 	if err != nil {
 		return err
 	}
-	if err = c.applyRemap(ctx, logger, workloads, engineParamsMap); err != nil {
+	if err = c.applyRemap(ctx, logger, node, workloads, engineParamsMap); err != nil {
 		return err
 	}
 	commit()
@@ -53,11 +56,18 @@ func (c *Calcium) computeRemap(ctx context.Context, node *types.Node) (map[strin
 	return engineParamsMap, workloads, nil
 }
 
-func (c *Calcium) applyRemap(ctx context.Context, logger *log.Fields, workloads []*types.Workload, engineParamsMap map[string]resourcetypes.Resources) error {
+func (c *Calcium) applyRemap(ctx context.Context, logger *log.Fields, node *types.Node, workloads []*types.Workload, engineParamsMap map[string]resourcetypes.Resources) error {
 	var errList []error
+	memo := c.remapped.load(node.Name)
+	applied := make(map[string]uint64, len(engineParamsMap))
 	for _, workload := range workloads {
 		engineParams, ok := engineParamsMap[workload.ID]
 		if !ok {
+			continue
+		}
+		digest := hashEngineParams(engineParams)
+		if recorded, seen := memo[workload.ID]; seen && recorded == digest {
+			applied[workload.ID] = digest
 			continue
 		}
 		logger.Infof(ctx, "remap workload ID %+v", workload.ID)
@@ -69,7 +79,36 @@ func (c *Calcium) applyRemap(ctx context.Context, logger *log.Fields, workloads 
 		case err != nil:
 			logger.Error(ctx, err)
 			errList = append(errList, err)
+		default:
+			applied[workload.ID] = digest
 		}
 	}
+	c.remapped.record(node.Name, applied)
 	return errors.Join(errList...)
+}
+
+type remapMemo struct {
+	mu     sync.Mutex
+	hashes map[string]map[string]uint64
+}
+
+func (m *remapMemo) load(nodename string) map[string]uint64 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.hashes[nodename]
+}
+
+func (m *remapMemo) record(nodename string, hashes map[string]uint64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.hashes == nil {
+		m.hashes = map[string]map[string]uint64{}
+	}
+	m.hashes[nodename] = hashes
+}
+
+func hashEngineParams(params resourcetypes.Resources) uint64 {
+	digest := fnv.New64a()
+	_, _ = fmt.Fprintf(digest, "%v", params)
+	return digest.Sum64()
 }

--- a/cluster/calcium/remap.go
+++ b/cluster/calcium/remap.go
@@ -62,7 +62,9 @@ func (c *Calcium) applyRemap(ctx context.Context, logger *log.Fields, workloads 
 		}
 		logger.Infof(ctx, "remap workload ID %+v", workload.ID)
 		switch err := workload.Engine.VirtualizationUpdateResource(ctx, workload.ID, engineParams); {
-		case errors.Is(err, types.ErrWorkloadNotExists), errors.Is(err, types.ErrEngineNotImplemented):
+		case errors.Is(err, types.ErrWorkloadNotExists):
+			logger.Debugf(ctx, "workload %s is gone, skip remap: %+v", workload.ID, err)
+		case errors.Is(err, types.ErrEngineNotImplemented):
 			logger.Warnf(ctx, "skip remap of workload %s: %+v", workload.ID, err)
 		case err != nil:
 			logger.Error(ctx, err)

--- a/cluster/calcium/remap_test.go
+++ b/cluster/calcium/remap_test.go
@@ -1,6 +1,7 @@
 package calcium
 
 import (
+	"strconv"
 	"sync/atomic"
 	"testing"
 
@@ -155,4 +156,79 @@ func TestRemapReplayRecomputesFromLiveState(t *testing.T) {
 	store.AssertExpectations(t)
 	rmgr.AssertExpectations(t)
 	engine.AssertExpectations(t)
+}
+
+func TestRemapSkipsWorkloadsWhoseParamsDidNotMove(t *testing.T) {
+	c := NewTestCluster()
+	ctx := t.Context()
+	logger := log.WithField("test", "memo")
+	params := resourcetypes.Resources{"cpumem": {"cpu": 2, "cpumap": map[string]int{"0": 100}}}
+	moved := resourcetypes.Resources{"cpumem": {"cpu": 3, "cpumap": map[string]int{"0": 100}}}
+
+	engine := &enginemocks.API{}
+	node := &types.Node{NodeMeta: types.NodeMeta{Name: "node1"}, Engine: engine}
+	workload := &types.Workload{ID: "workload1", Nodename: node.Name, Engine: engine}
+	store := c.store.(*storemocks.Store)
+	store.On("ListNodeWorkloads", mock.Anything, node.Name, mock.Anything).Return([]*types.Workload{workload}, nil)
+
+	rmgr := c.rmgr.(*resourcemocks.Manager)
+	rmgr.On("Remap", mock.Anything, node.Name, mock.Anything).Return(
+		map[string]resourcetypes.Resources{workload.ID: params}, nil,
+	).Twice()
+	engine.On("VirtualizationUpdateResource", mock.Anything, workload.ID, params).Return(nil).Once()
+
+	assert.NoError(t, c.doRemapResource(ctx, logger, node))
+	assert.NoError(t, c.doRemapResource(ctx, logger, node))
+	engine.AssertNumberOfCalls(t, "VirtualizationUpdateResource", 1)
+
+	rmgr.On("Remap", mock.Anything, node.Name, mock.Anything).Return(
+		map[string]resourcetypes.Resources{workload.ID: moved}, nil,
+	).Once()
+	engine.On("VirtualizationUpdateResource", mock.Anything, workload.ID, moved).Return(nil).Once()
+	assert.NoError(t, c.doRemapResource(ctx, logger, node))
+	engine.AssertNumberOfCalls(t, "VirtualizationUpdateResource", 2)
+	rmgr.AssertExpectations(t)
+	engine.AssertExpectations(t)
+}
+
+func TestRemapForgetsAWorkloadThatLeftTheNode(t *testing.T) {
+	c := NewTestCluster()
+	ctx := t.Context()
+	logger := log.WithField("test", "forget")
+	params := resourcetypes.Resources{"cpumem": {"cpu": 2}}
+
+	engine := &enginemocks.API{}
+	node := &types.Node{NodeMeta: types.NodeMeta{Name: "node1"}, Engine: engine}
+	first := &types.Workload{ID: "workload1", Nodename: node.Name, Engine: engine}
+	second := &types.Workload{ID: "workload2", Nodename: node.Name, Engine: engine}
+	store := c.store.(*storemocks.Store)
+	rmgr := c.rmgr.(*resourcemocks.Manager)
+	for _, workload := range []*types.Workload{first, second, first} {
+		store.On("ListNodeWorkloads", mock.Anything, node.Name, mock.Anything).Return([]*types.Workload{workload}, nil).Once()
+		rmgr.On("Remap", mock.Anything, node.Name, mock.Anything).Return(
+			map[string]resourcetypes.Resources{workload.ID: params}, nil,
+		).Once()
+	}
+	engine.On("VirtualizationUpdateResource", mock.Anything, first.ID, params).Return(nil).Twice()
+	engine.On("VirtualizationUpdateResource", mock.Anything, second.ID, params).Return(nil).Once()
+
+	for range 3 {
+		assert.NoError(t, c.doRemapResource(ctx, logger, node))
+	}
+	assert.Equal(t, map[string]uint64{first.ID: hashEngineParams(params)}, c.remapped.hashes[node.Name])
+	store.AssertExpectations(t)
+	rmgr.AssertExpectations(t)
+	engine.AssertExpectations(t)
+}
+
+func TestHashEngineParamsIsStableAcrossMapOrder(t *testing.T) {
+	params := resourcetypes.Resources{"cpumem": {}}
+	for i := range 16 {
+		params["cpumem"][strconv.Itoa(i)] = i
+	}
+	want := hashEngineParams(params)
+	for range 16 {
+		assert.Equal(t, want, hashEngineParams(params))
+	}
+	assert.NotEqual(t, want, hashEngineParams(resourcetypes.Resources{"cpumem": {"0": 0}}))
 }

--- a/cluster/calcium/remap_test.go
+++ b/cluster/calcium/remap_test.go
@@ -98,6 +98,26 @@ func TestRemapJournalRetainsUntilEngineSuccess(t *testing.T) {
 	}
 }
 
+func TestRemapDoesNotFailOnAVanishedWorkload(t *testing.T) {
+	c := NewTestCluster()
+	params := resourcetypes.Resources{"cpumem": {"cpu": 2}}
+
+	engine := &enginemocks.API{}
+	node := &types.Node{NodeMeta: types.NodeMeta{Name: "node1"}, Engine: engine}
+	workload := &types.Workload{ID: "workload1", Nodename: node.Name, Engine: engine}
+	store := c.store.(*storemocks.Store)
+	store.On("ListNodeWorkloads", mock.Anything, node.Name, mock.Anything).Return([]*types.Workload{workload}, nil).Once()
+
+	rmgr := c.rmgr.(*resourcemocks.Manager)
+	rmgr.On("Remap", mock.Anything, node.Name, mock.Anything).Return(
+		map[string]resourcetypes.Resources{workload.ID: params}, nil,
+	).Once()
+	engine.On("VirtualizationUpdateResource", mock.Anything, workload.ID, params).Return(types.ErrWorkloadNotExists).Once()
+
+	assert.NoError(t, c.doRemapResource(t.Context(), log.WithField("test", "gone"), node))
+	engine.AssertExpectations(t)
+}
+
 func TestRemapReplayRecomputesFromLiveState(t *testing.T) {
 	c := NewTestCluster()
 	enableTestWAL(t, c)

--- a/cluster/calcium/wal.go
+++ b/cluster/calcium/wal.go
@@ -262,7 +262,7 @@ func (h *remapNodeHandler) Handle(ctx context.Context, raw any) error {
 		if err != nil {
 			return err
 		}
-		return h.calcium.applyRemap(ctx, logger, workloads, engineParamsMap)
+		return h.calcium.applyRemap(ctx, logger, node, workloads, engineParamsMap)
 	})
 	if err != nil && (errors.Is(err, types.ErrNodeNotExists) || h.calcium.store.NotFound(err)) {
 		logger.Info(ctx, "node is gone, nothing to remap")

--- a/engine/containerd/lifecycle.go
+++ b/engine/containerd/lifecycle.go
@@ -218,16 +218,13 @@ func (e *Engine) VirtualizationUpdateResource(ctx context.Context, ID string, en
 	limits := resourceSpec(resource, &RawArgs{}, devices)
 	// the stored spec is what a restart replays, so both it and the live task are updated
 	if err = found.Update(ctx, withSpecResources(limits)); err != nil {
-		return err
+		return nilIfGone(err)
 	}
 	task, err := found.Task(ctx, nil)
 	if err != nil {
-		if cerrdefs.IsNotFound(err) {
-			return nil
-		}
-		return err
+		return nilIfGone(err)
 	}
-	return task.Update(ctx, client.WithResources(limits))
+	return nilIfGone(task.Update(ctx, client.WithResources(limits)))
 }
 
 // task loads the workload's running task; a workload without one cannot answer.
@@ -383,4 +380,11 @@ func userString(user specs.User) string {
 		return ""
 	}
 	return strconv.FormatUint(uint64(user.UID), 10) + ":" + strconv.FormatUint(uint64(user.GID), 10)
+}
+
+func nilIfGone(err error) error {
+	if cerrdefs.IsNotFound(err) {
+		return nil
+	}
+	return err
 }

--- a/engine/containerd/lifecycle_test.go
+++ b/engine/containerd/lifecycle_test.go
@@ -3,10 +3,16 @@ package containerd
 import (
 	"testing"
 
+	"github.com/cockroachdb/errors"
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/pkg/oci"
+	"github.com/containerd/errdefs/pkg/errgrpc"
 	"github.com/containerd/typeurl/v2"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	coretypes "github.com/projecteru2/core/types"
 )
 
 func TestUpdateKeepsTheLimitsItDoesNotOwn(t *testing.T) {
@@ -39,6 +45,16 @@ func TestUpdateKeepsTheLimitsItDoesNotOwn(t *testing.T) {
 	}
 	if updated.Linux.Resources.CPU.Cpus != "" {
 		t.Errorf("got %q, want the cpuset replaced, not merged", updated.Linux.Resources.CPU.Cpus)
+	}
+}
+
+func TestUpdateTreatsAVanishedTaskAsDone(t *testing.T) {
+	gone := errgrpc.ToNative(status.Errorf(codes.NotFound, "task w1 not found"))
+	if err := nilIfGone(gone); err != nil {
+		t.Errorf("got %v, want a task that vanished mid-update reported as done", err)
+	}
+	if err := nilIfGone(coretypes.ErrMockError); !errors.Is(err, coretypes.ErrMockError) {
+		t.Errorf("got %v, want a real failure preserved", err)
 	}
 }
 


### PR DESCRIPTION
Fixes #679, both halves from the 2026-08-27 full-functional run.

**Noise.** A concurrent remove can delete a task between the engine loading it and updating it; containerd answers a raw gRPC NotFound that never matched `ErrWorkloadNotExists`, so a remove that succeeded was logged at Error (`remap node failed ... not found`). The containerd engine now translates a task that vanished mid-update to done (`nilIfGone`), and the remap loop reports the remaining not-found case at Debug.

**O(N) remove.** Remap reapplied every resident workload after any binding change, one engine round-trip each under the node operation lock — measured 140ms remove on an empty node vs 344ms with 99 present, 27.1s for a concurrent 100-way teardown. Calcium now keeps an in-memory digest of the engine params it last applied per workload and skips the engine call when nothing moved; the node record is replaced wholesale each run so departed workloads are forgotten. fmt prints map keys sorted, which keeps the fnv digest stable. After a restart the first remap reapplies everything once and repopulates the memo. The WAL replay handler goes through the same path.

Testbed acceptance to follow in the issue: single remove with 99 present back near the empty-node cost, and no `remap node failed .* not found` lines during a 100-way teardown.