### PR TITLE
fix: persist a resource update for the next start

### DIFF
--- a/docs/engines.md
+++ b/docs/engines.md
@@ -409,7 +409,7 @@ as stopped rather than missing.
 
 | `engine.API` | Node command |
 | --- | --- |
-| `VirtualizationCreate` | copy the artifact from the cache into `<process.root>/<id>/lower`, or `oras pull` it there when the cache has no entry; prepare `upper`, `work` and `merged`, create the bind sources, write the meta record, and render the `systemd-run` command into `<process.root>/<id>/run.sh`. Nothing runs yet, and a failure rolls the directory back |
+| `VirtualizationCreate` | copy the artifact from the cache into `<process.root>/<id>/lower`, or `oras pull` it there when the cache has no entry; prepare `upper`, `work` and `merged`, create the bind sources, write the meta record, and render the `systemd-run` launcher into `<process.root>/<id>/run.sh` with the resource knobs in `<id>/props`. Nothing runs yet, and a failure rolls the directory back |
 | `VirtualizationStart` | no-op when the unit is already running; otherwise release the finished unit name, mount the overlay at `merged`, copy the meta record onto tmpfs and run `run.sh` |
 | `VirtualizationStop` | `systemctl stop`, then a lazy unmount; a forced stop sends `SIGKILL` to the whole unit first |
 | `VirtualizationRemove` | refuses a running workload unless forced, then `systemctl reset-failed`, lazy unmount, and delete the workload directory and the meta record |
@@ -419,7 +419,7 @@ as stopped rather than missing.
 | `VirtualizationLogs` | `journalctl -u eru-<id> -o cat`, with `-n`, `--since` and `--until`; a followed stream ends when the unit leaves `running` |
 | `VirtualizationAttach` | logs-follow; stdin returns `ErrEngineNotImplemented` |
 | `Execute` | `systemd-run --scope` in the workload's slice, entering the root with `chroot --userspec` or dropping privileges with `setpriv`, stdio streamed over the SSH session, exit code from the scope |
-| `VirtualizationUpdateResource` | `systemctl set-property --runtime` with the complete knob set — live, no restart |
+| `VirtualizationUpdateResource` | rewrite `<id>/props` (what the next start replays), then `systemctl set-property --runtime` with the complete knob set on a loaded unit — live when running, persisted either way |
 | `VirtualizationCopyTo` / `CopyFrom` | sftp through the mounted overlay at `merged`; when it is not mounted, writes land in `upper` and reads fall back from `upper` to `lower` |
 | `ImagePull` / `ImageList` / `ImageRemove` | `oras pull` into a cleared artifact cache entry / list the cache / `rm -rf` the entry |
 | `ImageBuildFromExist` | `systemctl freeze`, tar the mounted overlay at `merged` so the layer is a complete bundle, `oras push` it under the new ref, `systemctl thaw` |
