### PR TITLE
fix: lease a workload status whose record is absent

### DIFF
--- a/store/etcdv3/meta/etcd.go
+++ b/store/etcdv3/meta/etcd.go
@@ -367,7 +367,6 @@ func (e *ETCD) bindStatusWithTTL(ctx context.Context, entityKey, statusKey, stat
 	return err
 }
 
-// bindStatusWithoutTTL skips the entity check: an agent may report status before core records the entity.
 func (e *ETCD) bindStatusWithoutTTL(ctx context.Context, entityKey, statusKey, statusValue string) error {
 	logger := log.WithFunc("store.etcdv3.meta.bindStatusWithoutTTL")
 

--- a/store/etcdv3/meta/etcd.go
+++ b/store/etcdv3/meta/etcd.go
@@ -395,9 +395,19 @@ func (e *ETCD) bindStatusWithoutTTL(ctx context.Context, entityKey, statusKey, s
 	if err != nil {
 		return err
 	}
-	if _, err = e.cliv3.Put(ctx, statusKey, statusValue, clientv3.WithLease(lease.ID)); err != nil {
+	orphaned, err := e.cliv3.Txn(ctx).
+		If(clientv3.Compare(clientv3.Version(entityKey), "=", 0)).
+		Then(clientv3.OpPut(statusKey, statusValue, clientv3.WithLease(lease.ID))).
+		Else(clientv3.OpPut(statusKey, statusValue)).
+		Commit()
+	if err != nil {
 		e.revokeLease(ctx, lease.ID)
 		return err
+	}
+	if !orphaned.Succeeded {
+		e.revokeLease(ctx, lease.ID)
+		logger.Infof(ctx, "put: key %s value %s", statusKey, statusValue)
+		return nil
 	}
 	logger.Infof(ctx, "put: key %s value %s, leased %ds without %s", statusKey, statusValue, orphanStatusTTL, entityKey)
 	return nil

--- a/store/etcdv3/meta/etcd.go
+++ b/store/etcdv3/meta/etcd.go
@@ -27,6 +27,8 @@ const (
 	cmpValue   = "value"
 
 	txnLimit = 125
+
+	orphanStatusTTL = int64(time.Hour / time.Second)
 )
 
 // ETCDClientV3 is the etcd client surface the store depends on.
@@ -182,7 +184,7 @@ func (e *ETCD) BatchPut(ctx context.Context, data map[string]string) (*clientv3.
 
 func (e *ETCD) BindStatus(ctx context.Context, entityKey, statusKey, statusValue string, ttl int64) error {
 	if ttl == 0 {
-		return e.bindStatusWithoutTTL(ctx, statusKey, statusValue)
+		return e.bindStatusWithoutTTL(ctx, entityKey, statusKey, statusValue)
 	}
 	return e.bindStatusWithTTL(ctx, entityKey, statusKey, statusValue, ttl)
 }
@@ -366,38 +368,39 @@ func (e *ETCD) bindStatusWithTTL(ctx context.Context, entityKey, statusKey, stat
 }
 
 // bindStatusWithoutTTL skips the entity check: an agent may report status before core records the entity.
-func (e *ETCD) bindStatusWithoutTTL(ctx context.Context, statusKey, statusValue string) error {
-	updateStatus := []clientv3.Op{clientv3.OpPut(statusKey, statusValue)}
+func (e *ETCD) bindStatusWithoutTTL(ctx context.Context, entityKey, statusKey, statusValue string) error {
 	logger := log.WithFunc("store.etcdv3.meta.bindStatusWithoutTTL")
 
-	ttlChanged, err := e.isTTLChanged(ctx, statusKey, 0)
-	if err != nil {
-		return err
-	}
-	if ttlChanged {
-		if _, err = e.Put(ctx, statusKey, statusValue); err != nil {
-			return err
-		}
-
-		logger.Infof(ctx, "put: key %s value %s", statusKey, statusValue)
-		return nil
-	}
-
 	resp, err := e.cliv3.Txn(ctx).
-		If(clientv3.Compare(clientv3.Version(statusKey), "!=", 0)).
+		If(clientv3.Compare(clientv3.Version(entityKey), "!=", 0)).
 		Then(clientv3.OpTxn(
-			[]clientv3.Cmp{clientv3.Compare(clientv3.Value(statusKey), "!=", statusValue)},
-			updateStatus,
+			[]clientv3.Cmp{
+				clientv3.Compare(clientv3.Value(statusKey), "=", statusValue),
+				clientv3.Compare(clientv3.LeaseValue(statusKey), "=", 0),
+			},
 			[]clientv3.Op{},
+			[]clientv3.Op{clientv3.OpPut(statusKey, statusValue)},
 		)).
-		Else(updateStatus...).
 		Commit()
 	if err != nil {
 		return err
 	}
-	if !resp.Succeeded || resp.Responses[0].GetResponseTxn().Succeeded {
-		logger.Infof(ctx, "put: key %s value %s", statusKey, statusValue)
+	if resp.Succeeded {
+		if !resp.Responses[0].GetResponseTxn().Succeeded {
+			logger.Infof(ctx, "put: key %s value %s", statusKey, statusValue)
+		}
+		return nil
 	}
+
+	lease, err := e.cliv3.Grant(ctx, orphanStatusTTL)
+	if err != nil {
+		return err
+	}
+	if _, err = e.cliv3.Put(ctx, statusKey, statusValue, clientv3.WithLease(lease.ID)); err != nil {
+		e.revokeLease(ctx, lease.ID)
+		return err
+	}
+	logger.Infof(ctx, "put: key %s value %s, leased %ds without %s", statusKey, statusValue, orphanStatusTTL, entityKey)
 	return nil
 }
 

--- a/store/etcdv3/meta/etcd_test.go
+++ b/store/etcdv3/meta/etcd_test.go
@@ -159,6 +159,23 @@ func TestBindStatusWithZeroTTL(t *testing.T) {
 	require.Equal(t, nil, e.BindStatus(t.Context(), "/entity", "/status", "status", 0))
 }
 
+func TestBindStatusOrphanPutYieldsToAnEntityThatAppeared(t *testing.T) {
+	e, etcd, assert := testKeepAliveETCD(t)
+	defer assert()
+
+	txn := &mocks.Txn{}
+	defer txn.AssertExpectations(t)
+	txn.On("If", mock.Anything).Return(txn)
+	txn.On("Then", mock.Anything).Return(txn)
+	txn.On("Else", mock.Anything).Return(txn)
+	txn.On("Commit").Return(&clientv3.TxnResponse{Succeeded: false}, nil)
+
+	etcd.On("Txn", mock.Anything).Return(txn)
+	etcd.On("Grant", mock.Anything, mock.Anything).Return(&clientv3.LeaseGrantResponse{ID: 7}, nil)
+	etcd.On("Revoke", mock.Anything, clientv3.LeaseID(7)).Return(&clientv3.LeaseRevokeResponse{}, nil)
+	require.NoError(t, e.BindStatus(t.Context(), "/entity", "/status", "status", 0))
+}
+
 func TestBindStatusWithoutEntityCarriesALease(t *testing.T) {
 	e := NewEmbeddedETCD(t)
 	ctx := t.Context()

--- a/store/etcdv3/meta/etcd_test.go
+++ b/store/etcdv3/meta/etcd_test.go
@@ -152,13 +152,33 @@ func TestBindStatusWithZeroTTL(t *testing.T) {
 	defer txn.AssertExpectations(t)
 	txn.On("If", mock.Anything).Return(txn)
 	txn.On("Then", mock.Anything).Return(txn)
-	txn.On("Else", mock.Anything).Return(txn)
 	txn.On("Commit").Return(entityTxn, nil)
 
 	etcd.On("Txn", mock.Anything).Return(txn)
 
-	etcd.On("Get", mock.Anything, mock.Anything).Return(&clientv3.GetResponse{}, nil)
 	require.Equal(t, nil, e.BindStatus(t.Context(), "/entity", "/status", "status", 0))
+}
+
+func TestBindStatusWithoutEntityCarriesALease(t *testing.T) {
+	e := NewEmbeddedETCD(t)
+	ctx := t.Context()
+
+	require.NoError(t, e.BindStatus(ctx, "/entity", "/status", "gone", 0))
+	kv, err := e.GetOne(ctx, "/status")
+	require.NoError(t, err)
+	require.NotZero(t, kv.Lease)
+
+	_, err = e.Put(ctx, "/entity", "here")
+	require.NoError(t, err)
+	require.NoError(t, e.BindStatus(ctx, "/entity", "/status", "gone", 0))
+	kv, err = e.GetOne(ctx, "/status")
+	require.NoError(t, err)
+	require.Zero(t, kv.Lease)
+	require.Equal(t, "gone", string(kv.Value))
+
+	leases, err := e.cliv3.Leases(ctx)
+	require.NoError(t, err)
+	require.Len(t, leases.Leases, 1)
 }
 
 func TestBindStatusButValueTxnUnsuccessful(t *testing.T) {


### PR DESCRIPTION
The agent has reported every workload status with a zero TTL since selfmon moved into core (agent 1b75441, 2022), and the zero-TTL bind skipped the entity check on purpose so a status reported before its record landed was not lost. The same path accepted the die report the agent sends after core has removed a workload: `RemoveWorkload` deletes the status key, the engine kills the task, the agent reports `running: false`, and the key comes back with no lease and no record to hang off. Nothing ever removes it again. The test lane had collected three thousand such keys after one day of churn; a lambda-heavy cluster leaks one per invocation, and etcd's space quota is the eventual stop.

The zero-TTL bind is now one transaction. With the record present the status is written without a lease, and only when its value or its lease changed, so an unchanged report writes nothing. With the record absent it is written under a one-hour lease: an early report is adopted by the next report once the record exists, and a late report expires on its own. The hot path drops the `Get` and `TimeToLive` it made before the write.

Status stream subscribers already receive one not-found event when the die report lands; the lease expiry adds one delete event of the same class an hour later.

Tests: `TestBindStatusWithoutEntityCarriesALease` on embedded etcd; `TestBindStatusWithZeroTTL` updated to the single transaction.
