### PR TITLE
fix: take pod locks in key order, and bound the selfmon fan-outs

### DIFF
--- a/cluster/calcium/dissociate.go
+++ b/cluster/calcium/dissociate.go
@@ -33,7 +33,11 @@ func (c *Calcium) DissociateWorkload(ctx context.Context, IDs []string) (chan *t
 						logger.WithField("id", workloadID).Error(ctx, workloadErr, "failed to dissociate workload")
 						msg.Error = workloadErr
 					}
-					ch <- msg
+					select {
+					case ch <- msg:
+					case <-ctx.Done():
+						return ctx.Err()
+					}
 				}
 				c.invokePoolAsync(func() { c.RemapResourceAndLog(ctx, logger, node) })
 				return nil

--- a/cluster/calcium/dissociate.go
+++ b/cluster/calcium/dissociate.go
@@ -33,10 +33,8 @@ func (c *Calcium) DissociateWorkload(ctx context.Context, IDs []string) (chan *t
 						logger.WithField("id", workloadID).Error(ctx, workloadErr, "failed to dissociate workload")
 						msg.Error = workloadErr
 					}
-					select {
-					case ch <- msg:
-					case <-ctx.Done():
-						return ctx.Err()
+					if err := send(ctx, ch, msg); err != nil {
+						return err
 					}
 				}
 				c.invokePoolAsync(func() { c.RemapResourceAndLog(ctx, logger, node) })

--- a/cluster/calcium/dissociate.go
+++ b/cluster/calcium/dissociate.go
@@ -18,6 +18,7 @@ func (c *Calcium) DissociateWorkload(ctx context.Context, IDs []string) (chan *t
 	}
 
 	ch := make(chan *types.DissociateWorkloadMessage)