@@ -439,10 +439,12 @@ for bound CPUs, `CPUQuota` whenever a quota is set, then `MemoryMax`, `MemoryLow
 reservation), `MemorySwapMax=0`, `TasksMax` and the four `IO*Max` knobs per device. Volume
 bindings become `BindPaths=` — `BindReadOnlyPaths=` for an `ro` mode — with the source expanded
 against the workload's environment and created before the unit starts; a bind needs no
-`RootDirectory=`, so raw workloads get them too. `VirtualizationUpdateResource` sends every cgroup
-knob it can set, including the empty values that reset one, because `set-property` only touches
-what it is given and a realloc has to clear the shape it replaces; mounts are not live-settable
-and stay out of it.
+`RootDirectory=`, so raw workloads get them too. The resource knobs live in `<id>/props`, one
+property per line, which `run.sh` expands into `-p` flags on every start — the process analogue
+of containerd's stored spec, since `--runtime` properties die with the transient unit.
+`VirtualizationUpdateResource` rewrites that file and sends every cgroup knob it can set,
+including the empty values that reset one, because `set-property` only touches what it is given
+and a realloc has to clear the shape it replaces; mounts are not live-settable and stay out of it.
 
 `ExecStart` must be absolute, so a relative command resolves against the unit's root, or against
 the unpacked bundle for a raw workload.

--- a/engine/process/create.go
+++ b/engine/process/create.go
@@ -24,7 +24,7 @@ const (
 	podEnvKey = "ERU_POD"
 	rootUser  = "root"
 
-	createScript = "set -e\n" + unpackFunc + `dir=$1; ref=$2; cache=$3; launcher=$4; record=$5; overlay=$6; metadata=$7; binds=$8; shift 8
+	createScript = "set -e\n" + unpackFunc + `dir=$1; ref=$2; cache=$3; launcher=$4; record=$5; overlay=$6; metadata=$7; binds=$8; props=$9; shift 9
 trap 'rm -rf "$dir"' EXIT
 mkdir -p "$dir/lower"
 if [ -d "$cache" ]; then
@@ -39,6 +39,7 @@ printf '%s\n' "$binds" | while IFS= read -r source; do
 if [ -n "$source" ]; then mkdir -p "$source"; fi
 done
 printf '%s\n' "$launcher" > "$dir/run.sh"
+printf '%s\n' "$props" > "$dir/` + propsFile + `"
 printf '%s\n' "$metadata" > "$dir/meta.json"
 mkdir -p "$(dirname "$record")"
 cp -f "$dir/meta.json" "$record.tmp"
@@ -100,8 +101,8 @@ func (e *Engine) VirtualizationCreate(ctx context.Context, opts *enginetypes.Vir
 	}
 	overlay := strconv.Itoa(utils.Bool2Int(!rArgs.Raw))
 	argv := sshrunner.Shell(createScript, slices.Concat([]string{
-		dir, opts.Image, imageDir(e.root, opts.Image), sshrunner.Quote(u.argv()), workloadmeta.Path(ID), overlay, string(record),
-		strings.Join(bindSources(u.binds()), "\n"),
+		dir, opts.Image, imageDir(e.root, opts.Image), u.launcher(dir), workloadmeta.Path(ID), overlay, string(record),
+		strings.Join(bindSources(u.binds()), "\n"), strings.Join(resourceProperties(resource), "\n"),
 	}, e.registryFlags(opts.Image))...)
 	if _, err = e.run(ctx, argv...); err != nil {
 		return nil, err

--- a/engine/process/lifecycle.go
+++ b/engine/process/lifecycle.go
@@ -79,7 +79,10 @@ test -d "$dir" || exit %d
 systemctl show "$unit" -p %s
 `, workloadmeta.NotExistsCode, showProperties)
 
