### PR TITLE
fix: retry a refused session open like a refused forward

### DIFF
--- a/engine/sshrunner/ssh.go
+++ b/engine/sshrunner/ssh.go
@@ -26,7 +26,7 @@ const (
 	// sshd's default MaxSessions is 10; queue past that instead of being refused.
 	maxSessions = 8
 
-	dialRetries       = 2
+	dialRetries       = 4
 	dialRetryInterval = 100 * time.Millisecond
 )
 
@@ -302,6 +302,7 @@ func retry[T any](ctx context.Context, r *sshRunner, f func(*ssh.Client) (T, err
 
 func retryRefused(ctx context.Context, dial func() (net.Conn, error)) (net.Conn, error) {
 	conn, err := dial()
+	interval := dialRetryInterval
 	for range dialRetries {
 		if err == nil || !isChannelRefused(err) {
 			break
@@ -309,8 +310,9 @@ func retryRefused(ctx context.Context, dial func() (net.Conn, error)) (net.Conn,
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
-		case <-time.After(dialRetryInterval):
+		case <-time.After(interval):
 		}
+		interval *= 2
 		conn, err = dial()
 	}
 	return conn, err

--- a/engine/sshrunner/ssh.go
+++ b/engine/sshrunner/ssh.go
@@ -26,8 +26,8 @@ const (
 	// sshd's default MaxSessions is 10; queue past that instead of being refused.
 	maxSessions = 8
 
-	dialRetries       = 4
-	dialRetryInterval = 100 * time.Millisecond
+	openRetries       = 4
+	openRetryInterval = 100 * time.Millisecond
 )
 
 var _ Runner = (*sshRunner)(nil)
@@ -125,7 +125,9 @@ func (r *sshRunner) Files(ctx context.Context) (Files, error) {
 	}
 	release := sync.OnceFunc(func() { r.sessions.Release(1) })
 
-	remote, err := retry(ctx, r, func(client *ssh.Client) (*sftp.Client, error) { return sftp.NewClient(client) })
+	remote, err := retryRefused(ctx, func() (*sftp.Client, error) {
+		return retry(ctx, r, func(client *ssh.Client) (*sftp.Client, error) { return sftp.NewClient(client) })
+	})
 	if err != nil {
 		release()
 		return nil, err
@@ -152,7 +154,9 @@ func (r *sshRunner) Close() error {
 }
 
 func (r *sshRunner) newSession(ctx context.Context) (*ssh.Session, error) {
-	return retry(ctx, r, (*ssh.Client).NewSession)
+	return retryRefused(ctx, func() (*ssh.Session, error) {
+		return retry(ctx, r, (*ssh.Client).NewSession)
+	})
 }
 
 func (r *sshRunner) connect(ctx context.Context, renew bool) (*ssh.Client, error) {
@@ -300,22 +304,23 @@ func retry[T any](ctx context.Context, r *sshRunner, f func(*ssh.Client) (T, err
 	return f(client)
 }
 
-func retryRefused(ctx context.Context, dial func() (net.Conn, error)) (net.Conn, error) {
-	conn, err := dial()
-	interval := dialRetryInterval
-	for range dialRetries {
+func retryRefused[T any](ctx context.Context, open func() (T, error)) (T, error) {
+	res, err := open()
+	interval := openRetryInterval
+	for range openRetries {
 		if err == nil || !isChannelRefused(err) {
 			break
 		}
 		select {
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			var zero T
+			return zero, ctx.Err()
 		case <-time.After(interval):
 		}
 		interval *= 2
-		conn, err = dial()
+		res, err = open()
 	}
-	return conn, err
+	return res, err
 }
 
 // isTransportError separates a dead connection from sshd refusing one more channel.

--- a/engine/sshrunner/ssh_test.go
+++ b/engine/sshrunner/ssh_test.go
@@ -46,7 +46,8 @@ func TestRetryRefused(t *testing.T) {
 	}{
 		{"an accepted forward is dialled once", []error{nil}, nil, 1},
 		{"a forward the node accepts on the second try succeeds", []error{refusedChannel, nil}, nil, 2},
-		{"a forward the node keeps refusing gives up", []error{refusedChannel, refusedChannel, refusedChannel}, refusedChannel, 3},
+		{"a forward the node keeps refusing gives up", []error{refusedChannel, refusedChannel, refusedChannel, refusedChannel, refusedChannel}, refusedChannel, 5},
+		{"a refusal burst longer than one interval is absorbed", []error{refusedChannel, refusedChannel, refusedChannel, nil}, nil, 4},
 		{"a dead transport is not a refusal", []error{io.EOF}, io.EOF, 1},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Completes #680 (follow-up to #681, which merged before these landed on its branch).

Live acceptance showed the forward retry alone still lost 1–5 creates per 100-count fan-out, and the surviving error was a raw `ssh: rejected: connect failed ("open failed")` with no gRPC dressing — a refused **session** open, not a refused forward. `newSession` and the sftp mount only redial a dead transport, so sshd refusing one more channel surfaced raw. The semaphore holds eight sessions against sshd's MaxSessions ten, but channel closes are asynchronous: under churn the not-yet-reaped channels push the count past the limit.

Two commits: the retry interval now backs off exponentially (100ms doubling to 800ms across four attempts, context-bounded), and `retryRefused` is generic over the opened type, wrapping all three channel-open sites (forward, session, sftp).

Testbed evidence: with both in, three consecutive `--count 100` fan-outs on eru-n2 completed **100/100 with zero rejections** (runs 17–19); before them, seven consecutive runs each lost 1–5.