### PR TITLE
fix: repair a rolled-back realloc before clearing WAL

### DIFF
--- a/cluster/calcium/realloc.go
+++ b/cluster/calcium/realloc.go
@@ -89,30 +89,28 @@ func (c *Calcium) doReallocOnNode(ctx context.Context, node *types.Node, workloa
 		},
 		c.config.GlobalTimeout,
 	)
+	needsRepair := settled && runtimeUpdateAttempted && err != nil
 	if settled {
 		nodeCommit()
-		if err == nil || !runtimeUpdateAttempted {
+		if !needsRepair {
 			workloadCommit()
 		}
 	}
-	if err != nil {
-		if settled && runtimeUpdateAttempted {
-			return func() { c.repairRealloc(ctx, logger, node.Name, workload.ID, workloadCommit) }, err
-		}
+	switch {
+	case needsRepair:
+		return func() { c.repairRealloc(ctx, logger, workload.ID, workloadCommit) }, err
+	case err != nil:
 		return nil, err
 	}
 	c.invokePoolAsync(func() { c.RemapResourceAndLog(ctx, logger, node) })
 	return nil, nil
 }
 
-func (c *Calcium) repairRealloc(ctx context.Context, logger *log.Fields, nodename, workloadID string, commit reallocRepair) {
+func (c *Calcium) repairRealloc(ctx context.Context, logger *log.Fields, workloadID string, commit func()) {
 	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), c.config.GlobalTimeout)
 	defer cancel()
 
-	err := c.withNodeOperationLocked(ctx, nodename, func(ctx context.Context, _ *types.Node) error {
-		return (&ReallocWorkloadHandler{calcium: c}).Handle(ctx, workloadID)
-	})
-	if err != nil {
+	if err := (&ReallocWorkloadHandler{calcium: c}).Handle(ctx, workloadID); err != nil {
 		logger.Error(ctx, err, "repair realloc failed")
 		return
 	}

--- a/cluster/calcium/realloc.go
+++ b/cluster/calcium/realloc.go
@@ -12,6 +12,8 @@ import (
 	"github.com/projecteru2/core/utils"
 )
 
+type reallocRepair func()
+
 func (c *Calcium) ReallocResource(ctx context.Context, opts *types.ReallocOptions) (err error) {
 	logger := log.WithFunc("calcium.ReallocResource").WithField("opts", opts)
 	logger.Infof(ctx, "realloc workload %+v with options %+v", opts.ID, opts.Resources)
@@ -19,32 +21,40 @@ func (c *Calcium) ReallocResource(ctx context.Context, opts *types.ReallocOption
 	if err != nil {
 		return err
 	}
-	return c.withNodePodLocked(ctx, workload.Nodename, func(ctx context.Context, node *types.Node) error {
-		return c.withWorkloadLocked(ctx, opts.ID, false, func(ctx context.Context, workload *types.Workload) error {
-			err := c.doReallocOnNode(ctx, node, workload, opts)
-			logger.Error(ctx, err)
-			return err
+	var repair reallocRepair
+	err = c.withNodePodLocked(ctx, workload.Nodename, func(ctx context.Context, node *types.Node) error {
+		return c.withNodeOperationLocked(ctx, node.Name, func(ctx context.Context, node *types.Node) error {
+			return c.withWorkloadLocked(ctx, opts.ID, false, func(ctx context.Context, workload *types.Workload) error {
+				repair, err = c.doReallocOnNode(ctx, node, workload, opts)
+				logger.Error(ctx, err)
+				return err
+			})
 		})
 	})
+	if repair != nil {
+		repair()
+	}
+	return err
 }
 
-func (c *Calcium) doReallocOnNode(ctx context.Context, node *types.Node, workload *types.Workload, opts *types.ReallocOptions) error {
+func (c *Calcium) doReallocOnNode(ctx context.Context, node *types.Node, workload *types.Workload, opts *types.ReallocOptions) (reallocRepair, error) {
 	originWorkload := *workload
 
 	var resources resourcetypes.Resources
 	var deltaResources resourcetypes.Resources
 	var engineParams resourcetypes.Resources
 	var reallocated bool
+	var runtimeUpdateAttempted bool
 
 	logger := log.WithFunc("calcium.doReallocOnNode").WithField("opts", opts)
 	nodeCommit, err := c.journal(ctx, logger, eventWorkloadResourceAllocated, []*types.Node{node})
 	if err != nil {
-		return err
+		return nil, err
 	}
 	workloadCommit, err := c.journal(ctx, logger, eventWorkloadReallocated, workload.ID)
 	if err != nil {
 		nodeCommit()
-		return err
+		return nil, err
 	}
 
 	settled, err := utils.Txn(
@@ -62,6 +72,7 @@ func (c *Calcium) doReallocOnNode(ctx context.Context, node *types.Node, workloa
 			return c.store.UpdateWorkload(ctx, workload)
 		},
 		func(ctx context.Context) error {
+			runtimeUpdateAttempted = true
 			return node.Engine.VirtualizationUpdateResource(ctx, opts.ID, engineParams)
 		},
 		func(ctx context.Context, _ bool) error {
@@ -80,11 +91,30 @@ func (c *Calcium) doReallocOnNode(ctx context.Context, node *types.Node, workloa
 	)
 	if settled {
 		nodeCommit()
-		workloadCommit()
+		if err == nil || !runtimeUpdateAttempted {
+			workloadCommit()
+		}
 	}
 	if err != nil {
-		return err
+		if settled && runtimeUpdateAttempted {
+			return func() { c.repairRealloc(ctx, logger, node.Name, workload.ID, workloadCommit) }, err
+		}
+		return nil, err
 	}
 	c.invokePoolAsync(func() { c.RemapResourceAndLog(ctx, logger, node) })
-	return nil
+	return nil, nil
+}
+
+func (c *Calcium) repairRealloc(ctx context.Context, logger *log.Fields, nodename, workloadID string, commit reallocRepair) {
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), c.config.GlobalTimeout)
+	defer cancel()
+
+	err := c.withNodeOperationLocked(ctx, nodename, func(ctx context.Context, _ *types.Node) error {
+		return (&ReallocWorkloadHandler{calcium: c}).Handle(ctx, workloadID)
+	})
+	if err != nil {
+		logger.Error(ctx, err, "repair realloc failed")
+		return
+	}
+	commit()
 }

--- a/cluster/calcium/realloc_test.go
+++ b/cluster/calcium/realloc_test.go
@@ -96,12 +96,13 @@ func TestRealloc(t *testing.T) {
 	store.On("UpdateWorkload", mock.Anything, mock.Anything).Return(nil)
 
 	engine.On("VirtualizationUpdateResource", mock.Anything, mock.Anything, mock.Anything).Return(types.ErrNilEngine).Once()
+	engine.On("VirtualizationUpdateResource", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	c.remapped.Store("node1", &map[string]uint64{"c1": 1})
 	err = c.ReallocResource(ctx, opts)
 	assert.ErrorIs(t, err, types.ErrNilEngine)
+	engine.AssertNumberOfCalls(t, "VirtualizationUpdateResource", 2)
 	_, remembered := c.remapped.Load("node1")
 	assert.False(t, remembered, "a failed realloc must forget the node so the next remap reapplies store truth")
-	engine.On("VirtualizationUpdateResource", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	store.On("ListNodeWorkloads", mock.Anything, mock.Anything, mock.Anything).Return(nil, types.ErrMockError)
 	err = c.ReallocResource(ctx, opts)
@@ -139,9 +140,61 @@ func TestReallocJournalsRepairEntries(t *testing.T) {
 	)
 
 	opts := &types.ReallocOptions{ID: "c1", Resources: resourcetypes.Resources{}}
-	assert.NoError(t, c.doReallocOnNode(ctx, node, workload, opts))
+	repair, err := c.doReallocOnNode(ctx, node, workload, opts)
+	assert.NoError(t, err)
+	assert.Nil(t, repair)
 	assert.Equal(t, []string{eventWorkloadResourceAllocated, eventWorkloadReallocated}, logged)
 	assert.Equal(t, 2, committed)
+}
+
+func TestReallocRepairsRuntimeBeforeCommittingItsJournal(t *testing.T) {
+	c := NewTestCluster()
+	ctx := t.Context()
+	committed := map[string]int{}
+	mwal := &walmocks.WAL{}
+	mwal.On("Log", mock.Anything, mock.Anything).Return(func(eventyp string, _ any) (wal.Commit, error) {
+		return func() error { committed[eventyp]++; return nil }, nil
+	})
+	c.wal = mwal
+
+	oldParams := resourcetypes.Resources{"cpumem": {"cpu": 1}}
+	newParams := resourcetypes.Resources{"cpumem": {"cpu": 2}}
+	engine := &enginemocks.API{}
+	engine.On("VirtualizationUpdateResource", mock.Anything, "c1", newParams).Return(types.ErrMockError).Once()
+	engine.On("VirtualizationUpdateResource", mock.Anything, "c1", oldParams).Return(nil).Once()
+	node := &types.Node{NodeMeta: types.NodeMeta{Name: "node1"}, Engine: engine}
+	workload := &types.Workload{ID: "c1", Nodename: node.Name, Engine: engine, EngineParams: oldParams}
+
+	lock := &lockmocks.DistributedLock{}
+	lock.On("Lock", mock.Anything).Return(ctx, nil)
+	lock.On("Unlock", mock.Anything).Return(nil)
+	store := c.store.(*storemocks.Store)
+	store.On("UpdateWorkload", mock.Anything, mock.Anything).Return(nil)
+	store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
+	store.On("GetNode", mock.Anything, node.Name).Return(node, nil)
+	store.On("GetWorkload", mock.Anything, workload.ID).Return(&types.Workload{
+		ID:           workload.ID,
+		Nodename:     node.Name,
+		Engine:       engine,
+		EngineParams: oldParams,
+	}, nil)
+	rmgr := c.rmgr.(*resourcemocks.Manager)
+	rmgr.On("Realloc", mock.Anything, node.Name, mock.Anything, mock.Anything).Return(
+		newParams, resourcetypes.Resources{}, resourcetypes.Resources{}, nil,
+	)
+	rmgr.On("RollbackRealloc", mock.Anything, node.Name, mock.Anything).Return(nil)
+
+	repair, err := c.doReallocOnNode(ctx, node, workload, &types.ReallocOptions{ID: workload.ID})
+	assert.ErrorIs(t, err, types.ErrMockError)
+	assert.NotNil(t, repair)
+	assert.Equal(t, 1, committed[eventWorkloadResourceAllocated])
+	assert.Zero(t, committed[eventWorkloadReallocated])
+
+	repair()
+	assert.Equal(t, 1, committed[eventWorkloadReallocated])
+	engine.AssertExpectations(t)
+	store.AssertExpectations(t)
+	rmgr.AssertExpectations(t)
 }
 
 func TestReallocKeepsRepairEntriesUntilRollbackCompletes(t *testing.T) {
@@ -178,7 +231,9 @@ func TestReallocKeepsRepairEntriesUntilRollbackCompletes(t *testing.T) {
 			rmgr.On("RollbackRealloc", mock.Anything, node.Name, mock.Anything).Return(tc.rollback).Once()
 
 			opts := &types.ReallocOptions{ID: workload.ID, Resources: resourcetypes.Resources{}}
-			assert.ErrorIs(t, c.doReallocOnNode(ctx, node, workload, opts), types.ErrMockError)
+			repair, err := c.doReallocOnNode(ctx, node, workload, opts)
+			assert.ErrorIs(t, err, types.ErrMockError)
+			assert.Nil(t, repair)
 			assert.Equal(t, tc.committed, committed)
 			mwal.AssertExpectations(t)
 		})

--- a/cluster/calcium/wal.go
+++ b/cluster/calcium/wal.go
@@ -227,17 +227,22 @@ func (h *ReallocWorkloadHandler) Handle(ctx context.Context, raw any) error {
 	if err != nil || workload == nil {
 		return err
 	}
-
-	switch err = workload.Engine.VirtualizationUpdateResource(ctx, workloadID, workload.EngineParams); {
-	case errors.Is(err, types.ErrEngineNotImplemented):
-		logger.Warn(ctx, "the engine cannot reapply engine params, dropping the entry")
+	return h.calcium.withNodeOperationLocked(ctx, workload.Nodename, func(ctx context.Context, _ *types.Node) error {
+		workload, err := getWorkloadIfExists(ctx, h.calcium, workloadID)
+		if err != nil || workload == nil {
+			return err
+		}
+		switch err = workload.Engine.VirtualizationUpdateResource(ctx, workloadID, workload.EngineParams); {
+		case errors.Is(err, types.ErrEngineNotImplemented):
+			logger.Warn(ctx, "the engine cannot reapply engine params, dropping the entry")
+			return nil
+		case err != nil:
+			logger.Error(ctx, err)
+			return err
+		}
+		logger.Info(ctx, "engine params reapplied")
 		return nil
-	case err != nil:
-		logger.Error(ctx, err)
-		return err
-	}
-	logger.Info(ctx, "engine params reapplied")
-	return nil
+	})
 }
 
 type remapNodeHandler struct {

--- a/cluster/calcium/wal_test.go
+++ b/cluster/calcium/wal_test.go
@@ -281,9 +281,14 @@ func TestHandleReallocWorkload(t *testing.T) {
 	engine := &enginemocks.API{}
 	engineParams := resourcetypes.Resources{"cpumem": {"cpu": 2}}
 	store := c.store.(*storemocks.Store)
+	lock := &lockmocks.DistributedLock{}
+	lock.On("Lock", mock.Anything).Return(t.Context(), nil)
+	lock.On("Unlock", mock.Anything).Return(nil)
+	store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
+	store.On("GetNode", mock.Anything, "n1").Return(&types.Node{NodeMeta: types.NodeMeta{Name: "n1"}}, nil)
 	store.On("GetWorkload", mock.Anything, "workloadid").Return(
-		&types.Workload{ID: "workloadid", EngineParams: engineParams, Engine: engine}, nil,
-	).Once()
+		&types.Workload{ID: "workloadid", Nodename: "n1", EngineParams: engineParams, Engine: engine}, nil,
+	).Twice()
 	engine.On("VirtualizationUpdateResource", mock.Anything, "workloadid", engineParams).Return(nil).Once()
 
 	c.wal.Recover(t.Context())
@@ -303,9 +308,14 @@ func TestHandleReallocWorkloadOnAnEngineThatCannotReplayIt(t *testing.T) {
 	engine := &enginemocks.API{}
 	engineParams := resourcetypes.Resources{"cpumem": {"cpu": 2}}
 	store := c.store.(*storemocks.Store)
+	lock := &lockmocks.DistributedLock{}
+	lock.On("Lock", mock.Anything).Return(t.Context(), nil)
+	lock.On("Unlock", mock.Anything).Return(nil)
+	store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
+	store.On("GetNode", mock.Anything, "n1").Return(&types.Node{NodeMeta: types.NodeMeta{Name: "n1"}}, nil)
 	store.On("GetWorkload", mock.Anything, "workloadid").Return(
-		&types.Workload{ID: "workloadid", EngineParams: engineParams, Engine: engine}, nil,
-	).Once()
+		&types.Workload{ID: "workloadid", Nodename: "n1", EngineParams: engineParams, Engine: engine}, nil,
+	).Twice()
 	engine.On("VirtualizationUpdateResource", mock.Anything, "workloadid", engineParams).
 		Return(types.ErrEngineNotImplemented).Once()
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -104,8 +104,10 @@ bookkeeping; core owns node and workload metadata. See [Resource plugins](resour
    copy in any files, run the after-create hooks, start it, inspect it back, and send the message.
    Each workload has its own inner `utils.Txn` whose rollback removes both metadata and instance.
 5. **Remap**: after a node finishes, core recomputes engine params for that node's existing
-   workloads and applies them — this is how shared CPU pools converge. Remap is idempotent and
-   deliberately outside the transaction.
+   workloads and applies them — this is how shared CPU pools converge. Remap is idempotent,
+   skips workloads whose params digest has not moved since the last sweep, and stays
+   deliberately outside the transaction; a failed realloc drops the node's digests so the
+   next sweep reapplies store truth.
 6. **Rollback**: if any workload failed, its resources are given back with `rmgr.RollbackAlloc`
    under the node lock.
 7. **Cleanup**: the processing counters are deleted and every WAL entry that reached a stable

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -17,7 +17,7 @@ zero-padded, so replaying the keys in order replays the entries in order.
 | `allocate-workload` | resources are allocated on a set of nodes, a workload is removed, or a realloc starts | re-derives each node's usage from its actual workloads (`NodeResource` with `fix`) |
 | `create-workload` | the engine is asked to create a workload, and before one is removed | removes the workload — from the store if it is there, otherwise off the engine, found by name when the entry has no ID yet |
 | `replace-workload` | the old workload of a replace is removed | removes the old workload if the new one reached the store, releasing nothing, because the new one inherited its resources |
-| `realloc-workload` | a realloc mutates plugin usage, metadata and engine limits | re-applies the stored engine params to the workload |
+| `realloc-workload` | a realloc mutates plugin usage, metadata and engine limits | re-applies the stored engine params under the node-operation lock — the same step a failed realloc runs inline as its repair, committing the entry only when the reapply holds |
 | `create-processing` | an in-flight deploy counter is written | deletes the stale counter, so it stops inflating deploy counts forever |
 | `create-lambda` | a `RunAndWait` workload starts | waits for it to exit, then removes it |
 


### PR DESCRIPTION
## Summary

- keep the workload realloc journal after a live engine update fails and metadata rollback succeeds
- release the pod and workload locks, then reapply the final stored engine params under the existing node-operation lock
- commit the journal only after repair succeeds, leaving recovery or takeover to retry a failed or interrupted repair
- serialize realloc with remap through the existing node-operation lock so an older sweep cannot win after compensation

## Verification

- GOWORK=off go test ./cluster/calcium -run ^TestRealloc -count=1
- GOWORK=off go test ./cluster/calcium -count=1
- GOWORK=off go test -race -count=1 ./...
- GOWORK=off make lint
- GOWORK=off make fmt-check
- GOWORK=off GOOS=darwin asl ./...
- GOWORK=off GOOS=linux asl ./...