### PR TITLE
fix: revoke the lease a lost selfmon election granted

### DIFF
--- a/selfmon/selfmon.go
+++ b/selfmon/selfmon.go
@@ -56,16 +56,11 @@ func (n *NodeStatusWatcher) withActiveLock(parentCtx context.Context, f func(ctx
 		}
 	}()
 
+	retryInterval := max(time.Second, n.config.HAKeepaliveInterval/4)
+	warnEvery := max(1, int(time.Minute/retryInterval))
 	retryCounter := 0
 
 	for {
-		select {
-		case <-ctx.Done():
-			logger.Info(ctx, "context canceled")
-			return
-		default:
-		}
-
 		ne, un, err := n.store.StartEphemeral(ctx, ActiveKey, n.config.HAKeepaliveInterval)
 		if err == nil {
 			logger.Info(ctx, "node status watcher has been active")
@@ -77,16 +72,19 @@ func (n *NodeStatusWatcher) withActiveLock(parentCtx context.Context, f func(ctx
 			logger.Info(ctx, "context canceled")
 			return
 		}
-		if !errors.Is(err, types.ErrKeyExists) {
+		switch {
+		case !errors.Is(err, types.ErrKeyExists):
 			logger.Error(ctx, err, "failed to register")
-			time.Sleep(time.Second)
-			continue
-		}
-		if retryCounter == 0 {
+		case retryCounter == 0:
 			logger.Warn(ctx, "failed to register, there has been another active node status watcher")
 		}
-		retryCounter = (retryCounter + 1) % 60
-		time.Sleep(time.Second)
+		retryCounter = (retryCounter + 1) % warnEvery
+		select {
+		case <-ctx.Done():
+			logger.Info(ctx, "context canceled")
+			return
+		case <-time.After(retryInterval):
+		}
 	}
 
 	go func() {

--- a/store/etcdv3/meta/ephemeral.go
+++ b/store/etcdv3/meta/ephemeral.go
@@ -24,8 +24,10 @@ func (e *ETCD) StartEphemeral(ctx context.Context, path string, heartbeat time.D
 		Then(clientv3.OpPut(path, "", clientv3.WithLease(lease.ID))).
 		Commit(); {
 	case err != nil:
+		e.revokeLease(ctx, lease.ID)
 		return nil, nil, err
 	case !tx.Succeeded:
+		e.revokeLease(ctx, lease.ID)
 		return nil, nil, errors.Wrap(types.ErrKeyExists, path)
 	}
 

--- a/store/etcdv3/meta/ephemeral_test.go
+++ b/store/etcdv3/meta/ephemeral_test.go
@@ -87,4 +87,8 @@ func TestEphemeralFailedAsPutAlready(t *testing.T) {
 
 	_, _, err = m.StartEphemeral(ctx, path, heartbeat)
 	require.Error(t, err)
+
+	leases, err := m.cliv3.Leases(ctx)
+	require.NoError(t, err)
+	require.Len(t, leases.Leases, 1)
 }

--- a/store/etcdv3/meta/etcd.go
+++ b/store/etcdv3/meta/etcd.go
@@ -23,6 +23,8 @@ import (
 )
 
 const (
+	revokeTimeout = 10 * time.Second
+
 	cmpVersion = "version"
 	cmpValue   = "value"
 
@@ -405,6 +407,8 @@ func (e *ETCD) revokeLease(ctx context.Context, leaseID clientv3.LeaseID) {
 	if leaseID == 0 {
 		return
 	}
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), revokeTimeout)
+	defer cancel()
 	if _, err := e.cliv3.Revoke(ctx, leaseID); err != nil {
 		log.WithFunc("store.etcdv3.meta.revokeLease").Error(ctx, err, "revoke lease failed")
 	}


### PR DESCRIPTION
`StartEphemeral` granted its lease before the compare-and-put, and a lost election returned `ErrKeyExists` without revoking it. Every standby core therefore left one dead lease per attempt against a one-second retry loop: about sixteen outstanding leases at all times, and two etcd round trips per second per standby, for the life of the process.

The lost lease is now revoked on both the failed transaction and the lost compare, and the standby retries every quarter of `ha_keepalive_interval` instead of every second, waiting on the context so shutdown is not delayed. The leader's keepalive is unchanged.

Evidence, test lane with two cores (one leader, one standby), two rounds each:

| metric | master | this branch |
|---|---|---|
| leases granted per idle 60s | 66 | 21 |
| leases outstanding | 23 | 6 |

Test: `TestEphemeralFailedAsPutAlready` now asserts exactly one lease remains after the lost election.
