### PR TITLE
fix: count a task the restart plugin reaped as stopped

### DIFF
--- a/cluster/calcium/node.go
+++ b/cluster/calcium/node.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 
+	"github.com/projecteru2/core/engine"
 	enginefactory "github.com/projecteru2/core/engine/factory"
 	enginetypes "github.com/projecteru2/core/engine/types"
 	"github.com/projecteru2/core/log"
@@ -32,6 +33,10 @@ func (c *Calcium) AddNode(ctx context.Context, opts *types.AddNodeOptions) (*typ
 	}
 	nodeInfo, err := client.Info(ctx)
 	if err != nil {
+		return nil, err
+	}
+	if err = verifyNodeEngine(ctx, client); err != nil {
+		logger.Error(ctx, err)
 		return nil, err
 	}
 
@@ -308,4 +313,12 @@ func (c *Calcium) setAllWorkloadsOnNodeDown(ctx context.Context, nodename string
 			logger.Infof(ctx, "set workload %s on node %s as inactive", workload.ID, nodename)
 		}
 	}
+}
+
+func verifyNodeEngine(ctx context.Context, client engine.API) error {
+	verifier, ok := client.(engine.NodeVerifier)
+	if !ok {
+		return nil
+	}
+	return verifier.VerifyNode(ctx)
 }

--- a/cluster/calcium/node_test.go
+++ b/cluster/calcium/node_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
+	"github.com/projecteru2/core/engine"
 	"github.com/projecteru2/core/engine/factory"
 	enginemocks "github.com/projecteru2/core/engine/mocks"
 	enginetypes "github.com/projecteru2/core/engine/types"
@@ -356,3 +357,17 @@ func TestFilterNodesDedupesIncludes(t *testing.T) {
 	}
 	assert.Equal(t, []string{"A", "B", "C"}, names)
 }
+
+func TestVerifyNodeEngineGatesOnTheEnginesVerdict(t *testing.T) {
+	ctx := t.Context()
+	assert.NoError(t, verifyNodeEngine(ctx, &enginemocks.API{}))
+	assert.NoError(t, verifyNodeEngine(ctx, verifierEngine{}))
+	assert.ErrorIs(t, verifyNodeEngine(ctx, verifierEngine{err: types.ErrMockError}), types.ErrMockError)
+}
+
+type verifierEngine struct {
+	engine.API
+	err error
+}
+
+func (v verifierEngine) VerifyNode(context.Context) error { return v.err }

--- a/engine/containerd/containerd.go
+++ b/engine/containerd/containerd.go
@@ -44,7 +44,10 @@ var machines = map[string]string{
 	"armv7l":  "arm",
 }
 
-var _ engine.API = (*Engine)(nil)
+var (
+	_ engine.API          = (*Engine)(nil)
+	_ engine.NodeVerifier = (*Engine)(nil)
+)
 
 // Engine runs containers through a node's own containerd socket, forwarded over SSH.
 type Engine struct {
@@ -132,6 +135,14 @@ func (e *Engine) Ping(ctx context.Context) error {
 	}
 	if !serving {
 		return errors.Newf("containerd on %s is not serving", e.ep.Nodename)
+	}
+	return nil
+}
+
+// VerifyNode proves the node holds an agent binary that answers the hooks every spec references.
+func (e *Engine) VerifyNode(ctx context.Context) error {
+	if _, err := e.run(ctx, hookBinary, hookCommand, "--help"); err != nil {
+		return errors.Wrapf(err, "node %s cannot serve %s", e.ep.Nodename, hookBinary)
 	}
 	return nil
 }

--- a/engine/containerd/containerd_test.go
+++ b/engine/containerd/containerd_test.go
@@ -27,6 +27,29 @@ func TestInfoNamesTheEngine(t *testing.T) {
 	}
 }
 
