### PR TITLE
fix: keep engine state convergent when a realloc fails

### DIFF
--- a/cluster/calcium/realloc.go
+++ b/cluster/calcium/realloc.go
@@ -68,6 +68,7 @@ func (c *Calcium) doReallocOnNode(ctx context.Context, node *types.Node, workloa
 			if !reallocated {
 				return nil
 			}
+			c.remapped.Delete(workload.Nodename)
 			var rollbackErr error
 			if resourceErr := c.rmgr.RollbackRealloc(ctx, workload.Nodename, deltaResources); resourceErr != nil {
 				rollbackErr = errors.Join(rollbackErr, resourceErr)

--- a/cluster/calcium/realloc_test.go
+++ b/cluster/calcium/realloc_test.go
@@ -96,8 +96,11 @@ func TestRealloc(t *testing.T) {
 	store.On("UpdateWorkload", mock.Anything, mock.Anything).Return(nil)
 
 	engine.On("VirtualizationUpdateResource", mock.Anything, mock.Anything, mock.Anything).Return(types.ErrNilEngine).Once()
+	c.remapped.Store("node1", map[string]uint64{"c1": 1})
 	err = c.ReallocResource(ctx, opts)
 	assert.ErrorIs(t, err, types.ErrNilEngine)
+	_, remembered := c.remapped.Load("node1")
+	assert.False(t, remembered, "a failed realloc must forget the node so the next remap reapplies store truth")
 	engine.On("VirtualizationUpdateResource", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	store.On("ListNodeWorkloads", mock.Anything, mock.Anything, mock.Anything).Return(nil, types.ErrMockError)

--- a/docs/engines.md
+++ b/docs/engines.md
@@ -51,7 +51,7 @@ image's manifests against, since core's own platform is not the node's.
 | `VirtualizationAttach` | without stdin, the journald follow; with stdin, the three sessions relaying the workload's FIFOs |
 | `VirtualizationResize` | nothing: the stdio is a pipe, and a pipe has no geometry |
 | `Execute` / `ExecResize` / `ExecExitCode` | `ctr tasks exec` over the SSH session: stdio is the session's, the TTY is the session's pty, and the exit status is the session's |
-| `VirtualizationUpdateResource` | `container.Update` of the stored spec **and** `task.Update` of the live cgroup, so a restart replays the new limits |
+| `VirtualizationUpdateResource` | `task.Update` of the live cgroup first, then `container.Update` of the stored spec — a failure persists nothing, and a restart replays the new limits only once both held |
 | `VirtualizationCopyTo` / `CopyFrom` | a tar stream through `ctr tasks exec`; a workload whose task has not started yet is written into through its own snapshot, mounted on the node with `ctr snapshots mounts` |
 | `ImagePull` / `ImageList` / `ImageRemove` / `ImagesPrune` | `client.Pull` with unpack, the image store, and a prune of every image no container is built on |
 | `ImageBuildFromExist` | pause the task, diff the workload's snapshot against its image, then under one lease write the new config and manifest into the content store and tag them |
@@ -419,7 +419,7 @@ as stopped rather than missing.
 | `VirtualizationLogs` | `journalctl -u eru-<id> -o cat`, with `-n`, `--since` and `--until`; a followed stream ends when the unit leaves `running` |
 | `VirtualizationAttach` | logs-follow; stdin returns `ErrEngineNotImplemented` |
 | `Execute` | `systemd-run --scope` in the workload's slice, entering the root with `chroot --userspec` or dropping privileges with `setpriv`, stdio streamed over the SSH session, exit code from the scope |
-| `VirtualizationUpdateResource` | rewrite `<id>/props` (what the next start replays), then `systemctl set-property --runtime` with the complete knob set on a loaded unit — live when running, persisted either way |
+| `VirtualizationUpdateResource` | `systemctl set-property --runtime` on a loaded unit, then commit `<id>/props` (what the next start replays) — a failed live apply leaves the old props uncommitted |
 | `VirtualizationCopyTo` / `CopyFrom` | sftp through the mounted overlay at `merged`; when it is not mounted, writes land in `upper` and reads fall back from `upper` to `lower` |
 | `ImagePull` / `ImageList` / `ImageRemove` | `oras pull` into a cleared artifact cache entry / list the cache / `rm -rf` the entry |
 | `ImageBuildFromExist` | `systemctl freeze`, tar the mounted overlay at `merged` so the layer is a complete bundle, `oras push` it under the new ref, `systemctl thaw` |

--- a/engine/containerd/lifecycle.go
+++ b/engine/containerd/lifecycle.go
@@ -213,15 +213,15 @@ func (e *Engine) VirtualizationUpdateResource(ctx context.Context, ID string, en
 		return err
 	}
 	limits := resourceSpec(resource, &RawArgs{}, devices)
-	// the stored spec is what a restart replays, so both it and the live task are updated
-	if err = found.Update(ctx, withSpecResources(limits)); err != nil {
-		return notExistsIfGone(err)
+	// live first, stored spec second: a failure then persists nothing, and a restart replays the new limits only after both held
+	if task, taskErr := found.Task(ctx, nil); taskErr == nil {
+		if err = task.Update(ctx, client.WithResources(limits)); err != nil {
+			return notExistsIfGone(err)
+		}
+	} else if !cerrdefs.IsNotFound(taskErr) {
+		return taskErr
 	}
-	task, err := found.Task(ctx, nil)
-	if err != nil {
-		return notExistsIfGone(err)
-	}
-	return notExistsIfGone(task.Update(ctx, client.WithResources(limits)))
+	return notExistsIfGone(found.Update(ctx, withSpecResources(limits)))
 }
 
 // task loads the workload's running task; a workload without one cannot answer.

--- a/engine/process/lifecycle.go
+++ b/engine/process/lifecycle.go
@@ -82,9 +82,8 @@ systemctl show "$unit" -p %s
 	updateScript = "set -e\n" + loadedFunc + `unit=$1; dir=$2; shift 2
 test -d "$dir" || exit 0
 printf '%s\n' "$@" > "$dir/` + propsFile + `.tmp"
+if loaded "$unit"; then systemctl set-property --runtime "$unit" "$@"; fi
 mv "$dir/` + propsFile + `.tmp" "$dir/` + propsFile + `"
-loaded "$unit" || exit 0
-exec systemctl set-property --runtime "$unit" "$@"
 `
 )
 

--- a/engine/process/lifecycle_test.go
+++ b/engine/process/lifecycle_test.go
@@ -356,6 +356,27 @@ func TestUpdateScriptIsANoOpOnARemovedWorkload(t *testing.T) {
 	}
 }
 
+func TestUpdateScriptKeepsThePropsWhenTheLiveApplyFails(t *testing.T) {
+	node := newStubNode(t)
+	node.loadState, node.fail = "loaded", "set-property"
+	if err := os.WriteFile(filepath.Join(node.dir, propsFile), []byte("CPUQuota=20%\n"), 0o644); err != nil {
+		t.Fatalf("props: %v", err)
+	}
+
+	code := node.run(t, updateScript, "eru-w1.service", node.dir, "CPUQuota=200%")
+
+	if code == 0 {
+		t.Fatal("got exit 0, want the failed live apply reported")
+	}
+	body, err := os.ReadFile(filepath.Join(node.dir, propsFile))
+	if err != nil {
+		t.Fatalf("props: %v", err)
+	}
+	if want := "CPUQuota=20%\n"; string(body) != want {
+		t.Errorf("got %q, want the props of a failed realloc left uncommitted", body)
+	}
+}
+
 func TestUpdateScriptSetsThePropertiesOfALoadedUnit(t *testing.T) {
 	node := newStubNode(t)
 	node.loadState = "loaded"


### PR DESCRIPTION
Two partial-persistence windows (both P2, reported against #683/#685) let a failed realloc leave the engine carrying params the store rolled back, and the remap memo then pinned the divergence:

- **containerd** persisted the new spec before touching the live task, so a task the restart monitor was recreating mid-update failed the call *after* the spec write; a restart then replays limits the store no longer bills. The live task is updated first now — a failure persists nothing, and the spec-write-fails tail converges on restart.
- **process** committed the props file before `set-property`, so a failed live apply (or a dropped session mid-transaction) still installed the new props for the next start. The file is committed only after the live apply held; a failed apply leaves the old props in place (stub-executed regression test).
- **calcium** forgets the node's remap memo whenever a realloc rolls back: whatever half-state the engine kept, the next remap reapplies store truth instead of skipping on a stale digest — the eventual-fix loop is guaranteed again for every engine, which is the safety net over both windows above.