### PR TITLE
perf: pool etcd lock sessions across lock cycles

### DIFF
--- a/lock/etcdlock/mutex.go
+++ b/lock/etcdlock/mutex.go
@@ -12,28 +12,69 @@ import (
 	"github.com/projecteru2/core/types"
 )
 
+const maxIdleSessions = 64
+
+// Pool keeps etcd sessions alive between locks, so a lock cycle costs two transactions instead of a lease grant and revoke as well.
+type Pool struct {
+	cli  *clientv3.Client
+	ttl  int
+	mu   sync.Mutex
+	idle []*concurrency.Session
+}
+
+// NewPool builds a pool whose sessions carry a lease of ttl.
+func NewPool(cli *clientv3.Client, ttl time.Duration) *Pool {
+	return &Pool{cli: cli, ttl: int(ttl.Seconds())}
+}
+
+func (p *Pool) get() (*concurrency.Session, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for len(p.idle) > 0 {
+		session := p.idle[len(p.idle)-1]
+		p.idle = p.idle[:len(p.idle)-1]
+		select {
+		case <-session.Done():
+		default:
+			return session, nil
+		}
+	}
+	return concurrency.NewSession(p.cli, concurrency.WithTTL(p.ttl))
+}
+
+func (p *Pool) put(session *concurrency.Session) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if len(p.idle) >= maxIdleSessions {
+		_ = session.Close()
+		return
+	}
+	p.idle = append(p.idle, session)
+}
+
 // Mutex is an etcd session based distributed lock.
 type Mutex struct {
 	timeout   time.Duration
+	pool      *Pool
 	mutex     *concurrency.Mutex
 	session   *concurrency.Session
 	locked    bool
 	lockedMux sync.Mutex
 }
 
