### PR TITLE
perf: keep the request path off sentry, and fan a scrape out over nodes

### DIFF
--- a/auth/simple/simple.go
+++ b/auth/simple/simple.go
@@ -2,6 +2,7 @@ package simple
 
 import (
 	"context"
+	"crypto/subtle"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -43,7 +44,7 @@ func (b *BasicAuth) doAuth(ctx context.Context) error {
 	if len(passwords) == 0 {
 		return types.ErrInvaildGRPCUsername
 	}
-	if passwords[0] != b.password {
+	if subtle.ConstantTimeCompare([]byte(passwords[0]), []byte(b.password)) != 1 {
 		return types.ErrInvaildGRPCPassword
 	}
 	return nil

--- a/core.go
+++ b/core.go
@@ -44,6 +44,7 @@ func serve(ctx context.Context, _ *cli.Command) error {
 	if err = log.SetupLog(ctx, &config.Log, config.SentryDSN); err != nil {
 		zerolog.Fatal().Err(err).Send()
 	}
+	defer log.SentryFlush()
 	defer log.SentryDefer()
 	logger := log.WithFunc("main.serve")
 

--- a/log/inner.go
+++ b/log/inner.go
@@ -12,6 +12,7 @@ var argFormats = [...]string{"", "%+v", "%+v %+v", "%+v %+v %+v", "%+v %+v %+v %
 
 func fatalf(ctx context.Context, err error, format string, fields []field, args ...any) {
 	reportToSentry(ctx, sentry.LevelFatal, err, format, args...)
+	SentryFlush()
 	f := globalLogger.Fatal()
 	wrap(f, fields).Err(err).Msgf(format, args...)
 }

--- a/log/sentry.go
+++ b/log/sentry.go
@@ -14,16 +14,26 @@ import (
 	"github.com/projecteru2/core/types"
 )
 
+const sentryFlushTimeout = 2 * time.Second
+
 // SentryDefer reports a panic to Sentry and re-raises it.
 func SentryDefer() {
 	if sentryDSN == "" {
 		return
 	}
-	defer sentry.Flush(2 * time.Second)
 	if r := recover(); r != nil {
 		sentry.CaptureMessage(fmt.Sprintf("%+v: %s", r, debug.Stack()))
+		sentry.Flush(sentryFlushTimeout)
 		panic(r)
 	}
+}
+
+// SentryFlush sends the events still queued; main defers it so a normal exit loses none.
+func SentryFlush() {
+	if sentryDSN == "" {
+		return
+	}
+	sentry.Flush(sentryFlushTimeout)
 }
 
 func genGRPCTracingInfo(ctx context.Context) string {
@@ -46,7 +56,6 @@ func reportToSentry(ctx context.Context, level sentry.Level, err error, format s
 	if sentryDSN == "" {
 		return
 	}
-	defer sentry.Flush(2 * time.Second)
 	event, extraDetails := errors.BuildSentryReport(err)
 	if len(extraDetails) > 0 {
 		event.Contexts["extra"] = extraDetails

--- a/metrics/handler.go
+++ b/metrics/handler.go
@@ -4,29 +4,41 @@ import (
 	"context"
 	"net/http"
 
+	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/singleflight"
+
 	"github.com/projecteru2/core/cluster"
 	"github.com/projecteru2/core/log"
 	"github.com/projecteru2/core/types"
 )
 
-// ResourceMiddleware refreshes node metrics before the wrapped handler runs.
+const scrapeFanout = 8
+
+// ResourceMiddleware refreshes node metrics before the wrapped handler runs; overlapping scrapes share one refresh.
 func (m *Metrics) ResourceMiddleware(cluster cluster.Cluster) func(http.Handler) http.Handler {
 	logger := log.WithFunc("metrics.ResourceMiddleware")
+	var scrapes singleflight.Group
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			ctx, cancel := context.WithTimeout(r.Context(), m.Config.GlobalTimeout)
-			defer cancel()
-			nodes, err := cluster.ListPodNodes(ctx, &types.ListNodesOptions{All: true})
-			if err != nil {
-				logger.Error(ctx, err, "failed to list nodes")
-				h.ServeHTTP(w, r)
-				return
-			}
-			for node := range nodes {
-				m.SendPodNodeStatus(ctx, node)
-				m.SendNodeMetrics(ctx, node)
-			}
-
+			_, _, _ = scrapes.Do("refresh", func() (any, error) {
+				ctx, cancel := context.WithTimeout(r.Context(), m.Config.GlobalTimeout)
+				defer cancel()
+				nodes, err := cluster.ListPodNodes(ctx, &types.ListNodesOptions{All: true})
+				if err != nil {
+					logger.Error(ctx, err, "failed to list nodes")
+					return nil, err
+				}
+				var g errgroup.Group
+				g.SetLimit(scrapeFanout)
+				for node := range nodes {
+					g.Go(func() error {
+						m.SendPodNodeStatus(ctx, node)
+						m.SendNodeMetrics(ctx, node)
+						return nil
+					})
+				}
+				return nil, g.Wait()
+			})
 			h.ServeHTTP(w, r)
 		})
 	}

--- a/metrics/handler.go
+++ b/metrics/handler.go
@@ -14,14 +14,14 @@ import (
 
 const scrapeFanout = 8
 
-// ResourceMiddleware refreshes node metrics before the wrapped handler runs; overlapping scrapes share one refresh.
+// ResourceMiddleware refreshes node metrics before the wrapped handler runs; overlapping scrapes share one refresh, which outlives the scrape that started it.
 func (m *Metrics) ResourceMiddleware(cluster cluster.Cluster) func(http.Handler) http.Handler {
 	logger := log.WithFunc("metrics.ResourceMiddleware")
 	var scrapes singleflight.Group
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			_, _, _ = scrapes.Do("refresh", func() (any, error) {
-				ctx, cancel := context.WithTimeout(r.Context(), m.Config.GlobalTimeout)
+			refreshed := scrapes.DoChan("refresh", func() (any, error) {
+				ctx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), m.Config.GlobalTimeout)
 				defer cancel()
 				nodes, err := cluster.ListPodNodes(ctx, &types.ListNodesOptions{All: true})
 				if err != nil {
@@ -39,6 +39,11 @@ func (m *Metrics) ResourceMiddleware(cluster cluster.Cluster) func(http.Handler)
 				}
 				return nil, g.Wait()
 			})
+			select {
+			case <-refreshed:
+			case <-r.Context().Done():
+				return
+			}
 			h.ServeHTTP(w, r)
 		})
 	}

--- a/metrics/handler_test.go
+++ b/metrics/handler_test.go
@@ -16,22 +16,16 @@ import (
 	"github.com/projecteru2/core/types"
 )
 
-func TestResourceMiddlewareRefreshesNodesSequentially(t *testing.T) {
+func TestResourceMiddlewareRefreshesNodesConcurrently(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		nodes := make(chan *types.Node, 2)
-		nodes <- &types.Node{NodeMeta: types.NodeMeta{Name: "n1"}}
-		nodes <- &types.Node{NodeMeta: types.NodeMeta{Name: "n2"}}
-		close(nodes)
-
 		cluster := &clustermocks.Cluster{}
-		cluster.On("ListPodNodes", mock.Anything, mock.Anything).Return((<-chan *types.Node)(nodes), nil).Once()
+		cluster.On("ListPodNodes", mock.Anything, mock.Anything).Return(twoNodes(), nil).Once()
 		rmgr := &resourcemocks.Manager{}
 		firstStarted := make(chan struct{})
 		secondStarted := make(chan struct{})
 		releaseFirst := make(chan struct{})
 		rmgr.On("GetNodeMetrics", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
-			node := args.Get(1).(*types.Node)
-			if node.Name == "n1" {
+			if args.Get(1).(*types.Node).Name == "n1" {
 				close(firstStarted)
 				<-releaseFirst
 				return
@@ -50,22 +44,48 @@ func TestResourceMiddlewareRefreshesNodesSequentially(t *testing.T) {
 		synctest.Wait()
 		select {
 		case <-secondStarted:
-			t.Error("second node refresh started before the first completed")
+		default:
+			t.Error("second node refresh waited for the first")
+		}
+		select {
+		case <-served:
+			t.Error("scrape handler served before every node was refreshed")
 		default:
 		}
 
 		close(releaseFirst)
 		synctest.Wait()
 		select {
-		case <-secondStarted:
-		default:
-			t.Error("second node refresh did not start after the first completed")
-		}
-		select {
 		case <-served:
 		default:
 			t.Error("scrape handler was not served")
 		}
+	})
+}
+
+func TestResourceMiddlewareSharesOneRefreshBetweenOverlappingScrapes(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		cluster := &clustermocks.Cluster{}
+		cluster.On("ListPodNodes", mock.Anything, mock.Anything).Return(twoNodes(), nil).Once()
+		rmgr := &resourcemocks.Manager{}
+		release := make(chan struct{})
+		rmgr.On("GetNodeMetrics", mock.Anything, mock.Anything).Run(func(mock.Arguments) { <-release }).Return(nil, nil).Twice()
+
+		m := &Metrics{Config: types.Config{GlobalTimeout: time.Second}, rmgr: rmgr}
+		served := make(chan struct{}, 2)
+		handler := m.ResourceMiddleware(cluster)(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+			served <- struct{}{}
+		}))
+		for range 2 {
+			go handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/metrics", nil))
+		}
+		synctest.Wait()
+		close(release)
+		synctest.Wait()
+
+		assert.Len(t, served, 2)
+		cluster.AssertExpectations(t)
+		rmgr.AssertExpectations(t)
 	})
 }
 
@@ -86,4 +106,12 @@ func TestResourceMiddlewareListNodesFailed(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		assert.Fail(t, "scrape handler blocked after ListPodNodes failed")
 	}
+}
+
+func twoNodes() <-chan *types.Node {
+	nodes := make(chan *types.Node, 2)
+	nodes <- &types.Node{NodeMeta: types.NodeMeta{Name: "n1"}}
+	nodes <- &types.Node{NodeMeta: types.NodeMeta{Name: "n2"}}
+	close(nodes)
+	return nodes
 }

--- a/metrics/handler_test.go
+++ b/metrics/handler_test.go
@@ -1,8 +1,10 @@
 package metrics
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -85,6 +87,43 @@ func TestResourceMiddlewareSharesOneRefreshBetweenOverlappingScrapes(t *testing.
 
 		assert.Len(t, served, 2)
 		cluster.AssertExpectations(t)
+		rmgr.AssertExpectations(t)
+	})
+}
+
+func TestResourceMiddlewareRefreshOutlivesTheScrapeThatStartedIt(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		cluster := &clustermocks.Cluster{}
+		cluster.On("ListPodNodes", mock.Anything, mock.Anything).Return(twoNodes(), nil).Once()
+		rmgr := &resourcemocks.Manager{}
+		release := make(chan struct{})
+		var cancelled atomic.Int32
+		rmgr.On("GetNodeMetrics", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+			<-release
+			if args.Get(0).(context.Context).Err() != nil {
+				cancelled.Add(1)
+			}
+		}).Return(nil, nil).Twice()
+
+		m := &Metrics{Config: types.Config{GlobalTimeout: time.Second}, rmgr: rmgr}
+		served := make(chan struct{}, 2)
+		handler := m.ResourceMiddleware(cluster)(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+			served <- struct{}{}
+		}))
+		leaderCtx, leaveLeader := context.WithCancel(t.Context())
+		go handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/metrics", nil).WithContext(leaderCtx))
+		synctest.Wait()
+		go handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/metrics", nil))
+		synctest.Wait()
+
+		leaveLeader()
+		synctest.Wait()
+		assert.Empty(t, served)
+
+		close(release)
+		synctest.Wait()
+		assert.Len(t, served, 1)
+		assert.Zero(t, cancelled.Load())
 		rmgr.AssertExpectations(t)
 	})
 }