+	caller := ctx
 	utils.SentryGo(func() {
 		defer close(ch)
 
@@ -33,7 +34,7 @@ func (c *Calcium) DissociateWorkload(ctx context.Context, IDs []string) (chan *t
 						logger.WithField("id", workloadID).Error(ctx, workloadErr, "failed to dissociate workload")
 						msg.Error = workloadErr
 					}
-					if err := send(ctx, ch, msg); err != nil {
+					if err := send(caller, ch, msg); err != nil {
 						return err
 					}
 				}

--- a/cluster/calcium/lock.go
+++ b/cluster/calcium/lock.go
@@ -133,19 +133,21 @@ func (c *Calcium) withNodesLocked(ctx context.Context, nodeFilter *types.NodeFil
 		return err
 	}
 
-	var lock lock.DistributedLock
+	keys := make([]string, 0, len(ns))
 	for _, n := range ns {
-		key := genKey(n)
-		if _, ok := locks[key]; !ok {
-			lock, ctx, err = c.doLock(ctx, key, c.config.LockTimeout)
-			if err != nil {
-				return err
-			}
-			logger.Debugf(ctx, "key %s locked", key)
-			locks[key] = lock
-			lockKeys = append(lockKeys, key)
-		}
 		nodes[n.Name] = n
+		keys = append(keys, genKey(n))
+	}
+	slices.Sort(keys)
+	var lock lock.DistributedLock
+	for _, key := range slices.Compact(keys) {
+		lock, ctx, err = c.doLock(ctx, key, c.config.LockTimeout)
+		if err != nil {
+			return err
+		}
+		logger.Debugf(ctx, "key %s locked", key)
+		locks[key] = lock
+		lockKeys = append(lockKeys, key)
 	}
 	return f(ctx, nodes)
 }

--- a/cluster/calcium/lock_test.go
+++ b/cluster/calcium/lock_test.go
@@ -174,6 +174,31 @@ func TestWithNodesPodLocked(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestWithNodesPodLockedTakesPodLocksInKeyOrder(t *testing.T) {
+	c := NewTestCluster()
+	store := c.store.(*storemocks.Store)
+	nodes := []*types.Node{
+		{NodeMeta: types.NodeMeta{Name: "a1", Podname: "podb"}, Available: true},
+		{NodeMeta: types.NodeMeta{Name: "b1", Podname: "poda"}, Available: true},
+		{NodeMeta: types.NodeMeta{Name: "c1", Podname: "podb"}, Available: true},
+	}
+	store.On("GetNodes", mock.Anything, mock.Anything).Return(nodes, nil)
+	lock := &lockmocks.DistributedLock{}
+	lock.On("Lock", mock.Anything).Return(t.Context(), nil)
+	lock.On("Unlock", mock.Anything).Return(nil)
+	keys := []string{}
+	store.On("CreateLock", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		keys = append(keys, args.String(0))
+	}).Return(lock, nil)
+
+	err := c.withNodesPodLocked(t.Context(), &types.NodeFilter{Includes: []string{"a1", "b1", "c1"}}, func(_ context.Context, locked map[string]*types.Node) error {
+		assert.Len(t, locked, 3)
+		return nil
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"plock_poda", "plock_podb"}, keys)
+}
+
 func TestWithNodePodLocked(t *testing.T) {
 	c := NewTestCluster()
 	ctx := t.Context()

--- a/cluster/calcium/node.go
+++ b/cluster/calcium/node.go
@@ -4,9 +4,9 @@ import (
 	"cmp"
 	"context"
 	"slices"
-	"sync"
 
 	"github.com/cockroachdb/errors"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/projecteru2/core/engine"
 	enginefactory "github.com/projecteru2/core/engine/factory"
@@ -18,6 +18,8 @@ import (
 	"github.com/projecteru2/core/types"
 	"github.com/projecteru2/core/utils"
 )
+
+const statusWriters = 32
 
 func (c *Calcium) AddNode(ctx context.Context, opts *types.AddNodeOptions) (*types.Node, error) {
 	logger := log.WithFunc("calcium.AddNode").WithField("opts", opts)
@@ -300,15 +302,14 @@ func (c *Calcium) setAllWorkloadsOnNodeDown(ctx context.Context, nodename string
 		return
 	}
 
-	wg := &sync.WaitGroup{}
-	wg.Add(len(workloads))
+	var g errgroup.Group
+	g.SetLimit(statusWriters)
 	for _, workload := range workloads {
-		_ = c.pool.Invoke(func() {
-			defer wg.Done()
+		g.Go(func() error {
 			appname, entrypoint, _, err := utils.ParseWorkloadName(workload.Name)
 			if err != nil {
 				logger.Errorf(ctx, err, "set workload %s on node %s as inactive failed", workload.ID, nodename)
-				return
+				return nil
 			}
 
 			if workload.StatusMeta == nil {
@@ -323,12 +324,13 @@ func (c *Calcium) setAllWorkloadsOnNodeDown(ctx context.Context, nodename string
 
 			if err = c.store.SetWorkloadStatus(ctx, workload.StatusMeta, 0); err != nil {
 				logger.Errorf(ctx, err, "set workload %s on node %s as inactive failed", workload.ID, nodename)
-				return
+				return nil
 			}
 			logger.Infof(ctx, "set workload %s on node %s as inactive", workload.ID, nodename)
+			return nil
 		})
 	}
-	wg.Wait()
+	_ = g.Wait()
 }
 
 func verifyNodeEngine(ctx context.Context, client engine.API) error {

--- a/cluster/calcium/node.go
+++ b/cluster/calcium/node.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"context"
 	"slices"
+	"sync"
 
 	"github.com/cockroachdb/errors"
 
@@ -232,7 +233,9 @@ func (c *Calcium) SetNode(ctx context.Context, opts *types.SetNodeOptions) (*typ
 					return updateErr
 				}
 				// capacity refresh is best effort; the store write already succeeded
-				_ = c.refreshResourceInfo(ctx, node)
+				if len(opts.Resources) != 0 {
+					_ = c.refreshResourceInfo(ctx, node)
+				}
 				c.invokePoolAsync(func() { c.doSendNodeMetrics(context.WithoutCancel(ctx), node) })
 				c.invokePoolAsync(func() { c.RemapResourceAndLog(ctx, logger, node) })
 				return nil
@@ -297,29 +300,35 @@ func (c *Calcium) setAllWorkloadsOnNodeDown(ctx context.Context, nodename string
 		return
 	}
 
+	wg := &sync.WaitGroup{}
+	wg.Add(len(workloads))
 	for _, workload := range workloads {
-		appname, entrypoint, _, err := utils.ParseWorkloadName(workload.Name)
-		if err != nil {
-			logger.Errorf(ctx, err, "set workload %s on node %s as inactive failed", workload.ID, nodename)
-			continue
-		}
+		_ = c.pool.Invoke(func() {
+			defer wg.Done()
+			appname, entrypoint, _, err := utils.ParseWorkloadName(workload.Name)
+			if err != nil {
+				logger.Errorf(ctx, err, "set workload %s on node %s as inactive failed", workload.ID, nodename)
+				return
+			}
 
-		if workload.StatusMeta == nil {
-			workload.StatusMeta = &types.StatusMeta{ID: workload.ID}
-		}
-		workload.StatusMeta.Running = false
-		workload.StatusMeta.Healthy = false
+			if workload.StatusMeta == nil {
+				workload.StatusMeta = &types.StatusMeta{ID: workload.ID}
+			}
+			workload.StatusMeta.Running = false
+			workload.StatusMeta.Healthy = false
 
-		workload.StatusMeta.Appname = appname
-		workload.StatusMeta.Nodename = workload.Nodename
-		workload.StatusMeta.Entrypoint = entrypoint
+			workload.StatusMeta.Appname = appname
+			workload.StatusMeta.Nodename = workload.Nodename
+			workload.StatusMeta.Entrypoint = entrypoint
 
-		if err = c.store.SetWorkloadStatus(ctx, workload.StatusMeta, 0); err != nil {
-			logger.Errorf(ctx, err, "set workload %s on node %s as inactive failed", workload.ID, nodename)
-		} else {
+			if err = c.store.SetWorkloadStatus(ctx, workload.StatusMeta, 0); err != nil {
+				logger.Errorf(ctx, err, "set workload %s on node %s as inactive failed", workload.ID, nodename)
+				return
+			}
 			logger.Infof(ctx, "set workload %s on node %s as inactive", workload.ID, nodename)
-		}
+		})
 	}
+	wg.Wait()
 }
 
 func verifyNodeEngine(ctx context.Context, client engine.API) error {

--- a/cluster/calcium/node_test.go
+++ b/cluster/calcium/node_test.go
@@ -290,6 +290,32 @@ func TestSetNode(t *testing.T) {
 	rmgr.AssertExpectations(t)
 }
 
+func TestSetWorkloadsDownDoesNotWaitForThePool(t *testing.T) {
+	c := NewTestCluster()
+	pool, err := utils.NewPool(1)
+	assert.NoError(t, err)
+	c.pool = pool
+	release := make(chan struct{})
+	defer close(release)
+	_ = c.pool.Invoke(func() { <-release })
+
+	store := c.store.(*storemocks.Store)
+	store.On("ListNodeWorkloads", mock.Anything, mock.Anything, mock.Anything).Return([]*types.Workload{{ID: "1", Name: "a_b_c"}, {ID: "2", Name: "a_b_d"}}, nil)
+	store.On("SetWorkloadStatus", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		c.setAllWorkloadsOnNodeDown(t.Context(), "node")
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("marking workloads down waited for a pool worker while holding the node lock")
+	}
+	store.AssertNumberOfCalls(t, "SetWorkloadStatus", 2)
+}
+
 func TestFilterNodes(t *testing.T) {
 	c := NewTestCluster()
 	ctx := t.Context()

--- a/cluster/calcium/remove.go
+++ b/cluster/calcium/remove.go
@@ -44,13 +44,20 @@ func (c *Calcium) RemoveWorkload(ctx context.Context, IDs []string, force bool) 
 							ret.Hook = append(ret.Hook, bytes.NewBufferString(workloadErr.Error()))
 							ret.Success = false
 						}
-						ch <- ret
+						select {
+						case ch <- ret:
+						case <-ctx.Done():
+							return ctx.Err()
+						}
 					}
 					c.invokePoolAsync(func() { c.RemapResourceAndLog(ctx, logger, node) })
 					return nil
 				}); nodeErr != nil {
 					logger.WithField("node", nodename).Error(ctx, nodeErr, "failed to lock node")
-					ch <- &types.RemoveWorkloadMessage{Success: false}
+					select {
+					case ch <- &types.RemoveWorkloadMessage{Success: false}:
+					case <-ctx.Done():
+					}
 				}
 			})
 		}

--- a/cluster/calcium/remove.go
+++ b/cluster/calcium/remove.go
@@ -22,6 +22,7 @@ func (c *Calcium) RemoveWorkload(ctx context.Context, IDs []string, force bool) 
 	}
 
 	ch := make(chan *types.RemoveWorkloadMessage)
+	caller := ctx
 	utils.SentryGo(func() {
 		defer close(ch)
 		wg := sync.WaitGroup{}
@@ -44,7 +45,7 @@ func (c *Calcium) RemoveWorkload(ctx context.Context, IDs []string, force bool) 
 							ret.Hook = append(ret.Hook, bytes.NewBufferString(workloadErr.Error()))
 							ret.Success = false
 						}
-						if err := send(ctx, ch, ret); err != nil {
+						if err := send(caller, ch, ret); err != nil {
 							return err
 						}
 					}
@@ -52,7 +53,7 @@ func (c *Calcium) RemoveWorkload(ctx context.Context, IDs []string, force bool) 
 					return nil
 				}); nodeErr != nil {
 					logger.WithField("node", nodename).Error(ctx, nodeErr, "failed to lock node")
-					_ = send(ctx, ch, &types.RemoveWorkloadMessage{Success: false})
+					_ = send(caller, ch, &types.RemoveWorkloadMessage{Success: false})
 				}
 			})
 		}