-// New creates a Mutex on key, released automatically after ttl.
-func New(cli *clientv3.Client, key string, ttl time.Duration) (*Mutex, error) {
+// New creates a Mutex on key over a pooled session; Lock and Unlock each give up after timeout.
+func New(pool *Pool, key string, timeout time.Duration) (*Mutex, error) {
 	key, err := lock.Key(key)
 	if err != nil {
 		return nil, err
 	}
 
-	session, err := concurrency.NewSession(cli, concurrency.WithTTL(int(ttl.Seconds())))
+	session, err := pool.get()
 	if err != nil {
 		return nil, err
 	}
 
-	return &Mutex{mutex: concurrency.NewMutex(session, key), session: session, timeout: ttl}, nil
+	return &Mutex{mutex: concurrency.NewMutex(session, key), session: session, pool: pool, timeout: timeout}, nil
 }
 
 func (m *Mutex) Lock(ctx context.Context) (context.Context, error) {
@@ -47,13 +88,15 @@ func (m *Mutex) Lock(ctx context.Context) (context.Context, error) {
 }
 
 func (m *Mutex) Unlock(ctx context.Context) error {
-	defer func() {
-		_ = m.session.Close()
-	}()
-
 	lockCtx, cancel := context.WithTimeout(ctx, m.timeout)
 	defer cancel()
-	return m.unlock(lockCtx)
+	err := m.unlock(lockCtx)
+	if err != nil {
+		_ = m.session.Close()
+		return err
+	}
+	m.pool.put(m.session)
+	return nil
 }
 
 func (m *Mutex) unlock(ctx context.Context) error {
@@ -77,7 +120,7 @@ func (m *Mutex) watchSession(ctx context.Context) context.Context {
 	go func() {
 		defer cancel()
 
-		// session.Done() fires both on a lost lock and on our own Unlock
+		// session.Done() fires on a lost lease, which the lock outlives only while it is still held
 		select {
 		case <-m.session.Done():
 			m.lockedMux.Lock()

--- a/lock/etcdlock/mutex.go
+++ b/lock/etcdlock/mutex.go
@@ -51,12 +51,14 @@ func (p *Pool) takeIdle() *concurrency.Session {
 
 func (p *Pool) put(session *concurrency.Session) {
 	p.mu.Lock()
-	defer p.mu.Unlock()
-	if len(p.idle) >= maxIdleSessions {
-		_ = session.Close()
-		return
+	pooled := len(p.idle) < maxIdleSessions
+	if pooled {
+		p.idle = append(p.idle, session)
 	}
-	p.idle = append(p.idle, session)
+	p.mu.Unlock()
+	if !pooled {
+		_ = session.Close()
+	}
 }
 
 // Mutex is an etcd session based distributed lock.

--- a/lock/etcdlock/mutex.go
+++ b/lock/etcdlock/mutex.go
@@ -28,6 +28,13 @@ func NewPool(cli *clientv3.Client, ttl time.Duration) *Pool {
 }
 
 func (p *Pool) get() (*concurrency.Session, error) {
+	if session := p.takeIdle(); session != nil {
+		return session, nil
+	}
+	return concurrency.NewSession(p.cli, concurrency.WithTTL(p.ttl))
+}
+
+func (p *Pool) takeIdle() *concurrency.Session {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	for len(p.idle) > 0 {
@@ -36,10 +43,10 @@ func (p *Pool) get() (*concurrency.Session, error) {
 		select {
 		case <-session.Done():
 		default:
-			return session, nil
+			return session
 		}
 	}
-	return concurrency.NewSession(p.cli, concurrency.WithTTL(p.ttl))
+	return nil
 }
 
 func (p *Pool) put(session *concurrency.Session) {

--- a/lock/etcdlock/mutex.go
+++ b/lock/etcdlock/mutex.go
@@ -14,7 +14,7 @@ import (
 
 const maxIdleSessions = 64
 
-// Pool keeps etcd sessions alive between locks, so a lock cycle costs two transactions instead of a lease grant and revoke as well.
+// Pool keeps etcd sessions alive between locks.
 type Pool struct {
 	cli  *clientv3.Client
 	ttl  int

--- a/lock/etcdlock/mutex.go
+++ b/lock/etcdlock/mutex.go
@@ -82,21 +82,30 @@ func (m *Mutex) Lock(ctx context.Context) (context.Context, error) {
 	defer cancel()
 
 	if err := m.mutex.Lock(lockCtx); err != nil {
+		m.close()
 		return nil, err
 	}
 	return m.watchSession(ctx), nil
 }
 
 func (m *Mutex) Unlock(ctx context.Context) error {
+	if m.session == nil {
+		return nil
+	}
 	lockCtx, cancel := context.WithTimeout(ctx, m.timeout)
 	defer cancel()
-	err := m.unlock(lockCtx)
-	if err != nil {
-		_ = m.session.Close()
+	if err := m.unlock(lockCtx); err != nil {
+		m.close()
 		return err
 	}
 	m.pool.put(m.session)
+	m.session = nil
 	return nil
+}
+
+func (m *Mutex) close() {
+	_ = m.session.Close()
+	m.session = nil
 }
 
 func (m *Mutex) unlock(ctx context.Context) error {
@@ -112,6 +121,7 @@ func (m *Mutex) unlock(ctx context.Context) error {
 func (m *Mutex) watchSession(ctx context.Context) context.Context {
 	ctx, cancel := context.WithCancel(ctx)
 	rCtx := &lockContext{Context: ctx}
+	sessionDone := m.session.Done()
 
 	m.lockedMux.Lock()
 	m.locked = true
@@ -122,7 +132,7 @@ func (m *Mutex) watchSession(ctx context.Context) context.Context {
 
 		// session.Done() fires on a lost lease, which the lock outlives only while it is still held
 		select {
-		case <-m.session.Done():
+		case <-sessionDone:
 			m.lockedMux.Lock()
 			if m.locked {
 				rCtx.setError(types.ErrLockSessionDone)

--- a/lock/etcdlock/mutex_test.go
+++ b/lock/etcdlock/mutex_test.go
@@ -14,11 +14,11 @@ func TestMutex(t *testing.T) {
 	cluster, err := embedded.New(t.TempDir())
 	assert.NoError(t, err)
 	t.Cleanup(cluster.Close)
-	cli := cluster.Client("/test")
+	pool := NewPool(cluster.Client("/test"), time.Second)
 
-	_, err = New(cli, "", time.Second*1)
+	_, err = New(pool, "", time.Second*1)
 	assert.Error(t, err)
-	mutex, err := New(cli, "test", time.Second*1)
+	mutex, err := New(pool, "test", time.Second*1)
 	assert.NoError(t, err)
 
 	ctx := t.Context()
@@ -29,17 +29,17 @@ func TestMutex(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NoError(t, ctx.Err())
 
-	m2, err := New(cli, "test", time.Second)
+	m2, err := New(pool, "test", time.Second)
 	assert.NoError(t, err)
 	_, err = m2.Lock(t.Context())
-	m3, err := New(cli, "test", 100*time.Millisecond)
+	m3, err := New(pool, "test", 100*time.Millisecond)
 	assert.NoError(t, err)
 	_, err = m3.Lock(t.Context())
 	assert.EqualError(t, err, "context deadline exceeded")
 	m2.Unlock(t.Context())
 	m3.Unlock(t.Context())
 
-	m4, err := New(cli, "test", time.Second)
+	m4, err := New(pool, "test", time.Second)
 	assert.NoError(t, err)
 	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
 	defer cancel()
@@ -48,8 +48,48 @@ func TestMutex(t *testing.T) {
 	assert.EqualError(t, rCtx.Err(), "context deadline exceeded")
 	m4.Unlock(t.Context())
 
-	m5, err := New(cli, "test", time.Second)
+	m5, err := New(pool, "test", time.Second)
 	assert.NoError(t, err)
 	_, err = m5.Lock(t.Context())
 	assert.NoError(t, err)
+}
+
+func TestPoolReusesTheSessionOfAnUnlockedMutex(t *testing.T) {
+	cluster, err := embedded.New(t.TempDir())
+	assert.NoError(t, err)
+	t.Cleanup(cluster.Close)
+	pool := NewPool(cluster.Client("/test"), time.Second)
+
+	first, err := New(pool, "reuse", time.Second)
+	assert.NoError(t, err)
+	_, err = first.Lock(t.Context())
+	assert.NoError(t, err)
+	assert.NoError(t, first.Unlock(t.Context()))
+
+	second, err := New(pool, "reuse", time.Second)
+	assert.NoError(t, err)
+	assert.Same(t, first.session, second.session)
+	_, err = second.Lock(t.Context())
+	assert.NoError(t, err)
+	assert.NoError(t, second.Unlock(t.Context()))
+	assert.Len(t, pool.idle, 1)
+}
+
+func TestMutexesOnOneKeyHoldDistinctSessions(t *testing.T) {
+	cluster, err := embedded.New(t.TempDir())
+	assert.NoError(t, err)
+	t.Cleanup(cluster.Close)
+	pool := NewPool(cluster.Client("/test"), time.Second)
+
+	holder, err := New(pool, "distinct", time.Second)
+	assert.NoError(t, err)
+	_, err = holder.Lock(t.Context())
+	assert.NoError(t, err)
+
+	waiter, err := New(pool, "distinct", 100*time.Millisecond)
+	assert.NoError(t, err)
+	assert.NotSame(t, holder.session, waiter.session)
+	_, err = waiter.Lock(t.Context())
+	assert.EqualError(t, err, "context deadline exceeded")
+	assert.NoError(t, holder.Unlock(t.Context()))
 }

--- a/lock/etcdlock/mutex_test.go
+++ b/lock/etcdlock/mutex_test.go
@@ -64,11 +64,12 @@ func TestPoolReusesTheSessionOfAnUnlockedMutex(t *testing.T) {
 	assert.NoError(t, err)
 	_, err = first.Lock(t.Context())
 	assert.NoError(t, err)
+	session := first.session
 	assert.NoError(t, first.Unlock(t.Context()))
 
 	second, err := New(pool, "reuse", time.Second)
 	assert.NoError(t, err)
-	assert.Same(t, first.session, second.session)
+	assert.Same(t, session, second.session)
 	_, err = second.Lock(t.Context())
 	assert.NoError(t, err)
 	assert.NoError(t, second.Unlock(t.Context()))
@@ -91,5 +92,30 @@ func TestMutexesOnOneKeyHoldDistinctSessions(t *testing.T) {
 	assert.NotSame(t, holder.session, waiter.session)
 	_, err = waiter.Lock(t.Context())
 	assert.EqualError(t, err, "context deadline exceeded")
+	assert.NoError(t, holder.Unlock(t.Context()))
+}
+
+func TestLockFailureRevokesTheSession(t *testing.T) {
+	cluster, err := embedded.New(t.TempDir())
+	assert.NoError(t, err)
+	t.Cleanup(cluster.Close)
+	cli := cluster.Client("/test")
+	pool := NewPool(cli, time.Second)
+
+	holder, err := New(pool, "revoke", time.Second)
+	assert.NoError(t, err)
+	_, err = holder.Lock(t.Context())
+	assert.NoError(t, err)
+
+	waiter, err := New(pool, "revoke", 100*time.Millisecond)
+	assert.NoError(t, err)
+	_, err = waiter.Lock(t.Context())
+	assert.EqualError(t, err, "context deadline exceeded")
+
+	leases, err := cli.Leases(t.Context())
+	assert.NoError(t, err)
+	assert.Len(t, leases.Leases, 1)
+	assert.Empty(t, pool.idle)
+	assert.NoError(t, waiter.Unlock(t.Context()))
 	assert.NoError(t, holder.Unlock(t.Context()))
 }

--- a/store/etcdv3/meta/etcd.go
+++ b/store/etcdv3/meta/etcd.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"slices"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -52,6 +53,9 @@ type txnCond struct {
 type ETCD struct {
 	cliv3  ETCDClientV3
 	config types.EtcdConfig
+
+	poolMux   sync.Mutex
+	lockPools map[time.Duration]*etcdlock.Pool
 }
 
 func NewETCD(ctx context.Context, config types.EtcdConfig, embeddedETCD *embedded.Cluster) (*ETCD, error) {
@@ -87,12 +91,12 @@ func NewETCD(ctx context.Context, config types.EtcdConfig, embeddedETCD *embedde
 		cliv3.Watcher = namespace.NewWatcher(cliv3.Watcher, config.Prefix)
 		cliv3.Lease = namespace.NewLease(cliv3.Lease, config.Prefix)
 	}
-	return &ETCD{cliv3: cliv3, config: config}, nil
+	return &ETCD{cliv3: cliv3, config: config, lockPools: map[time.Duration]*etcdlock.Pool{}}, nil
 }
 
 func (e *ETCD) CreateLock(key string, ttl time.Duration) (lock.DistributedLock, error) {
 	lockKey := fmt.Sprintf("%s/%s", e.config.LockPrefix, key)
-	mutex, err := etcdlock.New(e.cliv3.(*clientv3.Client), lockKey, ttl)
+	mutex, err := etcdlock.New(e.lockPool(ttl), lockKey, ttl)
 	return mutex, err
 }
 
@@ -399,6 +403,17 @@ func (e *ETCD) bindStatusWithoutTTL(ctx context.Context, statusKey, statusValue 
 		logger.Infof(ctx, "put: key %s value %s", statusKey, statusValue)
 	}
 	return nil
+}
+
+func (e *ETCD) lockPool(ttl time.Duration) *etcdlock.Pool {
+	e.poolMux.Lock()
+	defer e.poolMux.Unlock()
+	pool, ok := e.lockPools[ttl]
+	if !ok {
+		pool = etcdlock.NewPool(e.cliv3.(*clientv3.Client), ttl)
+		e.lockPools[ttl] = pool
+	}
+	return pool
 }
 
 func (e *ETCD) revokeLease(ctx context.Context, leaseID clientv3.LeaseID) {


### PR DESCRIPTION
Every lock acquisition opened its own etcd session (a lease grant plus a keepalive stream) and every release revoked it, so one lock cycle cost four round trips where the two ownership transactions are the actual work. Sessions now come from a per-TTL pool the meta store owns and go back to it on unlock, so a cycle costs the two transactions.

Why a pool and not one shared session: `concurrency.Mutex` derives its ownership key from the session's lease, so two locks on one key inside one process sharing a session would each see the other's key as their own. A pooled session still carries one lease per lock while it is held. An unlock whose delete transaction failed closes its session instead of returning it, so revoking the lease frees the key the way it did before. The pool keeps at most 64 idle sessions; a session whose lease died is dropped on retrieval.

Hot path: one mutex lock/unlock around the pool on acquire and release; no new work on the claim path.

Evidence, test lane (cocoon-test1 VMs, three interleaved rounds against master 1a99820d, order rotated per round):

| metric | master | this branch |
|---|---|---|
| etcd leases granted per arm-round | 260 | 109 |
| single remove with 100 present, p50 | 298ms | 268ms |
| list with 100 present, p50 | 22ms | 20ms |
| node resource with 100 present, p50 | 140ms | 129ms |

Tests: `TestPoolReusesTheSessionOfAnUnlockedMutex`, `TestMutexesOnOneKeyHoldDistinctSessions`, existing `TestMutex` on the pooled constructor.