--- a/rpc/errors.go
+++ b/rpc/errors.go
@@ -15,25 +15,27 @@ const (
 	ListPods    codes.Code = 1024
 	PodResource codes.Code = 1025
 
-	AddNode         codes.Code = 1031
-	RemoveNode      codes.Code = 1032
-	ListPodNodes    codes.Code = 1033
-	GetNode         codes.Code = 1034
-	SetNode         codes.Code = 1035
-	SetNodeStatus   codes.Code = 1036
-	GetNodeResource codes.Code = 1037
-	GetNodeStatus   codes.Code = 1038
-	GetNodeEngine   codes.Code = 1039
+	AddNode          codes.Code = 1031
+	RemoveNode       codes.Code = 1032
+	ListPodNodes     codes.Code = 1033
+	GetNode          codes.Code = 1034
+	SetNode          codes.Code = 1035
+	SetNodeStatus    codes.Code = 1036
+	GetNodeResource  codes.Code = 1037
+	GetNodeStatus    codes.Code = 1038
+	GetNodeEngine    codes.Code = 1039
+	NodeStatusStream codes.Code = 10310
 
 	CalculateCapacity codes.Code = 1041
 
-	GetWorkload        codes.Code = 1051
-	GetWorkloads       codes.Code = 1052
-	ListWorkloads      codes.Code = 1053
-	ListNodeWorkloads  codes.Code = 1054
-	GetWorkloadsStatus codes.Code = 1055
-	SetWorkloadsStatus codes.Code = 1056
-	RawEngineStatus    codes.Code = 1057
+	GetWorkload          codes.Code = 1051
+	GetWorkloads         codes.Code = 1052
+	ListWorkloads        codes.Code = 1053
+	ListNodeWorkloads    codes.Code = 1054
+	GetWorkloadsStatus   codes.Code = 1055
+	SetWorkloadsStatus   codes.Code = 1056
+	RawEngineStatus      codes.Code = 1057
+	WorkloadStatusStream codes.Code = 1058
 
 	Copy          codes.Code = 1061
 	Send          codes.Code = 1062

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
+	"google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
 
 	"github.com/projecteru2/core/cluster"
@@ -61,7 +62,7 @@ func (v *Vibranium) WatchServiceStatus(_ *pb.Empty, stream pb.CoreRPC_WatchServi
 			}
 			s := toRPCServiceStatus(status)
 			if err = stream.Send(s); err != nil {
-				logUnsentMessages(task.context, "WatchServicesStatus", err, s)
+				logUnsentMessages(task.context, "WatchServiceStatus", err, s)
 				return grpcstatus.Error(WatchServiceStatus, err.Error())
 			}
 		case <-task.context.Done():
@@ -273,7 +274,7 @@ func (v *Vibranium) NodeStatusStream(_ *pb.Empty, stream pb.CoreRPC_NodeStatusSt
 	task := v.newTask(stream.Context(), "NodeStatusStream", true)
 	defer task.done()
 
-	return drainUntilStop(task, "NodeStatusStream", v.stop, v.cluster.NodeStatusStream(task.context), stream.Send,
+	return drainUntilStop(task, "NodeStatusStream", NodeStatusStream, v.stop, v.cluster.NodeStatusStream(task.context), stream.Send,
 		func(m *types.NodeStatus) *pb.NodeStatusStreamMessage {
 			r := &pb.NodeStatusStreamMessage{
 				Nodename: m.Nodename,
@@ -339,7 +340,7 @@ func (v *Vibranium) WorkloadStatusStream(opts *pb.WorkloadStatusStreamOptions, s
 		task.context,
 		opts.Appname, opts.Entrypoint, opts.Nodename, opts.Labels,
 	)
-	return drainUntilStop(task, "WorkloadStatusStream", v.stop, ch, stream.Send,
+	return drainUntilStop(task, "WorkloadStatusStream", WorkloadStatusStream, v.stop, ch, stream.Send,
 		func(m *types.WorkloadStatus) *pb.WorkloadStatusStreamMessage {
 			r := &pb.WorkloadStatusStreamMessage{Id: m.ID, Delete: m.Delete}
 			if m.Error != nil {
@@ -690,7 +691,7 @@ func (v *Vibranium) RemoveWorkload(opts *pb.RemoveWorkloadOptions, stream pb.Cor
 	force := opts.GetForce()
 
 	if len(IDs) == 0 {
-		return types.ErrNoWorkloadIDs
+		return grpcstatus.Error(RemoveWorkload, types.ErrNoWorkloadIDs.Error())
 	}
 	ch, err := v.cluster.RemoveWorkload(task.context, IDs, force)
 	if err != nil {
@@ -707,7 +708,7 @@ func (v *Vibranium) DissociateWorkload(opts *pb.DissociateWorkloadOptions, strea
 
 	IDs := opts.GetIDs()
 	if len(IDs) == 0 {
-		return types.ErrNoWorkloadIDs
+		return grpcstatus.Error(DissociateWorkload, types.ErrNoWorkloadIDs.Error())
 	}
 
 	ch, err := v.cluster.DissociateWorkload(task.context, IDs)
@@ -728,7 +729,7 @@ func (v *Vibranium) ControlWorkload(opts *pb.ControlWorkloadOptions, stream pb.C
 	force := opts.GetForce()
 
 	if len(IDs) == 0 {
-		return types.ErrNoWorkloadIDs
+		return grpcstatus.Error(ControlWorkload, types.ErrNoWorkloadIDs.Error())
 	}
 
 	ch, err := v.cluster.ControlWorkload(task.context, IDs, t, force)
@@ -750,26 +751,7 @@ func (v *Vibranium) ExecuteWorkload(stream pb.CoreRPC_ExecuteWorkloadServer) err
 	}
 	executeWorkloadOpts := toCoreExecuteWorkloadOptions(opts)
 
-	inCh := make(chan []byte)
-	utils.SentryGo(func() {
-		defer close(inCh)
-		if !opts.OpenStdin {
-			return
-		}
-		for {
-			execWorkloadOpt, recvErr := stream.Recv()
-			if execWorkloadOpt == nil || recvErr != nil {
-				log.WithFunc("vibranium.ExecuteWorkload").Error(task.context, recvErr, "recv command")
-				return
-			}
-			select {
-			case inCh <- execWorkloadOpt.ReplCmd:
-			case <-task.context.Done():
-				return
-			}
-		}
-	})
-
+	inCh := recvStdin(task.context, "ExecuteWorkload", opts.OpenStdin, stream.Recv, (*pb.ExecuteWorkloadOptions).GetReplCmd)
 	drain(task, "ExecuteWorkload", v.cluster.ExecuteWorkload(task.context, executeWorkloadOpts, inCh), stream.Send, toRPCAttachWorkloadMessage)
 	return nil
 }
@@ -788,7 +770,7 @@ func (v *Vibranium) ReallocResource(ctx context.Context, opts *pb.ReallocOptions
 	}
 
 	return reallocResult(v.cluster.ReallocResource(
-		ctx,
+		task.context,
 		&types.ReallocOptions{
 			ID:        opts.Id,
 			Resources: resources,
@@ -855,26 +837,7 @@ func (v *Vibranium) RunAndWait(stream pb.CoreRPC_RunAndWaitServer) error {
 		ctx, cancel = context.WithCancel(task.context)
 	}
 
-	inCh := make(chan []byte)
-	utils.SentryGo(func() {
-		defer close(inCh)
-		if !opts.OpenStdin {
-			return
-		}
-		for {
-			replOpts, recvErr := stream.Recv()
-			if replOpts == nil || recvErr != nil {
-				logger.Error(ctx, recvErr, "recv command")
-				break
-			}
-			select {
-			case inCh <- replOpts.Cmd:
-			case <-ctx.Done():
-				return
-			}
-		}
-	})
-
+	inCh := recvStdin(ctx, "RunAndWait", opts.OpenStdin, stream.Recv, (*pb.RunAndWaitOptions).GetCmd)
 	IDs, ch, err := v.cluster.RunAndWait(ctx, deployOpts, inCh)
 	if err != nil {
 		task.done()
@@ -968,6 +931,31 @@ func logUnsentMessages(ctx context.Context, msgType string, err error, msg any) 
 	log.WithFunc("vibranium.logUnsentMessages").Warnf(ctx, "unsent %s streamed message %+v: %+v", msgType, msg, err)
 }
 
+func recvStdin[T any](ctx context.Context, name string, open bool, recv func() (T, error), payload func(T) []byte) <-chan []byte {
+	inCh := make(chan []byte)
+	utils.SentryGo(func() {
+		defer close(inCh)
+		if !open {
+			return
+		}
+		for {
+			msg, err := recv()
+			if err != nil {
+				if !errors.Is(err, io.EOF) {
+					log.WithFunc("vibranium."+name).Error(ctx, err, "recv command")
+				}
+				return
+			}
+			select {
+			case inCh <- payload(msg):
+			case <-ctx.Done():
+				return
+			}
+		}
+	})
+	return inCh
+}
+
 func drain[T, R any](t *task, name string, ch <-chan T, send func(R) error, to func(T) R) {
 	for m := range ch {
 		if err := send(to(m)); err != nil {
@@ -976,7 +964,7 @@ func drain[T, R any](t *task, name string, ch <-chan T, send func(R) error, to f
 	}
 }
 
-func drainUntilStop[T, R any](t *task, name string, stop <-chan struct{}, ch <-chan T, send func(R) error, to func(T) R) error {
+func drainUntilStop[T, R any](t *task, name string, code codes.Code, stop <-chan struct{}, ch <-chan T, send func(R) error, to func(T) R) error {
 	for {
 		select {
 		case m, ok := <-ch:
@@ -984,7 +972,7 @@ func drainUntilStop[T, R any](t *task, name string, stop <-chan struct{}, ch <-c
 				if t.context.Err() != nil {
 					return nil
 				}
-				return types.ErrMessageChanClosed
+				return grpcstatus.Error(code, types.ErrMessageChanClosed.Error())
 			}
 			if err := send(to(m)); err != nil {
 				logUnsentMessages(t.context, name, err, m)

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -24,6 +24,11 @@ import (
 )
 
 // Vibranium implements the CoreRPC gRPC server.
+type (
+	sender[R any]       func(R) error
+	converter[T, R any] func(T) R
+)
+
 type Vibranium struct {
 	cluster cluster.Cluster
 	config  types.Config
@@ -957,7 +962,7 @@ func recvStdin[T any](ctx context.Context, name string, open bool, recv func() (
 	return inCh
 }
 
-func drain[T, R any](t *task, name string, ch <-chan T, send func(R) error, to func(T) R) {
+func drain[T, R any](t *task, name string, ch <-chan T, send sender[R], to converter[T, R]) {
 	for m := range ch {
 		if err := send(to(m)); err != nil {
 			logUnsentMessages(t.context, name, err, m)
@@ -965,7 +970,7 @@ func drain[T, R any](t *task, name string, ch <-chan T, send func(R) error, to f
 	}
 }
 
-func drainUntilStop[T, R any](t *task, name string, code codes.Code, stop <-chan struct{}, ch <-chan T, send func(R) error, to func(T) R) error {
+func drainUntilStop[T, R any](t *task, name string, code codes.Code, stop <-chan struct{}, ch <-chan T, send sender[R], to converter[T, R]) error {
 	for {
 		select {
 		case m, ok := <-ch:

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -933,11 +933,12 @@ func logUnsentMessages(ctx context.Context, msgType string, err error, msg any) 
 
 func recvStdin[T any](ctx context.Context, name string, open bool, recv func() (T, error), payload func(T) []byte) <-chan []byte {
 	inCh := make(chan []byte)
+	if !open {
+		close(inCh)
+		return inCh
+	}
 	utils.SentryGo(func() {
 		defer close(inCh)
-		if !open {
-			return
-		}
 		for {
 			msg, err := recv()
 			if err != nil {

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -23,12 +23,12 @@ import (
 	"github.com/projecteru2/core/version"
 )
 
-// Vibranium implements the CoreRPC gRPC server.
 type (
 	sender[R any]       func(R) error
 	converter[T, R any] func(T) R
 )
 
+// Vibranium implements the CoreRPC gRPC server.
 type Vibranium struct {
 	cluster cluster.Cluster
 	config  types.Config

--- a/types/options.go
+++ b/types/options.go
@@ -24,6 +24,37 @@ type Processing struct {
 	Ident     string
 }
 
+type ListWorkloadsOptions struct {
+	Appname    string
+	Entrypoint string
+	Nodename   string
+	Limit      int64
+	Labels     map[string]string
+}
+
+type ListNodesOptions struct {
+	Podname  string
+	Labels   map[string]string
+	All      bool
+	CallInfo bool
+}
+
+type TriOptions int
+
+type ExecuteWorkloadOptions struct {
+	WorkloadID string
+	Commands   []string
+	Envs       []string
+	Workdir    string
+	OpenStdin  bool
+	ReplCmd    []byte
+}
+
+type ReallocOptions struct {
+	ID        string
+	Resources resourcetypes.Resources
+}
+
 type DeployOptions struct {
 	Resources      resourcetypes.Resources
 	Name           string
@@ -135,14 +166,6 @@ func (o *SendOptions) Validate() error {
 	return nil
 }
 
-type ListWorkloadsOptions struct {
-	Appname    string
-	Entrypoint string
-	Nodename   string
-	Limit      int64
-	Labels     map[string]string
-}
-
 type ReplaceOptions struct {
 	DeployOptions
 	NetworkInherit bool
@@ -166,13 +189,6 @@ func (o *ReplaceOptions) Normalize() {
 	}
 }
 
-type ListNodesOptions struct {
-	Podname  string
-	Labels   map[string]string
-	All      bool
-	CallInfo bool
-}
-
 type AddNodeOptions struct {
 	Nodename  string
 	Endpoint  string
@@ -194,8 +210,6 @@ func (o *AddNodeOptions) Validate() error {
 	}
 	return nil
 }
-
-type TriOptions int
 
 type SetNodeOptions struct {
 	Nodename      string
@@ -228,20 +242,6 @@ func (o *ImageOptions) Validate() error {
 		return ErrEmptyPodName
 	}
 	return nil
-}
-
-type ExecuteWorkloadOptions struct {
-	WorkloadID string
-	Commands   []string
-	Envs       []string
-	Workdir    string
-	OpenStdin  bool
-	ReplCmd    []byte
-}
-
-type ReallocOptions struct {
-	ID        string
-	Resources resourcetypes.Resources
 }
 
 type RawArgs []byte

--- a/types/options.go
+++ b/types/options.go
@@ -13,7 +13,7 @@ const (
 	TriTrue
 	TriFalse
 
-	SendLargeFileChunkSize = 2 << 10
+	SendLargeFileChunkSize = 256 << 10
 )
 
 // Processing tracks the unfinished workload count for one deploy.


### PR DESCRIPTION
Four request-path mechanisms and four one-line fixes, all from the 2026-09-02 static round.

**Sentry.** `sentry.Flush(2s)` ran after every error log and on every pooled task or `SentryGo` goroutine exit, which the SDK explicitly warns against. With a DSN configured every `logger.Error` waited for the HTTP transport, every per-node and per-workload fan-out rendezvoused with the single transport goroutine, and an unreachable Sentry turned each error into a two-second stall. Flush now runs only where the process is about to leave: the panic path of `SentryDefer`, `Fatalf`, and a `SentryFlush` deferred in main so a normal exit loses nothing.

**Scrape fan-out.** `ResourceMiddleware` refreshed nodes sequentially, one plugin process per node per binary plugin, and two overlapping scrapes each ran a full pass. Nodes now refresh eight at a time through an `errgroup`, and overlapping scrapes share one pass through `singleflight`. The pinned-sequential test is replaced by one that asserts concurrency and one that asserts the shared refresh.

**stdin pumps.** `ExecuteWorkload` and `RunAndWait` each carried an 18-line pump that logged the client's normal `io.EOF` half-close at Error (and, with a DSN, captured it). One generic `recvStdin` relays both and treats EOF as end of input, the way `SendLargeFile` already did.

**One-liners.** `ReallocResource` passed the raw handler context and was the only RPC whose downstream logs lost the tracing id; the three empty-ID guards and `drainUntilStop` returned bare errors (`codes.Unknown`) where every other path returns a per-method code, so `NodeStatusStream` and `WorkloadStatusStream` gained codes; the gRPC password compare is now constant time; a log label typo.

**SendLargeFile chunk.** `SendLargeFileChunkSize` goes from 2 KiB to 256 KiB. Every chunk re-sends the ids, destination, mode and owner, so a 1 GiB file was ~524k messages; it is now ~4k. The cli reads the constant from core and picks it up on its next pin.

Hot path: the Sentry change removes work from every error and every fan-out; nothing else touches the claim path.
