### PR TITLE
feat: verify the oci hook binary when a node joins

### DIFF
--- a/cluster/calcium/node.go
+++ b/cluster/calcium/node.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 
+	"github.com/projecteru2/core/engine"
 	enginefactory "github.com/projecteru2/core/engine/factory"
 	enginetypes "github.com/projecteru2/core/engine/types"
 	"github.com/projecteru2/core/log"
@@ -32,6 +33,10 @@ func (c *Calcium) AddNode(ctx context.Context, opts *types.AddNodeOptions) (*typ
 	}
 	nodeInfo, err := client.Info(ctx)
 	if err != nil {
+		return nil, err
+	}
+	if err = verifyNodeEngine(ctx, client); err != nil {
+		logger.Error(ctx, err)
 		return nil, err
 	}
 
@@ -308,4 +313,12 @@ func (c *Calcium) setAllWorkloadsOnNodeDown(ctx context.Context, nodename string
 			logger.Infof(ctx, "set workload %s on node %s as inactive", workload.ID, nodename)
 		}
 	}
+}
+
+func verifyNodeEngine(ctx context.Context, client engine.API) error {
+	verifier, ok := client.(engine.NodeVerifier)
+	if !ok {
+		return nil
+	}
+	return verifier.VerifyNode(ctx)
 }

--- a/cluster/calcium/node_test.go
+++ b/cluster/calcium/node_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
+	"github.com/projecteru2/core/engine"
 	"github.com/projecteru2/core/engine/factory"
 	enginemocks "github.com/projecteru2/core/engine/mocks"
 	enginetypes "github.com/projecteru2/core/engine/types"
@@ -356,3 +357,17 @@ func TestFilterNodesDedupesIncludes(t *testing.T) {
 	}
 	assert.Equal(t, []string{"A", "B", "C"}, names)
 }
+
+func TestVerifyNodeEngineGatesOnTheEnginesVerdict(t *testing.T) {
+	ctx := t.Context()
+	assert.NoError(t, verifyNodeEngine(ctx, &enginemocks.API{}))
+	assert.NoError(t, verifyNodeEngine(ctx, verifierEngine{}))
+	assert.ErrorIs(t, verifyNodeEngine(ctx, verifierEngine{err: types.ErrMockError}), types.ErrMockError)
+}
+
+type verifierEngine struct {
+	engine.API
+	err error
+}
+
+func (v verifierEngine) VerifyNode(context.Context) error { return v.err }

--- a/engine/containerd/containerd.go
+++ b/engine/containerd/containerd.go
@@ -44,7 +44,10 @@ var machines = map[string]string{
 	"armv7l":  "arm",
 }
 
-var _ engine.API = (*Engine)(nil)
+var (
+	_ engine.API          = (*Engine)(nil)
+	_ engine.NodeVerifier = (*Engine)(nil)
+)
 
 // Engine runs containers through a node's own containerd socket, forwarded over SSH.
 type Engine struct {
@@ -132,6 +135,14 @@ func (e *Engine) Ping(ctx context.Context) error {
 	}
 	if !serving {
 		return errors.Newf("containerd on %s is not serving", e.ep.Nodename)
+	}
+	return nil
+}
+
+// VerifyNode proves the node holds an agent binary that answers the hooks every spec references.
+func (e *Engine) VerifyNode(ctx context.Context) error {
+	if _, err := e.run(ctx, hookBinary, hookCommand, "--help"); err != nil {
+		return errors.Wrapf(err, "node %s cannot serve %s", e.ep.Nodename, hookBinary)
 	}
 	return nil
 }

--- a/engine/containerd/containerd_test.go
+++ b/engine/containerd/containerd_test.go
@@ -27,6 +27,29 @@ func TestInfoNamesTheEngine(t *testing.T) {
 	}
 }
 
+func TestVerifyNodeProbesTheHookBinary(t *testing.T) {
+	runner := &sshrunnertest.Fake{Respond: func(string) *sshrunner.Result { return &sshrunner.Result{} }}
+
+	if err := testEngine(t, runner).VerifyNode(t.Context()); err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	want := sshrunner.Quote([]string{hookBinary, hookCommand, "--help"})
+	if lines := runner.Lines(); len(lines) != 1 || lines[0] != want {
+		t.Errorf("got %q, want %q", lines, want)
+	}
+}
+
+func TestVerifyNodeRefusesANodeWithoutTheHook(t *testing.T) {
+	runner := &sshrunnertest.Fake{Respond: func(string) *sshrunner.Result {
+		return &sshrunner.Result{Code: 127, Stderr: "eru-agent: not found"}
+	}}
+
+	err := testEngine(t, runner).VerifyNode(t.Context())
+	if err == nil || !strings.Contains(err.Error(), hookBinary) {
+		t.Errorf("got %v, want an error naming %s", err, hookBinary)
+	}
+}
+
 func TestNodePlatformMapsUnameOntoAnArchitecture(t *testing.T) {
 	runner := &sshrunnertest.Fake{Respond: func(string) *sshrunner.Result { return &sshrunner.Result{Stdout: "aarch64\n"} }}
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -57,3 +57,8 @@ type API interface {
 
 	RawEngine(ctx context.Context, opts *enginetypes.RawEngineOptions) (*enginetypes.RawEngineResult, error)
 }
+
+// NodeVerifier vets the node-side dependencies an engine's workloads need, once, as the node is added.
+type NodeVerifier interface {
+	VerifyNode(ctx context.Context) error
+}


### PR DESCRIPTION
## Why

containerd nodes serve networking and logs through the eru-agent binary that core wires into every OCI spec, as the createRuntime/poststop CNI hooks and as the log shim. `Ping` only proves the containerd socket answers, so a node missing the binary — or carrying one too old to know the `oci-hook` subcommand — joined the cluster fine and failed at the first workload create instead.

## What

- `engine.NodeVerifier`: an optional capability interface, vetted once as the node is added — never on engine-cache rebuilds.
- The containerd engine implements it by running `eru-agent oci-hook --help` on the node: exit 0 proves the binary exists and serves the subcommand; a missing binary (127) or a pre-hook agent (1) rejects the join with an error naming the binary.
- `AddNode` probes through the interface after `Info`, before any store or resource-plugin mutation.

cocoon and process already exercise their node binaries in `Ping` (`cocoon version`, `systemctl --version`), so only containerd implements the verifier.

## Evidence

- `go test ./...` green; new tests cover the probe argv, the rejection path, and the AddNode gate.
- `make lint` / `make fmt-check` 0 issues on both GOOS.
- Probe semantics verified against a locally built agent: `oci-hook --help` exits 0, an unknown subcommand exits 1.