### PR TITLE
review: close the round-2 findings

### DIFF
--- a/cluster/calcium/node.go
+++ b/cluster/calcium/node.go
@@ -31,13 +31,17 @@ func (c *Calcium) AddNode(ctx context.Context, opts *types.AddNodeOptions) (*typ
 	if err != nil {
 		return nil, err
 	}
+	evict := func(err error) error {
+		enginefactory.RemoveEngineFromCache(ctx, opts.Endpoint)
+		return err
+	}
 	nodeInfo, err := client.Info(ctx)
 	if err != nil {
-		return nil, err
+		return nil, evict(err)
 	}
 	if err = verifyNodeEngine(ctx, client); err != nil {
 		logger.Error(ctx, err)
-		return nil, err
+		return nil, evict(err)
 	}
 
 	_, txnErr := utils.Txn(
@@ -75,7 +79,10 @@ func (c *Calcium) AddNode(ctx context.Context, opts *types.AddNodeOptions) (*typ
 		},
 		c.config.GlobalTimeout,
 	)
-	return node, txnErr
+	if txnErr != nil {
+		return node, evict(txnErr)
+	}
+	return node, nil
 }
 
 func (c *Calcium) RemoveNode(ctx context.Context, nodename string) error {

--- a/cluster/calcium/node_test.go
+++ b/cluster/calcium/node_test.go
@@ -126,7 +126,7 @@ func TestRemoveNode(t *testing.T) {
 	store.On("SetNodeStatus", mock.Anything, mock.Anything, int64(-1)).Return(nil).Once()
 	rmgr := c.rmgr.(*resourcemocks.Manager)
 	rmgr.On("RemoveNode", mock.Anything, mock.Anything).Return(nil)
-	c.remapped.Store(name, map[string]uint64{"w1": 1})
+	c.remapped.Store(name, &map[string]uint64{"w1": 1})
 	assert.NoError(t, c.RemoveNode(ctx, name))
 	_, remembered := c.remapped.Load(name)
 	assert.False(t, remembered, "a removed node must leave the remap memo")

--- a/cluster/calcium/realloc_test.go
+++ b/cluster/calcium/realloc_test.go
@@ -96,7 +96,7 @@ func TestRealloc(t *testing.T) {
 	store.On("UpdateWorkload", mock.Anything, mock.Anything).Return(nil)
 
 	engine.On("VirtualizationUpdateResource", mock.Anything, mock.Anything, mock.Anything).Return(types.ErrNilEngine).Once()
-	c.remapped.Store("node1", map[string]uint64{"c1": 1})
+	c.remapped.Store("node1", &map[string]uint64{"c1": 1})
 	err = c.ReallocResource(ctx, opts)
 	assert.ErrorIs(t, err, types.ErrNilEngine)
 	_, remembered := c.remapped.Load("node1")

--- a/cluster/calcium/remap.go
+++ b/cluster/calcium/remap.go
@@ -58,7 +58,10 @@ func (c *Calcium) computeRemap(ctx context.Context, node *types.Node) (map[strin
 func (c *Calcium) applyRemap(ctx context.Context, logger *log.Fields, nodename string, workloads []*types.Workload, engineParamsMap map[string]resourcetypes.Resources) error {
 	var errList []error
 	memo, _ := c.remapped.Load(nodename)
-	recorded, _ := memo.(map[string]uint64)
+	var recorded map[string]uint64
+	if snapshot, ok := memo.(*map[string]uint64); ok {
+		recorded = *snapshot
+	}
 	applied := make(map[string]uint64, len(engineParamsMap))
 	for _, workload := range workloads {
 		engineParams, ok := engineParamsMap[workload.ID]
@@ -83,7 +86,11 @@ func (c *Calcium) applyRemap(ctx context.Context, logger *log.Fields, nodename s
 			applied[workload.ID] = digest
 		}
 	}
-	c.remapped.Store(nodename, applied)
+	if memo == nil {
+		c.remapped.LoadOrStore(nodename, &applied)
+	} else {
+		c.remapped.CompareAndSwap(nodename, memo, &applied)
+	}
 	return errors.Join(errList...)
 }
 

--- a/cluster/calcium/remap_test.go
+++ b/cluster/calcium/remap_test.go
@@ -216,10 +216,35 @@ func TestRemapForgetsAWorkloadThatLeftTheNode(t *testing.T) {
 		assert.NoError(t, c.doRemapResource(ctx, logger, node))
 	}
 	memo, _ := c.remapped.Load(node.Name)
-	assert.Equal(t, map[string]uint64{first.ID: hashEngineParams(params)}, memo)
+	assert.Equal(t, &map[string]uint64{first.ID: hashEngineParams(params)}, memo)
 	store.AssertExpectations(t)
 	rmgr.AssertExpectations(t)
 	engine.AssertExpectations(t)
+}
+
+func TestRemapCommitYieldsToAConcurrentInvalidation(t *testing.T) {
+	c := NewTestCluster()
+	ctx := t.Context()
+	logger := log.WithField("test", "cas")
+	params := resourcetypes.Resources{"cpumem": {"cpu": 2}}
+
+	engine := &enginemocks.API{}
+	node := &types.Node{NodeMeta: types.NodeMeta{Name: "node1"}, Engine: engine}
+	workload := &types.Workload{ID: "workload1", Nodename: node.Name, Engine: engine}
+	store := c.store.(*storemocks.Store)
+	store.On("ListNodeWorkloads", mock.Anything, node.Name, mock.Anything).Return([]*types.Workload{workload}, nil)
+	rmgr := c.rmgr.(*resourcemocks.Manager)
+	rmgr.On("Remap", mock.Anything, node.Name, mock.Anything).Return(
+		map[string]resourcetypes.Resources{workload.ID: params}, nil,
+	)
+	engine.On("VirtualizationUpdateResource", mock.Anything, workload.ID, params).Run(func(mock.Arguments) {
+		c.remapped.Delete(node.Name)
+	}).Return(nil)
+
+	c.remapped.Store(node.Name, &map[string]uint64{workload.ID: 42})
+	assert.NoError(t, c.doRemapResource(ctx, logger, node))
+	_, remembered := c.remapped.Load(node.Name)
+	assert.False(t, remembered, "a sweep must not resurrect a memo a failed realloc just dropped")
 }
 
 func TestHashEngineParamsIsStableAcrossInsertionOrder(t *testing.T) {

--- a/docs/engines.md
+++ b/docs/engines.md
@@ -42,7 +42,7 @@ image's manifests against, since core's own platform is not the node's.
 | --- | --- |
 | `VirtualizationCreate` | `NewContainer` with a new snapshot and the rendered OCI spec; the container id **is** the workload name, so eru-agent reads appname, entrypoint and ident straight off it, and it is also the workload's hostname — which caps it at 64 bytes, `HOST_NAME_MAX` |
 | `VirtualizationStart` | `NewTask` with the log-shim `LogURI`, `task.Start`, then `containerd.io/restart.status=running`; a workload created with `open_stdin` takes node-side FIFOs instead of the log URI, with three SSH sessions already relaying them |
-| `VirtualizationStop` | `containerd.io/restart.status=stopped` first so the restart plugin does not race, then the image's stop signal and `SIGKILL` after the grace period, then `task.Delete`. A plain stop takes `containerd.stop_timeout`, a forced one kills at once |
+| `VirtualizationStop` | `containerd.io/restart.status=stopped` first, then the image's stop signal and `SIGKILL` after the grace period, then `task.Delete`; a task the restart plugin reaped first counts as stopped. A plain stop takes `containerd.stop_timeout`, a forced one kills at once |
 | `VirtualizationRemove` | refuses a running workload unless forced, kills the task and deletes the container with its snapshot |
 | `VirtualizationSuspend` / `Resume` | `task.Pause` / `task.Resume` |
 | `VirtualizationInspect` | the container record for labels and spec, one task-service `Get` for the running state |
@@ -229,9 +229,10 @@ Which nodes may build is decided by `build.node_filter`, not by the engine.
 ### Node prerequisites
 
 containerd ≥ 2.0 with the restart plugin, `runc`, `ctr`, the CNI plugin binaries in
-`/opt/cni/bin` with conf in `/etc/cni/net.d`, the eru-agent binary at `/usr/local/bin/eru-agent`,
-`sshd` with core's key in `authorized_keys`, journald rate limits raised for the `eru` identifier,
-and `buildkitd` on the nodes `build.node_filter` selects.
+`/opt/cni/bin` with conf in `/etc/cni/net.d`, the eru-agent binary at `/usr/local/bin/eru-agent`
+— `AddNode` probes its hook subcommand once and refuses a node whose binary is missing or too
+old — `sshd` with core's key in `authorized_keys`, journald rate limits raised for the `eru`
+identifier, and `buildkitd` on the nodes `build.node_filter` selects.
 
 ## cocoon
 
@@ -442,9 +443,10 @@ against the workload's environment and created before the unit starts; a bind ne
 `RootDirectory=`, so raw workloads get them too. The resource knobs live in `<id>/props`, one
 property per line, which `run.sh` expands into `-p` flags on every start — the process analogue
 of containerd's stored spec, since `--runtime` properties die with the transient unit.
-`VirtualizationUpdateResource` rewrites that file and sends every cgroup knob it can set,
-including the empty values that reset one, because `set-property` only touches what it is given
-and a realloc has to clear the shape it replaces; mounts are not live-settable and stay out of it.
+`VirtualizationUpdateResource` sends every cgroup knob it can set — including the empty values
+that reset one, because `set-property` only touches what it is given and a realloc has to clear
+the shape it replaces — and commits the file only after the live apply held; mounts are not
+live-settable and stay out of it.
 
 `ExecStart` must be absolute, so a relative command resolves against the unit's root, or against
 the unpacked bundle for a raw workload.

--- a/engine/containerd/copy.go
+++ b/engine/containerd/copy.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/containerd/containerd/v2/client"
-	cerrdefs "github.com/containerd/errdefs"
 
 	"github.com/projecteru2/core/engine/sshrunner"
 	enginetypes "github.com/projecteru2/core/engine/types"
@@ -100,11 +99,13 @@ func (e *Engine) writeArgv(ctx context.Context, ID, target string) ([]string, er
 	if err != nil {
 		return nil, err
 	}
-	if _, taskErr := found.Task(ctx, nil); taskErr == nil {
+	task, err := optionalTask(ctx, found)
+	if err != nil {
+		return nil, err
+	}
+	if task != nil {
 		config := &enginetypes.ExecConfig{Cmd: []string{"tar", "-x", "-C", filepath.Dir(target)}}
 		return e.execArgv(found.ID(), utils.RandomID(), config), nil
-	} else if !cerrdefs.IsNotFound(taskErr) {
-		return nil, taskErr
 	}
 	info, err := found.Info(ctx, client.WithoutRefreshedMetadata)
 	if err != nil {

--- a/engine/containerd/image.go
+++ b/engine/containerd/image.go
@@ -145,7 +145,11 @@ func (e *Engine) ImageBuildFromExist(ctx context.Context, ID string, refs []stri
 	if err != nil {
 		return "", err
 	}
-	if task, taskErr := found.Task(ctx, nil); taskErr == nil {
+	task, err := optionalTask(ctx, found)
+	if err != nil {
+		return "", err
+	}
+	if task != nil {
 		if err = task.Pause(ctx); err != nil {
 			return "", err
 		}
@@ -154,8 +158,6 @@ func (e *Engine) ImageBuildFromExist(ctx context.Context, ID string, refs []stri
 				log.WithFunc("engine.containerd.ImageBuildFromExist").Error(ctx, resumeErr, "resume the paused workload")
 			}
 		}()
-	} else if !cerrdefs.IsNotFound(taskErr) {
-		return "", taskErr
 	}
 
 	ctx, release, err := e.client.WithLease(ctx)

--- a/engine/containerd/lifecycle.go
+++ b/engine/containerd/lifecycle.go
@@ -95,7 +95,11 @@ func (e *Engine) VirtualizationRemove(ctx context.Context, ID string, _, force b
 	if err != nil {
 		return err
 	}
-	if task, taskErr := found.Task(ctx, nil); taskErr == nil {
+	task, err := optionalTask(ctx, found)
+	if err != nil {
+		return err
+	}
+	if task != nil {
 		status, statusErr := task.Status(ctx)
 		if statusErr == nil && status.Status == client.Running && !force {
 			return errors.Wrapf(coretypes.ErrInvaildWorkloadOps, "workload %s is running, stop it first or force the removal", ID)
@@ -106,8 +110,6 @@ func (e *Engine) VirtualizationRemove(ctx context.Context, ID string, _, force b
 		if _, err = task.Delete(ctx); err != nil && !cerrdefs.IsNotFound(err) {
 			return err
 		}
-	} else if !cerrdefs.IsNotFound(taskErr) {
-		return taskErr
 	}
 
 	e.releaseAttach(ID)
@@ -214,12 +216,14 @@ func (e *Engine) VirtualizationUpdateResource(ctx context.Context, ID string, en
 	}
 	limits := resourceSpec(resource, &RawArgs{}, devices)
 	// live first, stored spec second: a failure then persists nothing, and a restart replays the new limits only after both held
-	if task, taskErr := found.Task(ctx, nil); taskErr == nil {
+	task, err := optionalTask(ctx, found)
+	if err != nil {
+		return err
+	}
+	if task != nil {
 		if err = task.Update(ctx, client.WithResources(limits)); err != nil {
 			return notExistsIfGone(err)
 		}
-	} else if !cerrdefs.IsNotFound(taskErr) {
-		return taskErr
 	}
 	return notExistsIfGone(found.Update(ctx, withSpecResources(limits)))
 }
@@ -384,6 +388,14 @@ func notExistsIfGone(err error) error {
 		return coretypes.ErrWorkloadNotExists
 	}
 	return err
+}
+
+func optionalTask(ctx context.Context, found client.Container) (client.Task, error) {
+	task, err := found.Task(ctx, nil)
+	if cerrdefs.IsNotFound(err) {
+		return nil, nil
+	}
+	return task, err
 }
 
 // nilIfGone is for the verbs whose goal is absence: a task already gone means the stop succeeded.


### PR DESCRIPTION
Second four-lens pass (reuse+simplify / efficiency+altitude / mechanical style) over the post-round increments — the #689 squash (NodeVerifier + stop fix) and #691 (realloc convergence). Style scan: all 12 files PASS, +3 comments all mandatory godoc. Findings closed here:

- **AddNode engine-cache leak**: a node refused by VerifyNode (or failing Info, or failing the txn) left its engine cached — one SSH connection + containerd client per abandoned endpoint, forever; nothing evicts a pingable engine. Every failure after `GetEngine` now evicts via the same `RemoveEngineFromCache` RemoveNode and SetNode already use.
- **Memo commit race**: `applyRemap`'s wholesale `Store` could overwrite a concurrent invalidation from a failed realloc (different locks: pod lock vs node-op lock; the Load→Store window is N engine RPCs wide), silently restoring the stale skip-digest the Delete existed to clear. The commit is now `LoadOrStore`/`CompareAndSwap` against the loaded snapshot (stored as a pointer for comparability) — a lost race drops the update and the next sweep recomputes. Regression test drives the interleaving through the engine mock.
- **optionalTask**: the fourth hand-written "task if the workload has one" probe named once; remove/update/copy/image-build now share it.
- **docs**: stop's reaped-task tolerance, AddNode's probe-and-refuse, and the process props commit order (prose contradicted the table).

Rejected findings recorded in the round ledger (inline NotFound spellings in remove as churn; VerifyNode-into-Info folding as wrong reuse).