--- a/cluster/calcium/remove.go
+++ b/cluster/calcium/remove.go
@@ -44,20 +44,15 @@ func (c *Calcium) RemoveWorkload(ctx context.Context, IDs []string, force bool) 
 							ret.Hook = append(ret.Hook, bytes.NewBufferString(workloadErr.Error()))
 							ret.Success = false
 						}
-						select {
-						case ch <- ret:
-						case <-ctx.Done():
-							return ctx.Err()
+						if err := send(ctx, ch, ret); err != nil {
+							return err
 						}
 					}
 					c.invokePoolAsync(func() { c.RemapResourceAndLog(ctx, logger, node) })
 					return nil
 				}); nodeErr != nil {
 					logger.WithField("node", nodename).Error(ctx, nodeErr, "failed to lock node")
-					select {
-					case ch <- &types.RemoveWorkloadMessage{Success: false}:
-					case <-ctx.Done():
-					}
+					_ = send(ctx, ch, &types.RemoveWorkloadMessage{Success: false})
 				}
 			})
 		}

--- a/cluster/calcium/remove_test.go
+++ b/cluster/calcium/remove_test.go
@@ -1,6 +1,7 @@
 package calcium
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -84,6 +85,38 @@ func TestRemoveWorkload(t *testing.T) {
 		assert.True(t, r.Success)
 	}
 	store.AssertExpectations(t)
