### PR TITLE
Fix possible fix(deps): 2 vulnerable dependencies in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/panjf2000/ants/v2 v2.12.1
 	github.com/pkg/sftp v1.13.11
 	github.com/prometheus/client_golang v1.24.1
+	github.com/prometheus/client_model v0.6.2
 	github.com/redis/go-redis/v9 v9.22.0
 	github.com/rs/zerolog v1.35.1
 	github.com/sanity-io/litter v1.5.8
@@ -112,7 +113,6 @@ require (
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.70.1 // indirect
 	github.com/prometheus/procfs v0.21.1 // indirect
 	github.com/rogpeppe/go-internal v1.16.0 // indirect
@@ -151,7 +151,7 @@ require (
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	golang.org/x/exp v0.0.0-20260820142414-ca536658362e // indirect
-	golang.org/x/mod v0.39.0 // indirect
+	golang.org/x/mod v0.40.0 // indirect
 	golang.org/x/net v0.58.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.41.0 // indirect


### PR DESCRIPTION
This changes `go.mod` to address something a scan flagged. It is around line 1.

The project depends on golang.org/x/mod v0.39.0, which is vulnerable to CVE-2026-56864. A compromised GOSUMDB can serve arbitrary module code that bypasses the Go module checksum database and transparency log, allowing an attacker to inject malicious code into builds without detection. This poses a high risk of supply‑chain compromise. Upgrading to the fixed version (v0.40.0) eliminates the flaw by incorporating the mitigations for malicious GOSUMDB handling.

Update golang.org/x/mod from v0.39.0 to v0.40.0 to resolve CVE‑2026‑56864 and CVE‑2026‑56865.

For reference: rule `CVE-2026-56864`. Rated high.

I may well be missing context here — if the current code is deliberate, feel free to close this.

---
*Found with automated scanning ([RedGem](https://code.redgem.net)) and reviewed before opening. If it is not useful, closing it is completely fine.*
