### PR TITLE
review: apply the simplify round on the remediation diffs

### DIFF
--- a/cluster/calcium/calcium.go
+++ b/cluster/calcium/calcium.go
@@ -3,6 +3,7 @@ package calcium
 import (
 	"context"
 	"strings"
+	"sync"
 
 	"github.com/panjf2000/ants/v2"
 
@@ -34,7 +35,7 @@ type Calcium struct {
 	identifier string
 	// serviceAddress is both the key RegisterService publishes and the journal's own prefix
 	serviceAddress string
-	remapped       remapMemo
+	remapped       sync.Map
 }
 
 // New returns a Calcium cluster.

--- a/cluster/calcium/node.go
+++ b/cluster/calcium/node.go
@@ -109,6 +109,7 @@ func (c *Calcium) RemoveNode(ctx context.Context, nodename string) error {
 				}
 				enginefactory.RemoveEngineFromCache(ctx, node.Endpoint)
 				metrics.Client.RemoveInvalidNodes(nodename)
+				c.remapped.Delete(nodename)
 				return nil
 			},
 			func(_ context.Context, _ bool) error {

--- a/cluster/calcium/node_test.go
+++ b/cluster/calcium/node_test.go
@@ -125,7 +125,10 @@ func TestRemoveNode(t *testing.T) {
 	store.On("SetNodeStatus", mock.Anything, mock.Anything, int64(-1)).Return(nil).Once()
 	rmgr := c.rmgr.(*resourcemocks.Manager)
 	rmgr.On("RemoveNode", mock.Anything, mock.Anything).Return(nil)
+	c.remapped.Store(name, map[string]uint64{"w1": 1})
 	assert.NoError(t, c.RemoveNode(ctx, name))
+	_, remembered := c.remapped.Load(name)
+	assert.False(t, remembered, "a removed node must leave the remap memo")
 	store.AssertExpectations(t)
 	rmgr.AssertExpectations(t)
 }

--- a/cluster/calcium/remap.go
+++ b/cluster/calcium/remap.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"hash/fnv"
-	"sync"
 
 	"github.com/cockroachdb/errors"
 
@@ -37,7 +36,7 @@ func (c *Calcium) doRemapResource(ctx context.Context, logger *log.Fields, node 
 	if err != nil {
 		return err
 	}
-	if err = c.applyRemap(ctx, logger, node, workloads, engineParamsMap); err != nil {
+	if err = c.applyRemap(ctx, logger, node.Name, workloads, engineParamsMap); err != nil {
 		return err
 	}
 	commit()
@@ -56,9 +55,10 @@ func (c *Calcium) computeRemap(ctx context.Context, node *types.Node) (map[strin
 	return engineParamsMap, workloads, nil
 }
 
-func (c *Calcium) applyRemap(ctx context.Context, logger *log.Fields, node *types.Node, workloads []*types.Workload, engineParamsMap map[string]resourcetypes.Resources) error {
+func (c *Calcium) applyRemap(ctx context.Context, logger *log.Fields, nodename string, workloads []*types.Workload, engineParamsMap map[string]resourcetypes.Resources) error {
 	var errList []error
-	memo := c.remapped.load(node.Name)
+	memo, _ := c.remapped.Load(nodename)
+	recorded, _ := memo.(map[string]uint64)
 	applied := make(map[string]uint64, len(engineParamsMap))
 	for _, workload := range workloads {
 		engineParams, ok := engineParamsMap[workload.ID]
@@ -66,7 +66,7 @@ func (c *Calcium) applyRemap(ctx context.Context, logger *log.Fields, node *type
 			continue
 		}
 		digest := hashEngineParams(engineParams)
-		if recorded, seen := memo[workload.ID]; seen && recorded == digest {
+		if prev, seen := recorded[workload.ID]; seen && prev == digest {
 			applied[workload.ID] = digest
 			continue
 		}
@@ -83,28 +83,8 @@ func (c *Calcium) applyRemap(ctx context.Context, logger *log.Fields, node *type
 			applied[workload.ID] = digest
 		}
 	}
-	c.remapped.record(node.Name, applied)
+	c.remapped.Store(nodename, applied)
 	return errors.Join(errList...)
-}
-
-type remapMemo struct {
-	mu     sync.Mutex
-	hashes map[string]map[string]uint64
-}
-
-func (m *remapMemo) load(nodename string) map[string]uint64 {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	return m.hashes[nodename]
-}
-
-func (m *remapMemo) record(nodename string, hashes map[string]uint64) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if m.hashes == nil {
-		m.hashes = map[string]map[string]uint64{}
-	}
-	m.hashes[nodename] = hashes
 }
 
 func hashEngineParams(params resourcetypes.Resources) uint64 {

--- a/cluster/calcium/remap_test.go
+++ b/cluster/calcium/remap_test.go
@@ -215,20 +215,22 @@ func TestRemapForgetsAWorkloadThatLeftTheNode(t *testing.T) {
 	for range 3 {
 		assert.NoError(t, c.doRemapResource(ctx, logger, node))
 	}
-	assert.Equal(t, map[string]uint64{first.ID: hashEngineParams(params)}, c.remapped.hashes[node.Name])
+	memo, _ := c.remapped.Load(node.Name)
+	assert.Equal(t, map[string]uint64{first.ID: hashEngineParams(params)}, memo)
 	store.AssertExpectations(t)
 	rmgr.AssertExpectations(t)
 	engine.AssertExpectations(t)
 }
 
-func TestHashEngineParamsIsStableAcrossMapOrder(t *testing.T) {
-	params := resourcetypes.Resources{"cpumem": {}}
+func TestHashEngineParamsIsStableAcrossInsertionOrder(t *testing.T) {
+	ascending := resourcetypes.Resources{"cpumem": {}}
 	for i := range 16 {
-		params["cpumem"][strconv.Itoa(i)] = i
+		ascending["cpumem"][strconv.Itoa(i)] = i
 	}
-	want := hashEngineParams(params)
-	for range 16 {
-		assert.Equal(t, want, hashEngineParams(params))
+	descending := resourcetypes.Resources{"cpumem": {}}
+	for i := 15; i >= 0; i-- {
+		descending["cpumem"][strconv.Itoa(i)] = i
 	}
-	assert.NotEqual(t, want, hashEngineParams(resourcetypes.Resources{"cpumem": {"0": 0}}))
+	assert.Equal(t, hashEngineParams(ascending), hashEngineParams(descending))
+	assert.NotEqual(t, hashEngineParams(ascending), hashEngineParams(resourcetypes.Resources{"cpumem": {"0": 0}}))
 }

--- a/cluster/calcium/wal.go
+++ b/cluster/calcium/wal.go
@@ -262,7 +262,7 @@ func (h *remapNodeHandler) Handle(ctx context.Context, raw any) error {
 		if err != nil {
 			return err
 		}
-		return h.calcium.applyRemap(ctx, logger, node, workloads, engineParamsMap)
+		return h.calcium.applyRemap(ctx, logger, node.Name, workloads, engineParamsMap)
 	})
 	if err != nil && (errors.Is(err, types.ErrNodeNotExists) || h.calcium.store.NotFound(err)) {
 		logger.Info(ctx, "node is gone, nothing to remap")

--- a/engine/containerd/lifecycle.go
+++ b/engine/containerd/lifecycle.go
@@ -240,7 +240,6 @@ func (e *Engine) task(ctx context.Context, ID string) (client.Task, error) {
 	return task, err
 }
 
-// setDesiredStatus tells the restart plugin what core wants; without a policy it does not watch.
 func (e *Engine) markStopped(ctx context.Context, ID string) (client.Container, map[string]string, error) {
 	found, err := e.container(ctx, ID)
 	if err != nil {
@@ -256,6 +255,7 @@ func (e *Engine) markStopped(ctx context.Context, ID string) (client.Container, 
 	return found, info.Labels, nil
 }
 
+// setDesiredStatus tells the restart plugin what core wants; without a policy it does not watch.
 func (e *Engine) setDesiredStatus(ctx context.Context, found client.Container, labels map[string]string, status client.ProcessStatus) error {
 	if labels[restart.PolicyLabel] == "" || labels[restart.StatusLabel] == string(status) {
 		return nil

--- a/engine/process/exec.go
+++ b/engine/process/exec.go
@@ -4,7 +4,6 @@ import (
 	"cmp"
 	"context"
 	"io"
-	"slices"
 	"strings"
 
 	"github.com/projecteru2/core/engine/sshrunner"
@@ -63,5 +62,6 @@ func scopeArgv(record *meta, config *enginetypes.ExecConfig) []string {
 	if config.WorkingDir == "" || config.WorkingDir == "/" {
 		return append(argv, config.Cmd...)
 	}
-	return append(argv, sshrunner.Shell(chdirScript, slices.Concat([]string{config.WorkingDir}, config.Cmd)...)...)
+	wrapped := sshrunner.Shell(chdirScript, config.WorkingDir)
+	return append(argv, append(wrapped, config.Cmd...)...)
 }

--- a/engine/sshrunner/ssh.go
+++ b/engine/sshrunner/ssh.go
@@ -125,9 +125,7 @@ func (r *sshRunner) Files(ctx context.Context) (Files, error) {
 	}
 	release := sync.OnceFunc(func() { r.sessions.Release(1) })
 
-	remote, err := retryRefused(ctx, func() (*sftp.Client, error) {
-		return retry(ctx, r, func(client *ssh.Client) (*sftp.Client, error) { return sftp.NewClient(client) })
-	})
+	remote, err := retry(ctx, r, func(client *ssh.Client) (*sftp.Client, error) { return sftp.NewClient(client) })
 	if err != nil {
 		release()
 		return nil, err
@@ -137,9 +135,7 @@ func (r *sshRunner) Files(ctx context.Context) (Files, error) {
 
 // Dial forwards a node socket; a forward is not a session, so MaxSessions does not bound it.
 func (r *sshRunner) Dial(ctx context.Context, network, addr string) (net.Conn, error) {
-	return retryRefused(ctx, func() (net.Conn, error) {
-		return retry(ctx, r, func(client *ssh.Client) (net.Conn, error) { return client.Dial(network, addr) })
-	})
+	return retry(ctx, r, func(client *ssh.Client) (net.Conn, error) { return client.Dial(network, addr) })
 }
 
 func (r *sshRunner) Close() error {
@@ -154,9 +150,7 @@ func (r *sshRunner) Close() error {
 }
 
 func (r *sshRunner) newSession(ctx context.Context) (*ssh.Session, error) {
-	return retryRefused(ctx, func() (*ssh.Session, error) {
-		return retry(ctx, r, (*ssh.Client).NewSession)
-	})
+	return retry(ctx, r, (*ssh.Client).NewSession)
 }
 
 func (r *sshRunner) connect(ctx context.Context, renew bool) (*ssh.Client, error) {
@@ -287,8 +281,12 @@ func closeOnDone(ctx context.Context, sess *ssh.Session) func() {
 	return func() { stop() }
 }
 
-// retry runs f once, and once more on a fresh connection when the transport died underneath it.
+// retry backs off on a refused channel open, and redials a transport that died underneath the call.
 func retry[T any](ctx context.Context, r *sshRunner, f func(*ssh.Client) (T, error)) (T, error) {
+	return retryRefused(ctx, func() (T, error) { return openOnce(ctx, r, f) })
+}
+
+func openOnce[T any](ctx context.Context, r *sshRunner, f func(*ssh.Client) (T, error)) (T, error) {
 	var zero T
 	client, err := r.connect(ctx, false)
 	if err != nil {
@@ -305,22 +303,19 @@ func retry[T any](ctx context.Context, r *sshRunner, f func(*ssh.Client) (T, err
 }
 
 func retryRefused[T any](ctx context.Context, open func() (T, error)) (T, error) {
-	res, err := open()
 	interval := openRetryInterval
-	for range openRetries {
-		if err == nil || !isChannelRefused(err) {
-			break
+	for attempt := 0; ; attempt++ {
+		res, err := open()
+		if err == nil || !isChannelRefused(err) || attempt == openRetries {
+			return res, err
 		}
 		select {
 		case <-ctx.Done():
-			var zero T
-			return zero, ctx.Err()
+			return res, ctx.Err()
 		case <-time.After(interval):
 		}
 		interval *= 2
-		res, err = open()
 	}
-	return res, err
 }
 
 // isTransportError separates a dead connection from sshd refusing one more channel.


### PR DESCRIPTION
Adjudicated fixes from the four-lens review (reuse / simplification / efficiency / altitude) of #681–#684:

- **sshrunner**: the refusal ladder composes inside `retry()` (`openOnce` carries the transport redial), so the three channel-open sites go back to plain one-line `retry` calls and a future caller cannot forget the wrapper; `retryRefused` keeps a single `open()` call site.
- **calcium**: `remapMemo` collapses into a `sync.Map` field — the house shape for keyed whole-value replacement (helium, wal, engine/factory); `applyRemap` takes the nodename it actually uses; **a removed node now leaves the memo** instead of holding its digests for the process lifetime (the one behavior delta here, with a test).
- **process**: `scopeArgv` drops the double `slices.Concat` spread and the import that existed only for it.
- **containerd**: the `setDesiredStatus` godoc sits on `setDesiredStatus` again instead of `markStopped`.
- **remap_test**: the hash-stability test varies insertion order instead of hashing one value sixteen times.

Rejected findings and their reasons are recorded in the round ledger (backoff/v4 substitution, %v→json digest, wal.go/ssh.go reordering claims that the house layout rules already sanction).