-	updateScript = "set -e\n" + loadedFunc + `unit=$1; shift
+	updateScript = "set -e\n" + loadedFunc + `unit=$1; dir=$2; shift 2
+test -d "$dir" || exit 0
+printf '%s\n' "$@" > "$dir/` + propsFile + `.tmp"
+mv "$dir/` + propsFile + `.tmp" "$dir/` + propsFile + `"
 loaded "$unit" || exit 0
 exec systemctl set-property --runtime "$unit" "$@"
 `
@@ -167,6 +170,6 @@ func (e *Engine) VirtualizationUpdateResource(ctx context.Context, ID string, en
 			Errorf(ctx, err, "failed to parse engine args %+v", engineParams)
 		return err
 	}
-	_, err := e.run(ctx, sshrunner.Shell(updateScript, slices.Concat([]string{unitName(ID)}, updateProperties(resource))...)...)
+	_, err := e.run(ctx, sshrunner.Shell(updateScript, slices.Concat([]string{unitName(ID), workloadDir(e.root, ID)}, updateProperties(resource))...)...)
 	return err
 }

--- a/engine/process/lifecycle_test.go
+++ b/engine/process/lifecycle_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 
+	"github.com/projecteru2/core/engine"
 	"github.com/projecteru2/core/engine/sshrunner"
 	"github.com/projecteru2/core/engine/sshrunner/sshrunnertest"
 	enginetypes "github.com/projecteru2/core/engine/types"
@@ -322,17 +323,36 @@ func TestRemoveScriptReportsAMissingWorkloadDirectory(t *testing.T) {
 	}
 }
 
-func TestUpdateScriptIsANoOpOnAnUnloadedUnit(t *testing.T) {
+func TestUpdateScriptPersistsPropsOnAnUnloadedUnit(t *testing.T) {
 	node := newStubNode(t)
 	node.loadState, node.fail = "not-found", "set-property"
 
-	code := node.run(t, updateScript, "eru-w1.service", "CPUQuota=200%")
+	code := node.run(t, updateScript, "eru-w1.service", node.dir, "CPUQuota=200%", "AllowedCPUs=0 1")
 
 	if code != 0 {
-		t.Fatalf("got exit %d, want a remap on a stopped workload to be a no-op", code)
+		t.Fatalf("got exit %d, want a remap on a stopped workload to persist quietly", code)
 	}
 	if log := node.log(t); log != "" {
 		t.Errorf("got %q, want nothing sent to a unit that is not loaded", log)
+	}
+	body, err := os.ReadFile(filepath.Join(node.dir, propsFile))
+	if err != nil {
+		t.Fatalf("props: %v", err)
+	}
+	if want := "CPUQuota=200%\nAllowedCPUs=0 1\n"; string(body) != want {
+		t.Errorf("got %q, want %q replayed by the next start", body, want)
+	}
+}
+
+func TestUpdateScriptIsANoOpOnARemovedWorkload(t *testing.T) {
+	node := newStubNode(t)
+	node.loadState = "not-found"
+	if err := os.RemoveAll(node.dir); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	if code := node.run(t, updateScript, "eru-w1.service", node.dir, "CPUQuota=200%"); code != 0 {
+		t.Fatalf("got exit %d, want a vanished workload skipped", code)
 	}
 }
 
@@ -340,7 +360,7 @@ func TestUpdateScriptSetsThePropertiesOfALoadedUnit(t *testing.T) {
 	node := newStubNode(t)
 	node.loadState = "loaded"
 
-	code := node.run(t, updateScript, "eru-w1.service", "CPUQuota=200%", "MemoryMax=1073741824")
+	code := node.run(t, updateScript, "eru-w1.service", node.dir, "CPUQuota=200%", "MemoryMax=1073741824")
 
 	if code != 0 {
 		t.Fatalf("got exit %d, want the properties set", code)
@@ -348,6 +368,43 @@ func TestUpdateScriptSetsThePropertiesOfALoadedUnit(t *testing.T) {
 	want := "set-property --runtime eru-w1.service CPUQuota=200% MemoryMax=1073741824\n"
 	if log := node.log(t); log != want {
 		t.Errorf("got %q, want %q", log, want)
+	}
+	body, err := os.ReadFile(filepath.Join(node.dir, propsFile))
+	if err != nil {
+		t.Fatalf("props: %v", err)
+	}
+	if want := "CPUQuota=200%\nMemoryMax=1073741824\n"; string(body) != want {
+		t.Errorf("got %q, want the live update persisted too", body)
+	}
+}
+
+func TestLauncherReplaysTheUpdatedProps(t *testing.T) {
+	node := newStubNode(t)
+	u := &unit{
+		ID:       "w1",
+		Podname:  "prod",
+		Bundle:   node.dir,
+		Working:  node.dir,
+		Opts:     &enginetypes.VirtualizationCreateOptions{Name: "app_web_x", Cmd: []string{"/bin/server"}},
+		Resource: &engine.VirtualizationResource{},
+	}
+	launcher := u.launcher(node.dir)
+	if err := os.WriteFile(filepath.Join(node.dir, propsFile), []byte("CPUQuota=300%\nAllowedCPUs=2 3\n"), 0o644); err != nil {
+		t.Fatalf("props: %v", err)
+	}
+	stub := "#!/bin/sh\necho \"$@\" >> \"$STUB_LOG\"\n"
+	if err := os.WriteFile(filepath.Join(node.bin, "systemd-run"), []byte(stub), 0o755); err != nil {
+		t.Fatalf("stub: %v", err)
+	}
+
+	if code := node.run(t, launcher); code != 0 {
+		t.Fatalf("got exit %d, want the launcher to start the unit", code)
+	}
+	log := node.log(t)
+	for _, part := range []string{"-p CPUQuota=300%", "-p AllowedCPUs=2 3", "-- /bin/server"} {
+		if !strings.Contains(log, part) {
+			t.Errorf("got %q, want %q applied on start", log, part)
+		}
 	}
 }
 
@@ -360,7 +417,7 @@ func TestVirtualizationUpdateResourceSetsLiveProperties(t *testing.T) {
 		t.Fatalf("update: %v", err)
 	}
 	want := sshrunner.Quote(sshrunner.Shell(updateScript,
-		"eru-w1.service",
+		"eru-w1.service", testRoot+"/w1",
 		"CPUQuota=200%", "AllowedCPUs=", "AllowedMemoryNodes=", "CPUWeight=100",
 		"MemoryMax=1073741824", "MemoryLow=536870912", "MemorySwapMax=0",
 		"IOReadIOPSMax=", "IOWriteIOPSMax=", "IOReadBandwidthMax=", "IOWriteBandwidthMax=",
@@ -378,7 +435,7 @@ func TestVirtualizationUpdateResourceClearsTheOldShape(t *testing.T) {
 		t.Fatalf("update: %v", err)
 	}
 	want := sshrunner.Quote(sshrunner.Shell(updateScript,
-		"eru-w1.service",
+		"eru-w1.service", testRoot+"/w1",
 		"CPUQuota=", "AllowedCPUs=", "AllowedMemoryNodes=", "CPUWeight=100",
 		"MemoryMax=infinity", "MemoryLow=0", "MemorySwapMax=0",
 		"IOReadIOPSMax=", "IOWriteIOPSMax=", "IOReadBandwidthMax=", "IOWriteBandwidthMax=",

--- a/engine/process/unit.go
+++ b/engine/process/unit.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/projecteru2/core/engine"
+	"github.com/projecteru2/core/engine/sshrunner"
 	enginetypes "github.com/projecteru2/core/engine/types"
 	"github.com/projecteru2/core/utils"
 )
@@ -42,7 +43,15 @@ func (u *unit) binds() []utils.VolumeBind {
 	return utils.ParseVolumeBinds(u.Resource.Volumes, u.Opts.Env)
 }
 
-func (u *unit) argv() []string {
+func (u *unit) launcher(dir string) string {
+	return "set -- " + sshrunner.Quote(u.staticArgv()) + `
+while IFS= read -r p; do
+[ -n "$p" ] && set -- "$@" -p "$p"
+done < ` + sshrunner.Quote([]string{propsPath(dir)}) + `
+exec "$@" -- ` + sshrunner.Quote(u.command())
+}
+
+func (u *unit) staticArgv() []string {
 	argv := []string{
 		"systemd-run",
 		"--unit=" + unitName(u.ID),
@@ -63,8 +72,8 @@ func (u *unit) argv() []string {
 	for _, env := range u.Opts.Env {
 		argv = append(argv, "-p", "Environment="+systemdEnv(env))
 	}
-	for _, property := range properties(u.Resource, u.TasksMax) {
-		argv = append(argv, "-p", property)
+	if u.TasksMax > 0 {
+		argv = append(argv, "-p", "TasksMax="+strconv.Itoa(u.TasksMax))
 	}
 	for _, property := range bindPaths(u.binds()) {
 		argv = append(argv, "-p", property)
@@ -75,7 +84,7 @@ func (u *unit) argv() []string {
 	if u.StopTimeout > 0 {
 		argv = append(argv, "-p", "TimeoutStopSec="+strconv.FormatInt(int64(u.StopTimeout.Seconds()), 10))
 	}
-	return append(append(argv, "--"), u.command()...)
+	return argv
 }
 
 // command makes ExecStart absolute, which systemd requires; a relative one resolves
@@ -96,7 +105,7 @@ func (u *unit) description() string {
 	return appname + "/" + entrypoint
 }
 
-func properties(resource *engine.VirtualizationResource, tasksMax int) []string {
+func resourceProperties(resource *engine.VirtualizationResource) []string {
 	props := []string{}
 	if cpus := allowedCPUs(resource); cpus != "" {
 		props = append(props, "AllowedCPUs="+cpus)
@@ -114,9 +123,6 @@ func properties(resource *engine.VirtualizationResource, tasksMax int) []string 
 			"MemoryLow="+memoryLow(resource),
 			"MemorySwapMax=0",
 		)
-	}
-	if tasksMax > 0 {
-		props = append(props, "TasksMax="+strconv.Itoa(tasksMax))
 	}
 	return append(props, throttles(resource.IOPSOptions)...)
 }

--- a/engine/process/unit_test.go
+++ b/engine/process/unit_test.go
@@ -2,6 +2,7 @@ package process
 
 import (
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -34,7 +35,7 @@ func TestUnitArgvRendersABoundWorkload(t *testing.T) {
 		},
 	}
 
-	want := []string{
+	wantStatic := []string{
 		"systemd-run",
 		"--unit=eru-abcdef.service",
 		"--slice=eru-prod.slice",
@@ -45,24 +46,28 @@ func TestUnitArgvRendersABoundWorkload(t *testing.T) {
 		"-p", "WorkingDirectory=/home/app",
 		"-p", "RootDirectory=" + testRoot + "/abcdef/merged",
 		"-p", `Environment=FOO="bar baz"`,
-		"-p", "AllowedCPUs=0 1",
-		"-p", "AllowedMemoryNodes=0",
-		"-p", "CPUWeight=50",
-		"-p", "CPUQuota=150%",
-		"-p", "MemoryMax=1073741824",
-		"-p", "MemoryLow=536870912",
-		"-p", "MemorySwapMax=0",
 		"-p", "TasksMax=512",
-		"-p", "IOReadIOPSMax=/dev/sda 100",
-		"-p", "IOWriteIOPSMax=/dev/sda 200",
-		"-p", "IOReadBandwidthMax=/dev/sda 1048576",
-		"-p", "IOWriteBandwidthMax=/dev/sda 2097152",
 		"-p", "Restart=on-failure",
 		"-p", "TimeoutStopSec=10",
-		"--", "/bin/server", "--port", "8080",
 	}
-	if got := u.argv(); !slices.Equal(got, want) {
-		t.Errorf("got %q, want %q", got, want)
+	if got := u.staticArgv(); !slices.Equal(got, wantStatic) {
+		t.Errorf("got %q, want %q", got, wantStatic)
+	}
+	wantProps := []string{
+		"AllowedCPUs=0 1",
+		"AllowedMemoryNodes=0",
+		"CPUWeight=50",
+		"CPUQuota=150%",
+		"MemoryMax=1073741824",
+		"MemoryLow=536870912",
+		"MemorySwapMax=0",
+		"IOReadIOPSMax=/dev/sda 100",
+		"IOWriteIOPSMax=/dev/sda 200",
+		"IOReadBandwidthMax=/dev/sda 1048576",
+		"IOWriteBandwidthMax=/dev/sda 2097152",
+	}
+	if got := resourceProperties(u.Resource); !slices.Equal(got, wantProps) {
+		t.Errorf("got %q, want %q", got, wantProps)
 	}
 }
 
@@ -79,7 +84,7 @@ func TestUnitArgvRendersARawWorkload(t *testing.T) {
 		Resource: &engine.VirtualizationResource{Quota: 2, Volumes: []string{"/data/app:/data:rw"}},
 	}
 
-	want := []string{
+	wantStatic := []string{
 		"systemd-run",
 		"--unit=eru-abcdef.service",
 		"--slice=eru-prod.slice",
@@ -87,12 +92,22 @@ func TestUnitArgvRendersARawWorkload(t *testing.T) {
 		"-p", "RemainAfterExit=yes",
 		"-p", "SyslogIdentifier=eru",
 		"-p", "WorkingDirectory=" + testRoot + "/abcdef/lower",
-		"-p", "CPUQuota=200%",
 		"-p", "BindPaths=/data/app:/data",
-		"--", testRoot + "/abcdef/lower/server",
 	}
-	if got := u.argv(); !slices.Equal(got, want) {
-		t.Errorf("got %q, want %q", got, want)
+	if got := u.staticArgv(); !slices.Equal(got, wantStatic) {
+		t.Errorf("got %q, want %q", got, wantStatic)
+	}
+	if got := resourceProperties(u.Resource); !slices.Equal(got, []string{"CPUQuota=200%"}) {
+		t.Errorf("got %q, want only the quota", got)
+	}
+	launcher := u.launcher(testRoot + "/abcdef")
+	for _, part := range []string{
+		"done < '" + testRoot + "/abcdef/props'",
+		`exec "$@" -- '` + testRoot + "/abcdef/lower/server'",
+	} {
+		if !strings.Contains(launcher, part) {
+			t.Errorf("launcher %q missing %q", launcher, part)
+		}
 	}
 }
 