+func TestVerifyNodeProbesTheHookBinary(t *testing.T) {
+	runner := &sshrunnertest.Fake{Respond: func(string) *sshrunner.Result { return &sshrunner.Result{} }}
+
+	if err := testEngine(t, runner).VerifyNode(t.Context()); err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	want := sshrunner.Quote([]string{hookBinary, hookCommand, "--help"})
+	if lines := runner.Lines(); len(lines) != 1 || lines[0] != want {
+		t.Errorf("got %q, want %q", lines, want)
+	}
+}
+
+func TestVerifyNodeRefusesANodeWithoutTheHook(t *testing.T) {
+	runner := &sshrunnertest.Fake{Respond: func(string) *sshrunner.Result {
+		return &sshrunner.Result{Code: 127, Stderr: "eru-agent: not found"}
+	}}
+
+	err := testEngine(t, runner).VerifyNode(t.Context())
+	if err == nil || !strings.Contains(err.Error(), hookBinary) {
+		t.Errorf("got %v, want an error naming %s", err, hookBinary)
+	}
+}
+
 func TestNodePlatformMapsUnameOntoAnArchitecture(t *testing.T) {
 	runner := &sshrunnertest.Fake{Respond: func(string) *sshrunner.Result { return &sshrunner.Result{Stdout: "aarch64\n"} }}
 

--- a/engine/containerd/lifecycle.go
+++ b/engine/containerd/lifecycle.go
@@ -81,16 +81,13 @@ func (e *Engine) VirtualizationStop(ctx context.Context, ID string, gracefulTime
 	}
 	task, err := found.Task(ctx, nil)
 	if err != nil {
-		if cerrdefs.IsNotFound(err) {
-			return nil
-		}
-		return err
+		return nilIfGone(err)
 	}
 	if err = killTask(ctx, task, stopSignal(labels), e.gracePeriod(gracefulTimeout)); err != nil {
-		return err
+		return nilIfGone(err)
 	}
 	_, err = task.Delete(ctx)
-	return err
+	return nilIfGone(err)
 }
 
 func (e *Engine) VirtualizationRemove(ctx context.Context, ID string, _, force bool) error {
@@ -103,7 +100,7 @@ func (e *Engine) VirtualizationRemove(ctx context.Context, ID string, _, force b
 		if statusErr == nil && status.Status == client.Running && !force {
 			return errors.Wrapf(coretypes.ErrInvaildWorkloadOps, "workload %s is running, stop it first or force the removal", ID)
 		}
-		if err = killTask(ctx, task, syscall.SIGKILL, 0); err != nil {
+		if err = killTask(ctx, task, syscall.SIGKILL, 0); err != nil && !cerrdefs.IsNotFound(err) {
 			return err
 		}
 		if _, err = task.Delete(ctx); err != nil && !cerrdefs.IsNotFound(err) {
@@ -385,6 +382,14 @@ func userString(user specs.User) string {
 func notExistsIfGone(err error) error {
 	if cerrdefs.IsNotFound(err) {
 		return coretypes.ErrWorkloadNotExists
+	}
+	return err
+}
+
+// nilIfGone is for the verbs whose goal is absence: a task already gone means the stop succeeded.
+func nilIfGone(err error) error {
+	if cerrdefs.IsNotFound(err) {
+		return nil
 	}
 	return err
 }

--- a/engine/containerd/lifecycle_test.go
+++ b/engine/containerd/lifecycle_test.go
@@ -48,6 +48,16 @@ func TestUpdateKeepsTheLimitsItDoesNotOwn(t *testing.T) {
 	}
 }
 
+func TestStopTreatsAVanishedTaskAsStopped(t *testing.T) {
+	gone := errgrpc.ToNative(status.Errorf(codes.NotFound, "task w1 not found"))
+	if err := nilIfGone(gone); err != nil {
+		t.Errorf("got %v, want a task the restart plugin reaped first counted as stopped", err)
+	}
+	if err := nilIfGone(coretypes.ErrMockError); !errors.Is(err, coretypes.ErrMockError) {
+		t.Errorf("got %v, want a real failure preserved", err)
+	}
+}
+
 func TestUpdateSpeaksOneWordForAVanishedTask(t *testing.T) {
 	gone := errgrpc.ToNative(status.Errorf(codes.NotFound, "task w1 not found"))
 	if err := notExistsIfGone(gone); !errors.Is(err, coretypes.ErrWorkloadNotExists) {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -57,3 +57,8 @@ type API interface {
 
 	RawEngine(ctx context.Context, opts *enginetypes.RawEngineOptions) (*enginetypes.RawEngineResult, error)
 }
+
+// NodeVerifier vets the node-side dependencies an engine's workloads need, once, as the node is added.
+type NodeVerifier interface {
+	VerifyNode(ctx context.Context) error
+}


### PR DESCRIPTION
Found during the final E2E: `workload stop` issued right after a deploy failed with a raw `task ... not found` three out of three times, while a stop a minute later never failed. The race: `markStopped` flips the desired-status label, the restart plugin reacts immediately inside the post-create event window and reaps the exited task itself, and core's own `killTask`/`task.Delete` loses the delete race. Outside that window the plugin sits on its 10s reconcile timer and core's ~100ms stop always wins — which is why every earlier mid-lifecycle stop test passed.

A vanished task is exactly what stop wants, so the kill and delete paths now treat NotFound as success (`nilIfGone`), and force-remove's kill gets the same tolerance. Update keeps speaking `ErrWorkloadNotExists` per #686 — its goal is application, not absence. Live evidence: immediate-stop 3×3 green after the fix (in the E2E ledger).