### PR TITLE
fix: speak one word for a workload that vanished mid-update

### DIFF
--- a/engine/containerd/lifecycle.go
+++ b/engine/containerd/lifecycle.go
@@ -218,13 +218,13 @@ func (e *Engine) VirtualizationUpdateResource(ctx context.Context, ID string, en
 	limits := resourceSpec(resource, &RawArgs{}, devices)
 	// the stored spec is what a restart replays, so both it and the live task are updated
 	if err = found.Update(ctx, withSpecResources(limits)); err != nil {
-		return nilIfGone(err)
+		return notExistsIfGone(err)
 	}
 	task, err := found.Task(ctx, nil)
 	if err != nil {
-		return nilIfGone(err)
+		return notExistsIfGone(err)
 	}
-	return nilIfGone(task.Update(ctx, client.WithResources(limits)))
+	return notExistsIfGone(task.Update(ctx, client.WithResources(limits)))
 }
 
 // task loads the workload's running task; a workload without one cannot answer.
@@ -382,9 +382,9 @@ func userString(user specs.User) string {
 	return strconv.FormatUint(uint64(user.UID), 10) + ":" + strconv.FormatUint(uint64(user.GID), 10)
 }
 
-func nilIfGone(err error) error {
+func notExistsIfGone(err error) error {
 	if cerrdefs.IsNotFound(err) {
-		return nil
+		return coretypes.ErrWorkloadNotExists
 	}
 	return err
 }

--- a/engine/containerd/lifecycle_test.go
+++ b/engine/containerd/lifecycle_test.go
@@ -48,12 +48,12 @@ func TestUpdateKeepsTheLimitsItDoesNotOwn(t *testing.T) {
 	}
 }
 
-func TestUpdateTreatsAVanishedTaskAsDone(t *testing.T) {
+func TestUpdateSpeaksOneWordForAVanishedTask(t *testing.T) {
 	gone := errgrpc.ToNative(status.Errorf(codes.NotFound, "task w1 not found"))
-	if err := nilIfGone(gone); err != nil {
-		t.Errorf("got %v, want a task that vanished mid-update reported as done", err)
+	if err := notExistsIfGone(gone); !errors.Is(err, coretypes.ErrWorkloadNotExists) {
+		t.Errorf("got %v, want a task that vanished mid-update reported as not exists", err)
 	}
-	if err := nilIfGone(coretypes.ErrMockError); !errors.Is(err, coretypes.ErrMockError) {
+	if err := notExistsIfGone(coretypes.ErrMockError); !errors.Is(err, coretypes.ErrMockError) {
 		t.Errorf("got %v, want a real failure preserved", err)
 	}
 }


### PR DESCRIPTION
From the simplify-round adjudication of #683.

`VirtualizationUpdateResource` answered a vanished workload two ways: the pre-check translated it to `ErrWorkloadNotExists` while a mid-flight NotFound became nil — which answer a caller got depended on where the race landed, and two tests in two packages pinned the two opposite answers. The nil also leaked into realloc, whose transaction then committed new engine params for a workload no longer on the node instead of rolling back.

The engine now speaks `ErrWorkloadNotExists` for every gone case (`notExistsIfGone`); remap already treats that as benign at Debug, realloc gets its rollback back, and a WAL replay retries once and drops the entry when the record is gone.