### PR TITLE
fix: let an image op name nodes without their pod

### DIFF
--- a/types/options.go
+++ b/types/options.go
@@ -224,7 +224,7 @@ type ImageOptions struct {
 }
 
 func (o *ImageOptions) Validate() error {
-	if o.Podname == "" {
+	if o.Podname == "" && len(o.Nodenames) == 0 {
 		return ErrEmptyPodName
 	}
 	return nil

--- a/types/options_test.go
+++ b/types/options_test.go
@@ -153,7 +153,10 @@ func TestImageOptions(t *testing.T) {
 	o := &ImageOptions{}
 	assert.Equal(ErrEmptyPodName, o.Validate())
 
-	o.Podname = "podname"
+	o.Nodenames = []string{"node"}
+	assert.NoError(o.Validate())
+
+	o = &ImageOptions{Podname: "podname"}
 	assert.NoError(o.Validate())
 }
 


### PR DESCRIPTION
From the simplify-round adjudication of cli#121.

`ImageOptions.Validate` demanded a podname that `filterNodes` then discards the moment `Includes` is non-empty, so every client had to resolve a pod it knew the server would ignore — the cli grew an extra `GetNode` round trip per image command for exactly this. A node-scoped image op now validates on its node list; a request naming neither pod nor node is still refused. The cli follow-up deletes its `resolvePodname` shim.