### PR TITLE
perf: ping a node with an ssh keepalive instead of a session

### DIFF
--- a/cluster/calcium/node.go
+++ b/cluster/calcium/node.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/cockroachdb/errors"
 
-	"github.com/projecteru2/core/engine"
 	enginefactory "github.com/projecteru2/core/engine/factory"
 	enginetypes "github.com/projecteru2/core/engine/types"
 	"github.com/projecteru2/core/log"
@@ -39,7 +38,7 @@ func (c *Calcium) AddNode(ctx context.Context, opts *types.AddNodeOptions) (*typ
 	if err != nil {
 		return nil, evict(err)
 	}
-	if err = verifyNodeEngine(ctx, client); err != nil {
+	if err = client.VerifyNode(ctx); err != nil {
 		logger.Error(ctx, err)
 		return nil, evict(err)
 	}
@@ -320,12 +319,4 @@ func (c *Calcium) setAllWorkloadsOnNodeDown(ctx context.Context, nodename string
 			logger.Infof(ctx, "set workload %s on node %s as inactive", workload.ID, nodename)
 		}
 	}
-}
-
-func verifyNodeEngine(ctx context.Context, client engine.API) error {
-	verifier, ok := client.(engine.NodeVerifier)
-	if !ok {
-		return nil
-	}
-	return verifier.VerifyNode(ctx)
 }

--- a/cluster/calcium/node_test.go
+++ b/cluster/calcium/node_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
-	"github.com/projecteru2/core/engine"
 	"github.com/projecteru2/core/engine/factory"
 	enginemocks "github.com/projecteru2/core/engine/mocks"
 	enginetypes "github.com/projecteru2/core/engine/types"
