### PR TITLE
feat: read sizes through one bytes-or-human accessor

### DIFF
--- a/resource/plugins/cpumem/calculate.go
+++ b/resource/plugins/cpumem/calculate.go
@@ -17,7 +17,9 @@ import (
 func (p Plugin) CalculateDeploy(ctx context.Context, nodename string, deployCount int, resourceRequest plugintypes.WorkloadResourceRequest) (*plugintypes.CalculateDeployResponse, error) {
 	logger := log.WithFunc("resource.cpumem.CalculateDeploy").WithField("node", nodename)
 	req := &cpumemtypes.WorkloadResourceRequest{}
-	req.Parse(resourceRequest)
+	if err := req.Parse(resourceRequest); err != nil {
+		return nil, err
+	}
 	if err := req.Validate(); err != nil {
 		logger.Errorf(ctx, err, "invalid resource opts %+v", req)
 		return nil, err
@@ -50,7 +52,9 @@ func (p Plugin) CalculateDeploy(ctx context.Context, nodename string, deployCoun
 
 func (p Plugin) CalculateRealloc(ctx context.Context, nodename string, resource plugintypes.WorkloadResource, resourceRequest plugintypes.WorkloadResourceRequest) (*plugintypes.CalculateReallocResponse, error) {
 	req := &cpumemtypes.WorkloadResourceRequest{}
-	req.Parse(resourceRequest)
+	if err := req.Parse(resourceRequest); err != nil {
+		return nil, err
+	}
 	originResource := &cpumemtypes.WorkloadResource{}
 	if err := originResource.Parse(resource); err != nil {
 		return nil, err

--- a/resource/plugins/cpumem/node.go
+++ b/resource/plugins/cpumem/node.go
@@ -113,8 +113,9 @@ func (p Plugin) RemoveNode(ctx context.Context, nodename string) (*plugintypes.R
 func (p Plugin) GetNodesDeployCapacity(ctx context.Context, nodenames []string, resource plugintypes.WorkloadResourceRequest) (*plugintypes.GetNodesDeployCapacityResponse, error) {
 	logger := log.WithFunc("resource.cpumem.GetNodesDeployCapacity")
 	req := &cpumemtypes.WorkloadResourceRequest{}
-	req.Parse(resource)
-
+	if err := req.Parse(resource); err != nil {
+		return nil, err
+	}
 	if err := req.Validate(); err != nil {
 		logger.Errorf(ctx, err, "invalid resource opts %+v", req)
 		return nil, err

--- a/resource/plugins/cpumem/types/node.go
+++ b/resource/plugins/cpumem/types/node.go
@@ -177,9 +177,7 @@ func (n *NodeResourceRequest) Parse(config coretypes.Config, rawParams resourcet
 			return err
 		}
 	}
-	if mem := rawParams.Int64("memory"); mem > 0 {
-		n.Memory = mem
-	} else if n.Memory, err = coreutils.ParseRAMInHuman(rawParams.String("memory")); err != nil {
+	if n.Memory, err = rawParams.SizeInBytes("memory"); err != nil {
 		return err
 	}
 
@@ -195,7 +193,7 @@ func (n *NodeResourceRequest) Parse(config coretypes.Config, rawParams resourcet
 
 	for index, nodeMemory := range rawParams.StringSlice("numa-memory") {
 		nodeID := strconv.Itoa(index)
-		mem, err := coreutils.ParseRAMInHuman(nodeMemory)
+		mem, err := resourcetypes.ParseRAMInHuman(nodeMemory)
 		if err != nil {
 			return err
 		}

--- a/resource/plugins/cpumem/types/workload.go
+++ b/resource/plugins/cpumem/types/workload.go
@@ -103,13 +103,18 @@ func (w *WorkloadResourceRequest) Validate() error {
 	return nil
 }
 
-func (w *WorkloadResourceRequest) Parse(rawParams resourcetypes.RawParams) {
+func (w *WorkloadResourceRequest) Parse(rawParams resourcetypes.RawParams) (err error) {
 	w.KeepCPUBind = rawParams.Bool("keep-cpu-bind")
 	w.CPUBind = rawParams.Bool("cpu-bind")
 
 	w.CPURequest = rawParams.Float64("cpu-request")
 	w.CPULimit = rawParams.Float64("cpu-limit")
 
-	w.MemRequest = rawParams.Int64("memory-request")
-	w.MemLimit = rawParams.Int64("memory-limit")
+	if w.MemRequest, err = rawParams.SizeInBytes("memory-request"); err != nil {
+		return err
+	}
+	if w.MemLimit, err = rawParams.SizeInBytes("memory-limit"); err != nil {
+		return err
+	}
+	return nil
 }

--- a/resource/plugins/cpumem/types/workload_test.go
+++ b/resource/plugins/cpumem/types/workload_test.go
@@ -4,7 +4,22 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	resourcetypes "github.com/projecteru2/core/resource/types"
 )
+
+func TestWorkloadResourceRequestParseMemoryForms(t *testing.T) {
+	req := &WorkloadResourceRequest{}
+	if err := req.Parse(resourcetypes.RawParams{"memory-request": "1G", "memory-limit": float64(2147483648)}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if req.MemRequest != 1073741824 || req.MemLimit != 2147483648 {
+		t.Errorf("got %d/%d, want the human string and the plain byte count both read", req.MemRequest, req.MemLimit)
+	}
+	if err := req.Parse(resourcetypes.RawParams{"memory-request": "1Q"}); err == nil {
+		t.Error("got nil, want a junk size reported instead of a silent zero")
+	}
+}
 
 func TestWorkloadResourceSubDeltasEveryField(t *testing.T) {
 	w := &WorkloadResource{

--- a/resource/types/ram.go
+++ b/resource/types/ram.go
@@ -1,4 +1,4 @@
-package utils
+package types
 
 import (
 	"strconv"

--- a/resource/types/ram_test.go
+++ b/resource/types/ram_test.go
@@ -1,4 +1,4 @@
-package utils
+package types
 
 import (
 	"testing"

--- a/resource/types/resource.go
+++ b/resource/types/resource.go
@@ -25,6 +25,18 @@ func (r RawParams) Int64(key string) int64 {
 	return intHelper[int64](r, key)
 }
 
+// SizeInBytes reads a size given as a plain byte count or a human-readable string; a negative delta stays negative.
+func (r RawParams) SizeInBytes(key string) (int64, error) {
+	switch value := r[key].(type) {
+	case nil:
+		return 0, nil
+	case string:
+		return ParseRAMInHuman(value)
+	default:
+		return r.Int64(key), nil
+	}
+}
+
 func (r RawParams) Int(key string) int {
 	return intHelper[int](r, key)
 }

--- a/resource/types/resource_test.go
+++ b/resource/types/resource_test.go
@@ -6,6 +6,31 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestSizeInBytesTakesEitherForm(t *testing.T) {
+	r := RawParams{
+		"bytes":    int64(1073741824),
+		"json-num": float64(2147483648),
+		"human":    "1G",
+		"delta":    int64(-1073741824),
+		"neg-str":  "-1G",
+		"junk":     "1Q",
+	}
+	for key, want := range map[string]int64{
+		"bytes":    1073741824,
+		"json-num": 2147483648,
+		"human":    1073741824,
+		"delta":    -1073741824,
+		"neg-str":  -1073741824,
+		"absent":   0,
+	} {
+		got, err := r.SizeInBytes(key)
+		assert.NoError(t, err, key)
+		assert.Equal(t, want, got, key)
+	}
+	_, err := r.SizeInBytes("junk")
+	assert.Error(t, err)
+}
+
 func TestRawParams(t *testing.T) {
 	var r RawParams
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -18,6 +18,7 @@ import (
 	"github.com/projecteru2/core/cluster"
 	enginetypes "github.com/projecteru2/core/engine/types"
 	"github.com/projecteru2/core/log"
+	resourcetypes "github.com/projecteru2/core/resource/types"
 	"github.com/projecteru2/core/types"
 )
 
@@ -254,6 +255,11 @@ func ParseVolumeBinds(volumes, env []string) []VolumeBind {
 		binds = append(binds, VolumeBind{Source: parts[0], Dest: parts[1], ReadOnly: len(parts) > 2 && parts[2] == "ro"})
 	}
 	return binds
+}
+
+// ParseRAMInHuman parses a human-readable size ("100KB", "-1T") into bytes; the implementation lives beside RawParams.
+func ParseRAMInHuman(ram string) (int64, error) {
+	return resourcetypes.ParseRAMInHuman(ram)
 }
 
 // ParseRate reads a human byte rate, treating junk and negatives as zero.


### PR DESCRIPTION
The deferred size-semantics unification, core half.

Two parsers answered the same wire question differently, each with a silent-zero path:
- `cpumem` node parse (`Int64 > 0` else string): a **numeric negative — a legal delta for `set-node-capacity`/`set-node-usage` — silently became 0**, while the string form `"-1G"` passed through. Same class as resource-extend#8, live on the delta path.
- `cpumem` workload parse (bare `Int64`): a **human string `"1G"` in `memory-request`/`memory-limit` silently became 0** — the exact mirror of rext#8.

`RawParams.SizeInBytes(key)` answers it once: plain byte count as-is (sign preserved), string through `ParseRAMInHuman`, absent → 0, junk → an error that `WorkloadResourceRequest.Parse` now returns and all three plugin verbs propagate instead of computing on zeros.

`ParseRAMInHuman` relocates from `utils` to `resource/types` (utils already imports resource/types, so the accessor could not reach it without a cycle); `utils.ParseRAMInHuman` remains as a forwarding alias for `ParseRate` and the sibling repos. Follow-ups once this merges: rext drops its `parseSizeInBytes` for the shared accessor, cli drops its `ParseRAMInHuman` copy — both ride one pin bump.