### PR TITLE
perf: renew an unchanged status lease instead of granting a new one

### DIFF
--- a/store/etcdv3/meta/etcd.go
+++ b/store/etcdv3/meta/etcd.go
@@ -266,111 +266,68 @@ func (e *ETCD) batchPut(ctx context.Context, data map[string]string, cond *txnCo
 	return e.doBatchOp(ctx, txnes)
 }
 
-func (e *ETCD) isTTLChanged(ctx context.Context, key string, ttl int64) (bool, error) {
-	resp, err := e.GetOne(ctx, key)
+func (e *ETCD) currentStatus(ctx context.Context, key string, ttl int64) (*mvccpb.KeyValue, bool, error) {
+	kv, err := e.GetOne(ctx, key)
 	if err != nil {
 		if errors.Is(err, types.ErrInvaildCount) {
-			return ttl != 0, nil
+			return nil, ttl != 0, nil
 		}
-		return false, err
+		return nil, false, err
+	}
+	if kv.Lease == 0 {
+		return kv, ttl != 0, nil
 	}
 
-	leaseID := clientv3.LeaseID(resp.Lease)
-	if leaseID == 0 {
-		return ttl != 0, nil
-	}
-
-	getTTLResp, err := e.cliv3.TimeToLive(ctx, leaseID)
+	granted, err := e.cliv3.TimeToLive(ctx, clientv3.LeaseID(kv.Lease))
 	if err != nil {
-		return false, err
+		return nil, false, err
 	}
-
-	changed := getTTLResp.GrantedTTL != ttl
+	changed := granted.GrantedTTL != ttl
 	if changed {
-		log.WithFunc("store.etcdv3.meta.isTTLChanged").Infof(ctx, "key %+v ttl changed from %+v to %+v", key, getTTLResp.GrantedTTL, ttl)
+		log.WithFunc("store.etcdv3.meta.currentStatus").Infof(ctx, "key %+v ttl changed from %+v to %+v", key, granted.GrantedTTL, ttl)
 	}
-
-	return changed, nil
+	return kv, changed, nil
 }
 
 func (e *ETCD) bindStatusWithTTL(ctx context.Context, entityKey, statusKey, statusValue string, ttl int64) error {
+	logger := log.WithFunc("store.etcdv3.meta.bindStatusWithTTL")
+	renewed, err := e.cliv3.Txn(ctx).
+		If(
+			clientv3.Compare(clientv3.Version(entityKey), "!=", 0),
+			clientv3.Compare(clientv3.Value(statusKey), "=", statusValue),
+		).
+		Then(clientv3.OpGet(statusKey)).
+		Commit()
+	if err != nil {
+		return err
+	}
+	if renewed.Succeeded {
+		if kvs := renewed.Responses[0].GetResponseRange().Kvs; len(kvs) == 1 && kvs[0].Lease != 0 {
+			alive, keepErr := e.cliv3.KeepAliveOnce(ctx, clientv3.LeaseID(kvs[0].Lease))
+			if keepErr == nil && alive.TTL == ttl {
+				return nil
+			}
+		}
+	}
+
 	lease, err := e.cliv3.Grant(ctx, ttl)
 	if err != nil {
 		return err
 	}
-
-	leaseID := lease.ID
-	updateStatus := []clientv3.Op{clientv3.OpPut(statusKey, statusValue, clientv3.WithLease(leaseID))}
-	logger := log.WithFunc("store.etcdv3.meta.bindStatusWithTTL")
-
-	ttlChanged, err := e.isTTLChanged(ctx, statusKey, ttl)
+	bound, err := e.cliv3.Txn(ctx).
+		If(clientv3.Compare(clientv3.Version(entityKey), "!=", 0)).
+		Then(clientv3.OpPut(statusKey, statusValue, clientv3.WithLease(lease.ID))).
+		Commit()
 	if err != nil {
+		e.revokeLease(ctx, lease.ID)
 		return err
 	}
-
-	var entityTxn *clientv3.TxnResponse
-
-	if ttlChanged {
-		entityTxn, err = e.cliv3.Txn(ctx).
-			If(clientv3.Compare(clientv3.Version(entityKey), "!=", 0)).
-			Then(updateStatus...).
-			Commit()
-	} else {
-		entityTxn, err = e.cliv3.Txn(ctx).
-			If(clientv3.Compare(clientv3.Version(entityKey), "!=", 0)).
-			Then(
-				clientv3.OpTxn(
-					[]clientv3.Cmp{clientv3.Compare(clientv3.Version(statusKey), "!=", 0)},
-					[]clientv3.Op{clientv3.OpTxn(
-						[]clientv3.Cmp{clientv3.Compare(clientv3.LeaseValue(statusKey), "!=", 0)},
-						[]clientv3.Op{clientv3.OpTxn(
-							[]clientv3.Cmp{clientv3.Compare(clientv3.Value(statusKey), "=", statusValue)},
-							[]clientv3.Op{clientv3.OpGet(statusKey)},
-							updateStatus,
-						)},
-						updateStatus,
-					)},
-					updateStatus,
-				),
-			).Commit()
-	}
-
-	if err != nil {
-		e.revokeLease(ctx, leaseID)
-		return err
-	}
-
-	if !entityTxn.Succeeded {
-		e.revokeLease(ctx, leaseID)
+	if !bound.Succeeded {
+		e.revokeLease(ctx, lease.ID)
 		return types.ErrInvaildCount
 	}
-
-	if ttlChanged {
-		logger.Infof(ctx, "put: key %s value %s", statusKey, statusValue)
-		return nil
-	}
-
-	valueTxn := entityTxn.Responses[0].GetResponseTxn()
-	for range 2 {
-		if !valueTxn.Succeeded {
-			logger.Infof(ctx, "put: key %s value %s", statusKey, statusValue)
-			return nil
-		}
-		valueTxn = valueTxn.Responses[0].GetResponseTxn()
-	}
-	if !valueTxn.Succeeded {
-		logger.Infof(ctx, "put: key %s value %s", statusKey, statusValue)
-		return nil
-	}
-
-	origLeaseID := clientv3.LeaseID(valueTxn.Responses[0].GetResponseRange().Kvs[0].Lease)
-
-	if origLeaseID != leaseID {
-		e.revokeLease(ctx, leaseID)
-	}
-
-	_, err = e.cliv3.KeepAliveOnce(ctx, origLeaseID)
-	return err
+	logger.Infof(ctx, "put: key %s value %s", statusKey, statusValue)
+	return nil
 }
 
 func (e *ETCD) bindStatusWithoutTTL(ctx context.Context, entityKey, statusKey, statusValue string) error {

--- a/store/etcdv3/meta/etcd_test.go
+++ b/store/etcdv3/meta/etcd_test.go
@@ -70,6 +70,13 @@ func TestBindStatusFailedAsGrantError(t *testing.T) {
 	e, etcd, assert := testKeepAliveETCD(t)
 	defer assert()
 	expErr := fmt.Errorf("exp")
+	txn := &mocks.Txn{}
+	defer txn.AssertExpectations(t)
+	txn.On("If", mock.Anything, mock.Anything).Return(txn)
+	txn.On("Then", mock.Anything).Return(txn)
+	txn.On("Commit").Return(&clientv3.TxnResponse{Succeeded: false}, nil)
+
+	etcd.On("Txn", mock.Anything).Return(txn)
 	etcd.On("Grant", mock.Anything, mock.Anything).Return(nil, expErr)
 	require.Equal(t, expErr, e.BindStatus(t.Context(), "/entity", "/status", "status", 1))
 }
@@ -81,10 +88,11 @@ func TestBindStatusFailedAsCommitError(t *testing.T) {
 	expErr := fmt.Errorf("exp")
 	txn := &mocks.Txn{}
 	defer txn.AssertExpectations(t)
-	etcd.On("Get", mock.Anything, mock.Anything).Return(&clientv3.GetResponse{}, nil)
-	txn.On("If", mock.Anything).Return(txn)
+	txn.On("If", mock.Anything, mock.Anything).Return(txn).Once()
+	txn.On("If", mock.Anything).Return(txn).Once()
 	txn.On("Then", mock.Anything).Return(txn)
-	txn.On("Commit").Return(nil, expErr)
+	txn.On("Commit").Return(&clientv3.TxnResponse{Succeeded: false}, nil).Once()
+	txn.On("Commit").Return(nil, expErr).Once()
 
 	etcd.On("Grant", mock.Anything, mock.Anything).Return(&clientv3.LeaseGrantResponse{}, nil)
 	etcd.On("Txn", mock.Anything).Return(txn)
@@ -95,43 +103,108 @@ func TestBindStatusButEntityTxnUnsuccessful(t *testing.T) {
 	e, etcd, assert := testKeepAliveETCD(t)
 	defer assert()
 
-	entityTxn := &clientv3.TxnResponse{Succeeded: false}
 	txn := &mocks.Txn{}
 	defer txn.AssertExpectations(t)
-	etcd.On("Get", mock.Anything, mock.Anything).Return(&clientv3.GetResponse{}, nil)
-	txn.On("If", mock.Anything).Return(txn)
+	txn.On("If", mock.Anything, mock.Anything).Return(txn).Once()
+	txn.On("If", mock.Anything).Return(txn).Once()
 	txn.On("Then", mock.Anything).Return(txn)
-	txn.On("Commit").Return(entityTxn, nil)
+	txn.On("Commit").Return(&clientv3.TxnResponse{Succeeded: false}, nil)
 
 	etcd.On("Grant", mock.Anything, mock.Anything).Return(&clientv3.LeaseGrantResponse{}, nil)
 	etcd.On("Txn", mock.Anything).Return(txn)
 	require.Equal(t, types.ErrInvaildCount, e.BindStatus(t.Context(), "/entity", "/status", "status", 1))
 }
 
-func TestBindStatusButStatusTxnUnsuccessful(t *testing.T) {
+func TestBindStatusRenewsAnUnchangedStatus(t *testing.T) {
 	e, etcd, assert := testKeepAliveETCD(t)
 	defer assert()
 
-	entityTxn := &clientv3.TxnResponse{
-		Succeeded: true,
-		Responses: []*etcdserverpb.ResponseOp{
-			{
-				Response: &etcdserverpb.ResponseOp_ResponseTxn{
-					ResponseTxn: &etcdserverpb.TxnResponse{Succeeded: false},
-				},
-			},
-		},
-	}
+	leaseID := int64(1235)
+	txn := &mocks.Txn{}
+	defer txn.AssertExpectations(t)
+	txn.On("If", mock.Anything, mock.Anything).Return(txn)
+	txn.On("Then", mock.Anything).Return(txn)
+	txn.On("Commit").Return(renewTxn("status", leaseID), nil)
+
+	etcd.On("Txn", mock.Anything).Return(txn)
+	etcd.On("KeepAliveOnce", mock.Anything, clientv3.LeaseID(leaseID)).Return(&clientv3.LeaseKeepAliveResponse{TTL: 1}, nil)
+	require.Equal(t, nil, e.BindStatus(t.Context(), "/entity", "/status", "status", 1))
+	etcd.AssertNotCalled(t, "Grant", mock.Anything, mock.Anything)
+}
+
+func TestBindStatusRebindsWhenTheRenewLostItsEntity(t *testing.T) {
+	e, etcd, assert := testKeepAliveETCD(t)
+	defer assert()
+
+	txn := &mocks.Txn{}
+	defer txn.AssertExpectations(t)
+	txn.On("If", mock.Anything, mock.Anything).Return(txn).Once()
+	txn.On("If", mock.Anything).Return(txn).Once()
+	txn.On("Then", mock.Anything).Return(txn)
+	txn.On("Commit").Return(&clientv3.TxnResponse{Succeeded: false}, nil)
+
+	etcd.On("Txn", mock.Anything).Return(txn)
+	etcd.On("Grant", mock.Anything, mock.Anything).Return(&clientv3.LeaseGrantResponse{}, nil)
+	require.Equal(t, types.ErrInvaildCount, e.BindStatus(t.Context(), "/entity", "/status", "status", 1))
+	etcd.AssertNotCalled(t, "KeepAliveOnce", mock.Anything, mock.Anything)
+}
+
+func TestBindStatusRebindsWhenTheTTLChanged(t *testing.T) {
+	e, etcd, assert := testKeepAliveETCD(t)
+	defer assert()
+
+	leaseID := int64(1235)
+	txn := &mocks.Txn{}
+	defer txn.AssertExpectations(t)
+	txn.On("If", mock.Anything, mock.Anything).Return(txn).Once()
+	txn.On("If", mock.Anything).Return(txn).Once()
+	txn.On("Then", mock.Anything).Return(txn)
+	txn.On("Commit").Return(renewTxn("status", leaseID), nil).Once()
+	txn.On("Commit").Return(&clientv3.TxnResponse{Succeeded: true}, nil).Once()
+
+	etcd.On("Txn", mock.Anything).Return(txn)
+	etcd.On("KeepAliveOnce", mock.Anything, clientv3.LeaseID(leaseID)).Return(&clientv3.LeaseKeepAliveResponse{TTL: 5}, nil)
+	etcd.On("Grant", mock.Anything, mock.Anything).Return(&clientv3.LeaseGrantResponse{}, nil)
+	require.Equal(t, nil, e.BindStatus(t.Context(), "/entity", "/status", "status", 1))
+}
+
+func TestBindStatusWithoutEntityCarriesALease(t *testing.T) {
+	e := NewEmbeddedETCD(t)
+	ctx := t.Context()
+
+	require.NoError(t, e.BindStatus(ctx, "/entity", "/status", "gone", 0))
+	kv, err := e.GetOne(ctx, "/status")
+	require.NoError(t, err)
+	require.NotZero(t, kv.Lease)
+
+	_, err = e.Put(ctx, "/entity", "here")
+	require.NoError(t, err)
+	require.NoError(t, e.BindStatus(ctx, "/entity", "/status", "gone", 0))
+	kv, err = e.GetOne(ctx, "/status")
+	require.NoError(t, err)
+	require.Zero(t, kv.Lease)
+	require.Equal(t, "gone", string(kv.Value))
+
+	leases, err := e.cliv3.Leases(ctx)
+	require.NoError(t, err)
+	require.Len(t, leases.Leases, 1)
+}
+
+func TestBindStatusOrphanPutYieldsToAnEntityThatAppeared(t *testing.T) {
+	e, etcd, assert := testKeepAliveETCD(t)
+	defer assert()
+
 	txn := &mocks.Txn{}
 	defer txn.AssertExpectations(t)
 	txn.On("If", mock.Anything).Return(txn)
 	txn.On("Then", mock.Anything).Return(txn)
-	txn.On("Commit").Return(entityTxn, nil)
+	txn.On("Else", mock.Anything).Return(txn)
+	txn.On("Commit").Return(&clientv3.TxnResponse{Succeeded: false}, nil)
 
-	etcd.On("Grant", mock.Anything, mock.Anything).Return(&clientv3.LeaseGrantResponse{}, nil)
 	etcd.On("Txn", mock.Anything).Return(txn)
-	etcd.On("Get", mock.Anything, mock.Anything).Return(&clientv3.GetResponse{}, nil)
-	require.Equal(t, nil, e.BindStatus(t.Context(), "/entity", "/status", "status", 1))
+	etcd.On("Grant", mock.Anything, mock.Anything).Return(&clientv3.LeaseGrantResponse{ID: 7}, nil)
+	etcd.On("Revoke", mock.Anything, clientv3.LeaseID(7)).Return(&clientv3.LeaseRevokeResponse{}, nil)
+	require.NoError(t, e.BindStatus(t.Context(), "/entity", "/status", "status", 0))
 }
 
 func TestBindStatusWithZeroTTL(t *testing.T) {
@@ -159,130 +232,43 @@ func TestBindStatusWithZeroTTL(t *testing.T) {
 	require.Equal(t, nil, e.BindStatus(t.Context(), "/entity", "/status", "status", 0))
 }
 
-func TestBindStatusOrphanPutYieldsToAnEntityThatAppeared(t *testing.T) {
+func TestBindStatusRebindsAChangedValue(t *testing.T) {
 	e, etcd, assert := testKeepAliveETCD(t)
 	defer assert()
 
 	txn := &mocks.Txn{}
 	defer txn.AssertExpectations(t)
-	txn.On("If", mock.Anything).Return(txn)
+	txn.On("If", mock.Anything, mock.Anything).Return(txn).Once()
+	txn.On("If", mock.Anything).Return(txn).Once()
 	txn.On("Then", mock.Anything).Return(txn)
-	txn.On("Else", mock.Anything).Return(txn)
-	txn.On("Commit").Return(&clientv3.TxnResponse{Succeeded: false}, nil)
+	txn.On("Commit").Return(&clientv3.TxnResponse{Succeeded: false}, nil).Once()
+	txn.On("Commit").Return(&clientv3.TxnResponse{Succeeded: true}, nil).Once()
 
+	etcd.On("Grant", mock.Anything, mock.Anything).Return(&clientv3.LeaseGrantResponse{}, nil)
 	etcd.On("Txn", mock.Anything).Return(txn)
-	etcd.On("Grant", mock.Anything, mock.Anything).Return(&clientv3.LeaseGrantResponse{ID: 7}, nil)
-	etcd.On("Revoke", mock.Anything, clientv3.LeaseID(7)).Return(&clientv3.LeaseRevokeResponse{}, nil)
-	require.NoError(t, e.BindStatus(t.Context(), "/entity", "/status", "status", 0))
+	require.Equal(t, nil, e.BindStatus(t.Context(), "/entity", "/status", "status", 1))
+	etcd.AssertNotCalled(t, "KeepAliveOnce", mock.Anything, mock.Anything)
 }
 
-func TestBindStatusWithoutEntityCarriesALease(t *testing.T) {
+func TestBindStatusKeepsOneLeaseAcrossRepeatedReports(t *testing.T) {
 	e := NewEmbeddedETCD(t)
 	ctx := t.Context()
+	_, err := e.Put(ctx, "/entity", "here")
+	require.NoError(t, err)
 
-	require.NoError(t, e.BindStatus(ctx, "/entity", "/status", "gone", 0))
-	kv, err := e.GetOne(ctx, "/status")
+	require.NoError(t, e.BindStatus(ctx, "/entity", "/status", "status", 5))
+	first, err := e.GetOne(ctx, "/status")
 	require.NoError(t, err)
-	require.NotZero(t, kv.Lease)
+	require.NotZero(t, first.Lease)
 
-	_, err = e.Put(ctx, "/entity", "here")
+	require.NoError(t, e.BindStatus(ctx, "/entity", "/status", "status", 5))
+	second, err := e.GetOne(ctx, "/status")
 	require.NoError(t, err)
-	require.NoError(t, e.BindStatus(ctx, "/entity", "/status", "gone", 0))
-	kv, err = e.GetOne(ctx, "/status")
-	require.NoError(t, err)
-	require.Zero(t, kv.Lease)
-	require.Equal(t, "gone", string(kv.Value))
+	require.Equal(t, first.Lease, second.Lease)
 
 	leases, err := e.cliv3.Leases(ctx)
 	require.NoError(t, err)
 	require.Len(t, leases.Leases, 1)
-}
-
-func TestBindStatusButValueTxnUnsuccessful(t *testing.T) {
-	e, etcd, assert := testKeepAliveETCD(t)
-	defer assert()
-
-	statusTxn := &etcdserverpb.TxnResponse{
-		Succeeded: true,
-		Responses: []*etcdserverpb.ResponseOp{
-			{
-				Response: &etcdserverpb.ResponseOp_ResponseTxn{
-					ResponseTxn: &etcdserverpb.TxnResponse{Succeeded: false},
-				},
-			},
-		},
-	}
-	entityTxn := &clientv3.TxnResponse{
-		Succeeded: true,
-		Responses: []*etcdserverpb.ResponseOp{
-			{
-				Response: &etcdserverpb.ResponseOp_ResponseTxn{
-					ResponseTxn: statusTxn,
-				},
-			},
-		},
-	}
-	txn := &mocks.Txn{}
-	defer txn.AssertExpectations(t)
-	txn.On("If", mock.Anything).Return(txn)
-	txn.On("Then", mock.Anything).Return(txn)
-	txn.On("Commit").Return(entityTxn, nil)
-
-	etcd.On("Txn", mock.Anything).Return(txn)
-	etcd.On("Grant", mock.Anything, mock.Anything).Return(&clientv3.LeaseGrantResponse{}, nil)
-	etcd.On("Get", mock.Anything, mock.Anything).Return(&clientv3.GetResponse{}, nil)
-	require.Equal(t, nil, e.BindStatus(t.Context(), "/entity", "/status", "status", 1))
-}
-
-func TestBindStatus(t *testing.T) {
-	e, etcd, assert := testKeepAliveETCD(t)
-	defer assert()
-
-	leaseID := int64(1235)
-	valueTxn := &etcdserverpb.TxnResponse{
-		Succeeded: true,
-		Responses: []*etcdserverpb.ResponseOp{
-			{
-				Response: &etcdserverpb.ResponseOp_ResponseRange{
-					ResponseRange: &etcdserverpb.RangeResponse{
-						Kvs: []*mvccpb.KeyValue{
-							{Lease: leaseID},
-						},
-					},
-				},
-			},
-		},
-	}
-	statusTxn := &etcdserverpb.TxnResponse{
-		Succeeded: true,
-		Responses: []*etcdserverpb.ResponseOp{
-			{
-				Response: &etcdserverpb.ResponseOp_ResponseTxn{
-					ResponseTxn: valueTxn,
-				},
-			},
-		},
-	}
-	entityTxn := &clientv3.TxnResponse{
-		Succeeded: true,
-		Responses: []*etcdserverpb.ResponseOp{
-			{
-				Response: &etcdserverpb.ResponseOp_ResponseTxn{
-					ResponseTxn: statusTxn,
-				},
-			},
-		},
-	}
-	txn := &mocks.Txn{}
-	defer txn.AssertExpectations(t)
-	txn.On("If", mock.Anything).Return(txn)
-	txn.On("Then", mock.Anything).Return(txn)
-	txn.On("Commit").Return(entityTxn, nil)
-
-	etcd.On("Grant", mock.Anything, mock.Anything).Return(&clientv3.LeaseGrantResponse{}, nil)
-	etcd.On("Txn", mock.Anything).Return(txn)
-	etcd.On("Get", mock.Anything, mock.Anything).Return(&clientv3.GetResponse{}, nil)
-	require.Equal(t, nil, e.BindStatus(t.Context(), "/entity", "/status", "status", 1))
 }
 
 func TestETCD(t *testing.T) {
@@ -468,4 +454,15 @@ func testKeepAliveETCD(t *testing.T) (*ETCD, *mocks.ETCDClientV3, func()) {
 	etcd, ok := e.cliv3.(*mocks.ETCDClientV3)
 	require.True(t, ok)
 	return e, etcd, func() { etcd.AssertExpectations(t) }
+}
+
+func renewTxn(value string, lease int64) *clientv3.TxnResponse {
+	return &clientv3.TxnResponse{
+		Succeeded: true,
+		Responses: []*etcdserverpb.ResponseOp{{
+			Response: &etcdserverpb.ResponseOp_ResponseRange{
+				ResponseRange: &etcdserverpb.RangeResponse{Kvs: []*mvccpb.KeyValue{{Value: []byte(value), Lease: lease}}},
+			},
+		}},
+	}
 }


### PR DESCRIPTION
`bindStatusWithTTL` granted a lease before it knew whether the status had changed. In the common case, an agent heartbeat repeating the same value, it then revoked the lease it had just granted and kept the original one alive: `Grant`, `Get`, `TimeToLive`, the nested transaction, `Revoke`, `KeepAliveOnce` — six etcd round trips per status entry, two of them pure waste, and `SetWorkloadsStatus` walks its entries one at a time.

The bind now reads the current status first. When the value and the ttl are unchanged it renews the existing lease behind one transaction that compares the entity's presence, the status value and its lease, so a status that moved under us falls through to the write path. Only a changed status (or one whose ttl or lease changed) grants a lease and writes it. The three-level nested transaction that encoded the same decision server-side is gone. Steady state is four round trips instead of six; the changed path keeps its four.

Tests: `TestBindStatusRenewsAnUnchangedStatus` asserts no `Grant` on the steady path, `TestBindStatusRebindsWhenTheRenewLostItsEntity` covers the fall-through, `TestBindStatusRebindsAChangedValue` the write path, and `TestBindStatusKeepsOneLeaseAcrossRepeatedReports` on embedded etcd asserts the lease id is stable and exactly one lease exists after repeated reports.