--- a/engine/process/utils.go
+++ b/engine/process/utils.go
@@ -14,6 +14,7 @@ const (
 	unitSuffix  = ".service"
 	sliceSuffix = ".slice"
 	imageCache  = "_images"
+	propsFile   = "props"
 )
 
 var (
@@ -33,6 +34,10 @@ func sliceName(podname string) string {
 
 func workloadDir(root, ID string) string {
 	return filepath.Join(root, ID)
+}
+
+func propsPath(dir string) string {
+	return filepath.Join(dir, propsFile)
 }
 
 func imageDir(root, ref string) string {


### PR DESCRIPTION
Reported against #683's remap memo: stop a process workload, let any remap run (the engine's updateScript exits 0 on an unloaded unit, so calcium records the digest as applied), start it again — run.sh replays the create-time properties and every later remap computing the same target skips on the memo, so the stale cgroup params are never repaired.

The defect is older than the memo: `set-property --runtime` on a transient unit dies with the unit, so even an update applied while running reverted on the next stop/start — pre-#683 the next remap round silently re-applied it, post-#683 nothing did. A realloc on a stopped workload has always been lost entirely.

The resource knobs now live in `<id>/props`: create writes it, `run.sh` expands it into `-p` flags on every start, and `VirtualizationUpdateResource` rewrites it atomically before patching a loaded unit live — the process analogue of containerd updating the stored spec (`docs/engines.md` updated). Regression tests: props persisted on an unloaded unit, live update also persisted, a launcher start replays updated props, an update racing a remove stays quiet.