@@ -216,6 +215,7 @@ func TestGetNodeEngine(t *testing.T) {
 
 	engine := &enginemocks.API{}
 	engine.On("Info", mock.Anything).Return(&enginetypes.Info{Type: "fake"}, nil)
+	engine.On("VerifyNode", mock.Anything).Return(nil)
 	node := &types.Node{
 		NodeMeta: types.NodeMeta{Name: nodename},
 		Engine:   engine,
@@ -357,17 +357,3 @@ func TestFilterNodesDedupesIncludes(t *testing.T) {
 	}
 	assert.Equal(t, []string{"A", "B", "C"}, names)
 }
-
-func TestVerifyNodeEngineGatesOnTheEnginesVerdict(t *testing.T) {
-	ctx := t.Context()
-	assert.NoError(t, verifyNodeEngine(ctx, &enginemocks.API{}))
-	assert.NoError(t, verifyNodeEngine(ctx, verifierEngine{}))
-	assert.ErrorIs(t, verifyNodeEngine(ctx, verifierEngine{err: types.ErrMockError}), types.ErrMockError)
-}
-
-type verifierEngine struct {
-	engine.API
-	err error
-}
-
-func (v verifierEngine) VerifyNode(context.Context) error { return v.err }

--- a/docs/engines.md
+++ b/docs/engines.md
@@ -357,8 +357,9 @@ until its next start; in between, only a direct-boot guest's console logs are mi
 
 ### Node prerequisites
 
-cocoon, with `cocoon daemon` as a systemd service (the engine does not need it, eru-agent uses it
-for events), the cocoonstack `dev` builds of Cloud Hypervisor, Firecracker and
+cocoon — `AddNode` runs `cocoon version` once and refuses a node without it — with `cocoon daemon`
+as a systemd service (the engine does not need it, eru-agent uses it for events), the cocoonstack
+`dev` builds of Cloud Hypervisor, Firecracker and
 rust-hypervisor-firmware (the Windows fixes live there), the CNI plugin binaries in `/opt/cni/bin`
 with conf in `/etc/cni/net.d`, cocoon-agent inside the guest images (with `runuser`, `setpriv` and
 `env` there too, for execs that name a user or a working dir), `sshd` with core's key in
@@ -458,8 +459,9 @@ Two per-workload options ride in the deploy request's raw args:
 | `raw` | bool | Run on the host filesystem: no `RootDirectory=`, and the working directory defaults to the unpacked bundle. Such a workload has no filesystem boundary, so `ImageBuildFromExist` refuses it |
 | `tasks_max` | int | `TasksMax=` for the unit |
 
-Node prerequisites: systemd ≥ 244 on cgroup v2, `sshd`, `oras`, `util-linux` for `setpriv`,
-coreutils for `chroot`, and a writable `process.root`.
+Node prerequisites: systemd ≥ 244 on cgroup v2 — `AddNode` runs `systemctl --version` once and
+refuses a node without it — `sshd`, `oras`, `util-linux` for `setpriv`, coreutils for `chroot`,
+and a writable `process.root`.
 
 ### The bundle format
 
@@ -495,7 +497,10 @@ Two different things share the name:
 `engine/factory` keeps one client per `(endpoint, ca, cert, key)` tuple, so repeated calls to the
 same node reuse one connection. Two background loops keep it honest:
 
-- **Liveness sweep** — every `connection_timeout`, `Ping` every cached engine. A failing engine is
+- **Liveness sweep** — every `connection_timeout`, `Ping` every cached engine: `IsServing` over the
+  forward for containerd, an SSH keepalive request on the connection for process and cocoon. Neither
+  takes a session, so a node whose eight sessions are all held still answers, and the binary each
+  engine needs is checked once at `AddNode` instead. A failing engine is
   replaced by `EngineWithErr` holding the error; a cached `EngineWithErr` is retried, and if it
   connects, the real client takes its place. If the retry fails and the node's status key is gone,
   the entry is dropped.

--- a/engine/cocoon/cocoon.go
+++ b/engine/cocoon/cocoon.go
@@ -25,10 +25,7 @@ const (
 	defaultCgroupParent = "cocoon.slice"
 )
 
-var (
-	_ engine.API          = (*Engine)(nil)
-	_ engine.NodeVerifier = (*Engine)(nil)
-)
+var _ engine.API = (*Engine)(nil)
 
 // Engine runs VMs through the cocoon CLI over SSH.
 type Engine struct {

--- a/engine/cocoon/cocoon.go
+++ b/engine/cocoon/cocoon.go
@@ -6,6 +6,8 @@ import (
 	"slices"
 	"sync"
 
+	"github.com/cockroachdb/errors"
+
 	"github.com/projecteru2/core/engine"
 	"github.com/projecteru2/core/engine/sshrunner"
 	enginetypes "github.com/projecteru2/core/engine/types"
@@ -23,7 +25,10 @@ const (
 	defaultCgroupParent = "cocoon.slice"
 )
 
-var _ engine.API = (*Engine)(nil)
+var (
+	_ engine.API          = (*Engine)(nil)
+	_ engine.NodeVerifier = (*Engine)(nil)
+)
 
 // Engine runs VMs through the cocoon CLI over SSH.
 type Engine struct {
@@ -71,8 +76,14 @@ func (e *Engine) Info(ctx context.Context) (*enginetypes.Info, error) {
 }
 
 func (e *Engine) Ping(ctx context.Context) error {
-	_, err := e.run(ctx, e.cocoon.Binary, "version")
-	return err
+	return e.runner.Ping(ctx)
+}
+
+func (e *Engine) VerifyNode(ctx context.Context) error {
+	if _, err := e.run(ctx, e.cocoon.Binary, "version"); err != nil {
+		return errors.Wrapf(err, "node %s cannot serve %s", e.ep.Nodename, e.cocoon.Binary)
+	}
+	return nil
 }
 
 func (e *Engine) CloseConn() error {

--- a/engine/containerd/containerd.go
+++ b/engine/containerd/containerd.go
@@ -44,10 +44,7 @@ var machines = map[string]string{
 	"armv7l":  "arm",
 }
 
-var (
-	_ engine.API          = (*Engine)(nil)
-	_ engine.NodeVerifier = (*Engine)(nil)
-)
+var _ engine.API = (*Engine)(nil)
 
 // Engine runs containers through a node's own containerd socket, forwarded over SSH.
 type Engine struct {

--- a/engine/containerd/containerd.go
+++ b/engine/containerd/containerd.go
@@ -136,7 +136,6 @@ func (e *Engine) Ping(ctx context.Context) error {
 	return nil
 }
 
-// VerifyNode proves the node holds an agent binary that answers the hooks every spec references.
 func (e *Engine) VerifyNode(ctx context.Context) error {
 	if _, err := e.run(ctx, hookBinary, hookCommand, "--help"); err != nil {
 		return errors.Wrapf(err, "node %s cannot serve %s", e.ep.Nodename, hookBinary)

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -56,9 +56,7 @@ type API interface {
 	VirtualizationCopyFrom(ctx context.Context, ID, path string) (content []byte, uid, gid int, mode int64, _ error)
 
 	RawEngine(ctx context.Context, opts *enginetypes.RawEngineOptions) (*enginetypes.RawEngineResult, error)
-}
 
-// NodeVerifier vets the node-side dependencies an engine's workloads need, once, as the node is added.
-type NodeVerifier interface {
+	// VerifyNode vets the node-side dependencies the engine's workloads need, once, as the node is added.
 	VerifyNode(ctx context.Context) error
 }

--- a/engine/fake/fake.go
+++ b/engine/fake/fake.go
@@ -24,6 +24,10 @@ func (f *EngineWithErr) Ping(_ context.Context) error {
 	return f.DefaultErr
 }
 
+func (f *EngineWithErr) VerifyNode(_ context.Context) error {
+	return f.DefaultErr
+}
+
 func (f *EngineWithErr) CloseConn() error {
 	return nil
 }

--- a/engine/mocks/API.go
+++ b/engine/mocks/API.go
@@ -1611,6 +1611,57 @@ func (_c *API_RawEngine_Call) RunAndReturn(run func(ctx context.Context, opts *t
 	return _c
 }
 
+// VerifyNode provides a mock function for the type API
+func (_mock *API) VerifyNode(ctx context.Context) error {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for VerifyNode")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) error); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// API_VerifyNode_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'VerifyNode'
+type API_VerifyNode_Call struct {
+	*mock.Call
+}
+
+// VerifyNode is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *API_Expecter) VerifyNode(ctx any) *API_VerifyNode_Call {
+	return &API_VerifyNode_Call{Call: _e.mock.On("VerifyNode", ctx)}
+}
+
+func (_c *API_VerifyNode_Call) Run(run func(ctx context.Context)) *API_VerifyNode_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *API_VerifyNode_Call) Return(err error) *API_VerifyNode_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *API_VerifyNode_Call) RunAndReturn(run func(ctx context.Context) error) *API_VerifyNode_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // VirtualizationAttach provides a mock function for the type API
 func (_mock *API) VirtualizationAttach(ctx context.Context, ID string, stream bool, openStdin bool) (io.ReadCloser, io.ReadCloser, io.WriteCloser, error) {
 	ret := _mock.Called(ctx, ID, stream, openStdin)

--- a/engine/mocks/fakeengine/mock.go
+++ b/engine/mocks/fakeengine/mock.go
@@ -35,6 +35,7 @@ func MakeClient(_ context.Context, _ coretypes.Config, nodename, endpoint string
 	}
 	e.On("Info", mock.Anything).Return(&enginetypes.Info{NCPU: 100, MemTotal: units.GiB * 100, StorageTotal: units.GiB * 100}, nil)
 	e.On("Ping", mock.Anything).Return(nil)
+	e.On("VerifyNode", mock.Anything).Return(nil)
 	e.On("GetParams").Return(params)
 	e.On("CloseConn").Return(nil)
 	e.On("Execute", mock.Anything, mock.Anything, mock.Anything).Return(

--- a/engine/process/process.go
+++ b/engine/process/process.go
@@ -33,10 +33,7 @@ if mountpoint -q "$dir/merged"; then echo 1; else echo 0; fi
 cat "$dir/meta.json"
 `, workloadmeta.NotExistsCode)
 
-var (
-	_ engine.API          = (*Engine)(nil)
-	_ engine.NodeVerifier = (*Engine)(nil)
-)
+var _ engine.API = (*Engine)(nil)
 
 // Engine runs bare processes as systemd transient units over SSH.
 type Engine struct {

--- a/engine/process/process.go
+++ b/engine/process/process.go
@@ -33,7 +33,10 @@ if mountpoint -q "$dir/merged"; then echo 1; else echo 0; fi
 cat "$dir/meta.json"
 `, workloadmeta.NotExistsCode)
 
-var _ engine.API = (*Engine)(nil)
+var (
+	_ engine.API          = (*Engine)(nil)
+	_ engine.NodeVerifier = (*Engine)(nil)
+)
 
 // Engine runs bare processes as systemd transient units over SSH.
 type Engine struct {
@@ -76,8 +79,14 @@ func (e *Engine) Info(ctx context.Context) (*enginetypes.Info, error) {
 }
 
 func (e *Engine) Ping(ctx context.Context) error {
-	_, err := e.run(ctx, "systemctl", "--version")
-	return err
+	return e.runner.Ping(ctx)
+}
+
+func (e *Engine) VerifyNode(ctx context.Context) error {
+	if _, err := e.run(ctx, "systemctl", "--version"); err != nil {
+		return errors.Wrapf(err, "node %s cannot serve systemd", e.ep.Nodename)
+	}
+	return nil
 }
 
 func (e *Engine) CloseConn() error {

--- a/engine/sshrunner/info_test.go
+++ b/engine/sshrunner/info_test.go
@@ -88,6 +88,10 @@ func (r *stubRunner) Dial(context.Context, string, string) (net.Conn, error) {
 	return nil, os.ErrInvalid
 }
 
+func (r *stubRunner) Ping(context.Context) error {
+	return nil
+}
+
 func (r *stubRunner) Close() error {
 	return nil
 }

--- a/engine/sshrunner/runner.go
+++ b/engine/sshrunner/runner.go
@@ -13,6 +13,7 @@ type Runner interface {
 	Start(ctx context.Context, line string, opts *StartOptions) (Session, error)
 	Files(ctx context.Context) (Files, error)
 	Dial(ctx context.Context, network, addr string) (net.Conn, error)
+	Ping(ctx context.Context) error
 	Close() error
 }
 

--- a/engine/sshrunner/runner.go
+++ b/engine/sshrunner/runner.go
@@ -58,11 +58,6 @@ type FileInfo struct {
 	Mode os.FileMode
 }
 
-// Reader streams a running command's stdout and closes the session with it.
-func Reader(sess Session) io.ReadCloser {
-	return &sessionReader{Reader: sess.Stdout(), sess: sess}
-}
-
 type sessionReader struct {
 	io.Reader
 	sess Session
@@ -70,4 +65,9 @@ type sessionReader struct {
 
 func (r *sessionReader) Close() error {
 	return r.sess.Close()
+}
+
+// Reader streams a running command's stdout and closes the session with it.
+func Reader(sess Session) io.ReadCloser {
+	return &sessionReader{Reader: sess.Stdout(), sess: sess}
 }

--- a/engine/sshrunner/ssh.go
+++ b/engine/sshrunner/ssh.go
@@ -32,6 +32,8 @@ const (
 	keepaliveRequest = "keepalive@openssh.com"
 )
 
+type sshOp[T any] func(*ssh.Client) (T, error)
+
 var _ Runner = (*sshRunner)(nil)
 
 // sshRunner keeps one connection per node and redials when the transport drops.
@@ -135,13 +137,13 @@ func (r *sshRunner) Files(ctx context.Context) (Files, error) {
 	return &sftpFiles{client: remote, release: release}, nil
 }
 
-// Dial forwards a node socket; a forward is not a session, so MaxSessions does not bound it.
 func (r *sshRunner) Dial(ctx context.Context, network, addr string) (net.Conn, error) {
+	// a forward is not a session, so MaxSessions does not bound it
 	return retry(ctx, r, func(client *ssh.Client) (net.Conn, error) { return client.Dial(network, addr) })
 }
 
-// Ping is a global request on the connection itself, so a node whose sessions are all held still answers.
 func (r *sshRunner) Ping(ctx context.Context) error {
+	// a global request on the connection answers even when every session is held
 	_, err := retry(ctx, r, func(client *ssh.Client) (struct{}, error) {
 		replied := make(chan error, 1)
 		go func() {
@@ -303,11 +305,11 @@ func closeOnDone(ctx context.Context, sess *ssh.Session) func() {
 }
 
 // retry backs off on a refused channel open, and redials a transport that died underneath the call.
-func retry[T any](ctx context.Context, r *sshRunner, f func(*ssh.Client) (T, error)) (T, error) {
+func retry[T any](ctx context.Context, r *sshRunner, f sshOp[T]) (T, error) {
 	return retryRefused(ctx, func() (T, error) { return openOnce(ctx, r, f) })
 }
 
-func openOnce[T any](ctx context.Context, r *sshRunner, f func(*ssh.Client) (T, error)) (T, error) {
+func openOnce[T any](ctx context.Context, r *sshRunner, f sshOp[T]) (T, error) {
 	var zero T
 	client, err := r.connect(ctx, nil)
 	if err != nil {

--- a/engine/sshrunner/ssh.go
+++ b/engine/sshrunner/ssh.go
@@ -28,6 +28,8 @@ const (
 
 	openRetries       = 4
 	openRetryInterval = 100 * time.Millisecond
+
+	keepaliveRequest = "keepalive@openssh.com"
 )
 
 var _ Runner = (*sshRunner)(nil)
@@ -138,6 +140,24 @@ func (r *sshRunner) Dial(ctx context.Context, network, addr string) (net.Conn, e
 	return retry(ctx, r, func(client *ssh.Client) (net.Conn, error) { return client.Dial(network, addr) })
 }
 
+// Ping is a global request on the connection itself, so a node whose sessions are all held still answers.
+func (r *sshRunner) Ping(ctx context.Context) error {
+	_, err := retry(ctx, r, func(client *ssh.Client) (struct{}, error) {
+		replied := make(chan error, 1)
+		go func() {
+			_, _, err := client.SendRequest(keepaliveRequest, true, nil)
+			replied <- err
+		}()
+		select {
+		case err := <-replied:
+			return struct{}{}, err
+		case <-ctx.Done():
+			return struct{}{}, ctx.Err()
+		}
+	})
+	return err
+}
+
 func (r *sshRunner) Close() error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -153,11 +173,12 @@ func (r *sshRunner) newSession(ctx context.Context) (*ssh.Session, error) {
 	return retry(ctx, r, (*ssh.Client).NewSession)
 }
 
-func (r *sshRunner) connect(ctx context.Context, renew bool) (*ssh.Client, error) {
+// connect hands out the current client, and redials only when the caller's stale client is still the current one.
+func (r *sshRunner) connect(ctx context.Context, stale *ssh.Client) (*ssh.Client, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.client != nil {
-		if !renew {
+		if r.client != stale {
 			return r.client, nil
 		}
 		_ = r.client.Close()
@@ -288,7 +309,7 @@ func retry[T any](ctx context.Context, r *sshRunner, f func(*ssh.Client) (T, err
 
 func openOnce[T any](ctx context.Context, r *sshRunner, f func(*ssh.Client) (T, error)) (T, error) {
 	var zero T
-	client, err := r.connect(ctx, false)
+	client, err := r.connect(ctx, nil)
 	if err != nil {
 		return zero, err
 	}
@@ -296,7 +317,7 @@ func openOnce[T any](ctx context.Context, r *sshRunner, f func(*ssh.Client) (T, 
 	if err == nil || !isTransportError(err) {
 		return v, err
 	}
-	if client, err = r.connect(ctx, true); err != nil {
+	if client, err = r.connect(ctx, client); err != nil {
 		return zero, err
 	}
 	return f(client)

--- a/engine/sshrunner/ssh_test.go
+++ b/engine/sshrunner/ssh_test.go
@@ -86,6 +86,20 @@ func TestRetryRefusedStopsOnADoneContext(t *testing.T) {
 	}
 }
 
+func TestConnectKeepsAClientAnotherCallerRenewed(t *testing.T) {
+	runner := newSSHRunner("127.0.0.1:1", &ssh.ClientConfig{})
+	current := &ssh.Client{}
+	runner.client = current
+
+	got, err := runner.connect(t.Context(), &ssh.Client{})
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	if got != current {
+		t.Error("a stale client that is no longer current must not trigger a redial")
+	}
+}
+
 func TestSSHRunnerBoundsConcurrentSessions(t *testing.T) {
 	runner := newSSHRunner("127.0.0.1:22", &ssh.ClientConfig{})
 

--- a/engine/sshrunner/sshrunnertest/fake.go
+++ b/engine/sshrunner/sshrunnertest/fake.go
@@ -87,6 +87,10 @@ func (f *Fake) Dial(context.Context, string, string) (net.Conn, error) {
 	return nil, coretypes.ErrEngineNotImplemented
 }
 
+func (f *Fake) Ping(ctx context.Context) error {
+	return ctx.Err()
+}
+
 func (f *Fake) Close() error {
 	return nil
 }


### PR DESCRIPTION
The liveness sweep pinged process and cocoon nodes by running `systemctl --version` or `cocoon version`, which takes one of the eight sessions a node's connection allows. A `RunAndWait` on a process node holds two sessions for its whole life (the wait and the followed log), so four concurrent lambdas fill the cap; the sweep's `Acquire` then waits out `connection_timeout`, the sweep reads that as a dead node, installs `EngineWithErr`, and `CloseConn` tears down the connection under every session on it. Saturation became a self-inflicted outage.

`Runner.Ping` is now an SSH global request (`keepalive@openssh.com`) on the connection itself, which no session bounds, and it rides the same redial path as every other call so a stale connection is replaced rather than reported dead. The binary each engine needs is verified once at `AddNode` through `NodeVerifier`, the seam containerd's hook probe already used, so a node without systemd or without cocoon is still refused where it was before.

Second, `connect` renewed whatever client was current, so two callers that both hit a dead connection serialized on the mutex and the second closed the fresh connection the first had just made. It now renews only when the caller's stale client is still the current one.

Hot path: Ping runs only from the sweep; the redial change is one pointer compare.

Tests: `TestConnectKeepsAClientAnotherCallerRenewed`; the scripted runner and the info stub gained `Ping`. docs/engines.md describes the sweep and the two AddNode checks.