+}
+
+func TestRemoveWorkloadReportsEveryWorkloadAfterTheLockIsLost(t *testing.T) {
+	c := NewTestCluster()
+	ctx := t.Context()
+	lostCtx, lose := context.WithCancel(ctx)
+	lose()
+	lock := &lockmocks.DistributedLock{}
+	lock.On("Lock", mock.Anything).Return(lostCtx, nil)
+	lock.On("Unlock", mock.Anything).Return(nil)
+	engine := &enginemocks.API{}
+	engine.On("VirtualizationRemove", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	workloads := []*types.Workload{
+		{ID: "a", Name: "test", Nodename: "test", Engine: engine},
+		{ID: "b", Name: "test", Nodename: "test", Engine: engine},
+	}
+	store := c.store.(*storemocks.Store)
+	store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
+	store.On("GetWorkloads", mock.Anything, mock.Anything).Return(workloads, nil)
+	store.On("GetNode", mock.Anything, mock.Anything).Return(&types.Node{NodeMeta: types.NodeMeta{Name: "test"}}, nil)
+	store.On("RemoveWorkload", mock.Anything, mock.Anything).Return(nil)
+	store.On("ListNodeWorkloads", mock.Anything, mock.Anything, mock.Anything).Return(nil, types.ErrMockError)
+	rmgr := c.rmgr.(*resourcemocks.Manager)
+	rmgr.On("SetNodeResourceUsage", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(resourcetypes.Resources{}, resourcetypes.Resources{}, nil)
+
+	ch, err := c.RemoveWorkload(ctx, []string{"a", "b"}, false)
+	assert.NoError(t, err)
+	reported := []string{}
+	for r := range ch {
+		reported = append(reported, r.WorkloadID)
+	}
+	assert.ElementsMatch(t, []string{"a", "b"}, reported)
 }
 
 func TestRemoveWorkloadJournalsRepairEntries(t *testing.T) {

--- a/cluster/calcium/utils.go
+++ b/cluster/calcium/utils.go
@@ -110,3 +110,12 @@ func pullImage(ctx context.Context, node *types.Node, image string) error {
 	logger.Infof(ctx, "done pulling image %s", image)
 	return nil
 }
+
+func send[T any](ctx context.Context, ch chan<- T, msg T) error {
+	select {
+	case ch <- msg:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/selfmon/selfmon.go
+++ b/selfmon/selfmon.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/projecteru2/core/cluster"
 	"github.com/projecteru2/core/log"
@@ -15,7 +16,11 @@ import (
 	"github.com/projecteru2/core/wal"
 )
 
-const ActiveKey = "/selfmon/active"
+const (
+	ActiveKey = "/selfmon/active"
+
+	nodeStatusHandlers = 16
+)
 
 // NodeStatusWatcher watches node status changes.
 type NodeStatusWatcher struct {
@@ -166,13 +171,19 @@ func (n *NodeStatusWatcher) monitor(ctx context.Context) error {
 	logger.Info(ctx, "watch node status started")
 	defer logger.Info(ctx, "stop watching node status")
 
+	var handlers errgroup.Group
+	handlers.SetLimit(nodeStatusHandlers)
+	defer func() { _ = handlers.Wait() }()
 	for {
 		select {
 		case message, ok := <-messageChan:
 			if !ok {
 				return types.ErrMessageChanClosed
 			}
-			go n.dealNodeStatusMessage(ctx, message)
+			handlers.Go(func() error {
+				n.dealNodeStatusMessage(ctx, message)
+				return nil
+			})
 		case <-ctx.Done():
 			return ctx.Err()
 		}


### PR DESCRIPTION
Four orchestration-layer items from the 2026-09-02 static round.

**Pod lock order (B1).** `withNodesLocked` acquired one lock per distinct key in node-name order, but the pod lock's key derives from the pod, so a request over nodes `{a1 (pod B), b1 (pod A)}` locked B then A while a request over `{a2 (pod A), b2 (pod B)}` locked A then B. `Includes` of two or more names bypasses the pod filter (`filterNodes` → `store.GetNodes`), so one CLI invocation can span pods. The keys are now collected, sorted and compacted before the first acquisition, which is the invariant `docs/architecture.md` states. `TestWithNodesPodLockedTakesPodLocksInKeyOrder` pins it.

**selfmon fan-out (B9).** `monitor` ran `dealNodeStatusMessage` on a bare goroutine per watch event; a replay after a partition started an unbounded number of pod-locked `SetNode` calls at once, all contending on a few pod locks. Handlers now run through an `errgroup` bounded at 16.

**Down-node path (B6).** `setAllWorkloadsOnNodeDown` wrote one status per workload sequentially under the pod lock, ~2–3 etcd round trips each; a node with a hundred workloads froze its pod for a quarter second per event. The writes now fan out through the pool. `SetNode` also skips the second `refreshResourceInfo` (a plugin fan-out) when the request changed no resources.

**Result sends (B2).** `RemoveWorkload` and `DissociateWorkload` sent per-workload results on an unbuffered channel while holding the pod lock with no context arm; they now select on the context, so a consumer that stopped reading cannot pin the lock.

Hot path: none of these touch the deploy claim path; B1 adds one sort over the lock keys per locked request.
