### PR TITLE
refactor: cpumem keeps its node records in the cluster store

### DIFF
--- a/cluster/calcium/calcium.go
+++ b/cluster/calcium/calcium.go
@@ -65,7 +65,7 @@ func New(ctx context.Context, config types.Config, embeddedETCD *embedded.Cluste
 	watcher := helium.New(ctx, config.GRPCConfig, store)
 
 	rmgr := cobalt.New(config)
-	if err = rmgr.LoadPlugins(ctx, embeddedETCD); err != nil {
+	if err = rmgr.LoadPlugins(ctx, store); err != nil {
 		logger.Error(ctx, err)
 		return nil, err
 	}

--- a/docs/resource-plugins.md
+++ b/docs/resource-plugins.md
@@ -65,10 +65,9 @@ discard the result.
 
 ## cpumem — the built-in plugin
 
-Always loaded, under the name `cpumem`. It stores its own bookkeeping in etcd at
-`/resource/cpumem/<nodename>` (under `etcd.prefix`), reusing core's etcd config — including the
-embedded cluster when `--embedded-storage` is on. With `store: redis` and no etcd endpoints
-configured, plugin construction fails, so a redis deployment still needs `etcd.machines`.
+Always loaded, under the name `cpumem`. It keeps one record per node at
+`/resource/cpumem/<nodename>` in the cluster store core itself uses (under `etcd.prefix` on etcd),
+so a `store: redis` deployment needs no etcd.
 
 It reads two scheduler settings:
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -57,8 +57,8 @@ One behaviour differs from etcd and is marked as such in the code: `Update` chec
 existence before writing rather than doing it in one transaction. Tests run against an embedded
 miniredis.
 
-Note that even with `store: redis`, the built-in cpumem resource plugin still uses the etcd
-config for its own bookkeeping — see [Resource plugins](resource-plugins.md).
+The built-in cpumem resource plugin keeps its node records in the same store — see
+[Resource plugins](resource-plugins.md).
 
 ## Locks
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -58,7 +58,10 @@ existence before writing rather than doing it in one transaction. Tests run agai
 miniredis.
 
 The built-in cpumem resource plugin keeps its node records in the same store — see
-[Resource plugins](resource-plugins.md).
+[Resource plugins](resource-plugins.md). A `store: redis` deployment that predates this kept those
+records in etcd under `<etcd.prefix>/resource/cpumem/`: copy them into redis under the same keys
+before starting the new cores, and move every core together, since an old core would keep writing
+the etcd copy.
 
 ## Locks
 

--- a/resource/cobalt/cobalt.go
+++ b/resource/cobalt/cobalt.go
@@ -7,6 +7,7 @@ import (
 	"github.com/projecteru2/core/resource/plugins"
 	"github.com/projecteru2/core/resource/plugins/binary"
 	"github.com/projecteru2/core/resource/plugins/cpumem"
+	"github.com/projecteru2/core/store"
 	"github.com/projecteru2/core/types"
 	"github.com/projecteru2/core/utils"
 )
@@ -21,7 +22,7 @@ func New(config types.Config) *Manager {
 	return &Manager{config: config}
 }
 
-func (m *Manager) LoadPlugins(ctx context.Context, store cpumem.Store) error {
+func (m *Manager) LoadPlugins(ctx context.Context, store store.Store) error {
 	logger := log.WithFunc("resource.cobalt.LoadPlugins")
 	m.AddPlugins(cpumem.NewPlugin(m.config, store))
 

--- a/resource/cobalt/cobalt.go
+++ b/resource/cobalt/cobalt.go
@@ -7,7 +7,6 @@ import (
 	"github.com/projecteru2/core/resource/plugins"
 	"github.com/projecteru2/core/resource/plugins/binary"
 	"github.com/projecteru2/core/resource/plugins/cpumem"
-	"github.com/projecteru2/core/store/etcdv3/embedded"
 	"github.com/projecteru2/core/types"
 	"github.com/projecteru2/core/utils"
 )
@@ -22,13 +21,9 @@ func New(config types.Config) *Manager {
 	return &Manager{config: config}
 }
 
-func (m *Manager) LoadPlugins(ctx context.Context, embeddedETCD *embedded.Cluster) error {
+func (m *Manager) LoadPlugins(ctx context.Context, store cpumem.Store) error {
 	logger := log.WithFunc("resource.cobalt.LoadPlugins")
-	cm, err := cpumem.NewPlugin(ctx, m.config, embeddedETCD)
-	if err != nil {
-		return err
-	}
-	m.AddPlugins(cm)
+	m.AddPlugins(cpumem.NewPlugin(m.config, store))
 
 	if m.config.ResourcePlugin.Dir == "" {
 		return nil

--- a/resource/plugins/cpumem/calculate_test.go
+++ b/resource/plugins/cpumem/calculate_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestCalculateDeploy(t *testing.T) {
 	ctx := t.Context()
-	cm := initCPUMEM(ctx, t)
+	cm := initCPUMEM(t)
 	nodes := generateNodes(ctx, t, cm, 1, 2, 4*units.GB, 100, 0)
 	node := nodes[0]
 
@@ -117,7 +117,7 @@ func TestCalculateDeploy(t *testing.T) {
 
 func TestCalculateRealloc(t *testing.T) {
 	ctx := t.Context()
-	cm := initCPUMEM(ctx, t)
+	cm := initCPUMEM(t)
 	nodes := generateNodes(ctx, t, cm, 1, 2, 4*units.GB, 100, 0)
 	node := nodes[0]
 
@@ -192,7 +192,7 @@ func TestCalculateRealloc(t *testing.T) {
 
 func TestCalculateRemap(t *testing.T) {
 	ctx := t.Context()
-	cm := initCPUMEM(ctx, t)
+	cm := initCPUMEM(t)
 	nodes := generateNodes(ctx, t, cm, 1, 4, 4*units.GB, 100, 0)
 	node := nodes[0]
 

--- a/resource/plugins/cpumem/cpumem.go
+++ b/resource/plugins/cpumem/cpumem.go
@@ -3,9 +3,6 @@ package cpumem
 import (
 	"context"
 
-	"github.com/projecteru2/core/log"
-	"github.com/projecteru2/core/store/etcdv3/embedded"
-	"github.com/projecteru2/core/store/etcdv3/meta"
 	coretypes "github.com/projecteru2/core/types"
 )
 
@@ -16,24 +13,22 @@ const (
 	priority            = 100
 )
 
+// Store is the slice of the cluster store that keeps the node records of this plugin.
+type Store interface {
+	GetMulti(ctx context.Context, keys []string) (map[string]string, error)
+	Put(ctx context.Context, data map[string]string) error
+	Delete(ctx context.Context, keys []string) error
+}
+
 // Plugin is the built-in cpu and memory resource plugin.
 type Plugin struct {
 	name   string
 	config coretypes.Config
-	store  meta.KV
+	store  Store
 }
 
-func NewPlugin(ctx context.Context, config coretypes.Config, embeddedETCD *embedded.Cluster) (*Plugin, error) {
-	if embeddedETCD == nil && len(config.Etcd.Machines) < 1 {
-		return nil, coretypes.ErrConfigInvaild
-	}
-	var err error
-	plugin := &Plugin{name: name, config: config}
-	if plugin.store, err = meta.NewETCD(ctx, config.Etcd, embeddedETCD); err != nil {
-		log.WithFunc("resource.cpumem.NewPlugin").Error(ctx, err)
-		return nil, err
-	}
-	return plugin, nil
+func NewPlugin(config coretypes.Config, store Store) *Plugin {
+	return &Plugin{name: name, config: config, store: store}
 }
 
 func (p Plugin) Name() string {

--- a/resource/plugins/cpumem/cpumem.go
+++ b/resource/plugins/cpumem/cpumem.go
@@ -15,6 +15,7 @@ const (
 
 // Store is the slice of the cluster store that keeps the node records of this plugin.
 type Store interface {
+	NotFound(err error) bool
 	GetMulti(ctx context.Context, keys []string) (map[string]string, error)
 	Put(ctx context.Context, data map[string]string) error
 	Delete(ctx context.Context, keys []string) error

--- a/resource/plugins/cpumem/cpumem_test.go
+++ b/resource/plugins/cpumem/cpumem_test.go
@@ -3,38 +3,30 @@ package cpumem
 import (
 	"context"
 	"fmt"
+	"maps"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	enginetypes "github.com/projecteru2/core/engine/types"
 	plugintypes "github.com/projecteru2/core/resource/plugins/types"
-	"github.com/projecteru2/core/store/etcdv3/embedded"
 	coretypes "github.com/projecteru2/core/types"
 )
 
 func TestName(t *testing.T) {
-	cm := initCPUMEM(t.Context(), t)
+	cm := initCPUMEM(t)
 	assert.Equal(t, cm.name, cm.Name())
 }
 
-func initCPUMEM(ctx context.Context, t testing.TB) *Plugin {
+func initCPUMEM(t testing.TB) *Plugin {
 	config := coretypes.Config{
-		Etcd: coretypes.EtcdConfig{
-			Prefix: "/cpumem",
-		},
 		Scheduler: coretypes.SchedulerConfig{
 			MaxShare:  -1,
 			ShareBase: 100,
 		},
 	}
-
-	cluster, err := embedded.New(t.TempDir())
-	assert.NoError(t, err)
-	t.Cleanup(cluster.Close)
-	cm, err := NewPlugin(ctx, config, cluster)
-	assert.NoError(t, err)
-	return cm
+	return NewPlugin(config, &memStore{data: map[string]string{}})
 }
 
 func generateNodes(
@@ -68,4 +60,39 @@ func generateNodeResourceRequests(t testing.TB, nums, cores int, memory int64, s
 		infos[fmt.Sprintf("test%v", i)] = info
 	}
 	return infos
+}
+
+type memStore struct {
+	mu   sync.Mutex
+	data map[string]string
+}
+
+func (s *memStore) GetMulti(_ context.Context, keys []string) (map[string]string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	data := make(map[string]string, len(keys))
+	for _, key := range keys {
+		value, ok := s.data[key]
+		if !ok {
+			return nil, coretypes.ErrInvaildCount
+		}
+		data[key] = value
+	}
+	return data, nil
+}
+
+func (s *memStore) Put(_ context.Context, data map[string]string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	maps.Copy(s.data, data)
+	return nil
+}
+
+func (s *memStore) Delete(_ context.Context, keys []string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, key := range keys {
+		delete(s.data, key)
+	}
+	return nil
 }

--- a/resource/plugins/cpumem/cpumem_test.go
+++ b/resource/plugins/cpumem/cpumem_test.go
@@ -2,6 +2,7 @@ package cpumem
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"sync"
@@ -65,6 +66,10 @@ func generateNodeResourceRequests(t testing.TB, nums, cores int, memory int64, s
 type memStore struct {
 	mu   sync.Mutex
 	data map[string]string
+}
+
+func (s *memStore) NotFound(err error) bool {
+	return errors.Is(err, coretypes.ErrInvaildCount)
 }
 
 func (s *memStore) GetMulti(_ context.Context, keys []string) (map[string]string, error) {

--- a/resource/plugins/cpumem/metrics_test.go
+++ b/resource/plugins/cpumem/metrics_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestGetMetricsDescription(t *testing.T) {
 	ctx := t.Context()
-	cm := initCPUMEM(ctx, t)
+	cm := initCPUMEM(t)
 	md, err := cm.GetMetricsDescription(ctx)
 	assert.NoError(t, err)
 	assert.NotNil(t, md)
@@ -18,7 +18,7 @@ func TestGetMetricsDescription(t *testing.T) {
 
 func TestGetMetrics(t *testing.T) {
 	ctx := t.Context()
-	cm := initCPUMEM(ctx, t)
+	cm := initCPUMEM(t)
 	_, err := cm.GetMetrics(ctx, "", "")
 	assert.Error(t, err)
 

--- a/resource/plugins/cpumem/node.go
+++ b/resource/plugins/cpumem/node.go
@@ -9,7 +9,6 @@ import (
 	"slices"
 	"strconv"
 
-	"github.com/cockroachdb/errors"
 	"github.com/sanity-io/litter"
 
 	enginetypes "github.com/projecteru2/core/engine/types"
@@ -35,7 +34,7 @@ func (p Plugin) AddNode(ctx context.Context, nodename string, resource plugintyp
 		return nil, coretypes.ErrNodeExists
 	}
 
-	if !errors.Is(err, coretypes.ErrInvaildCount) {
+	if !p.store.NotFound(err) {
 		log.WithFunc("resource.cpumem.AddNode").WithField("node", nodename).Error(ctx, err, "failed to get resource info of node")
 		return nil, err
 	}
@@ -404,7 +403,6 @@ func (p Plugin) doGetNodeDeployCapacity(nodeResourceInfo *cpumemtypes.NodeResour
 	return capacityInfo
 }
 
-// calculateNodeResource priority: node resource request > node resource > workload resource args list
 func (p Plugin) calculateNodeResource(req *cpumemtypes.NodeResourceRequest, nodeResource, origin *cpumemtypes.NodeResource, workloadsResource []*cpumemtypes.WorkloadResource, delta, incr bool) *cpumemtypes.NodeResource {
 	var resp *cpumemtypes.NodeResource
 	if origin == nil || !delta { // no delta means node resource rewrite with whole new data

--- a/resource/plugins/cpumem/node.go
+++ b/resource/plugins/cpumem/node.go
@@ -103,8 +103,8 @@ func (p Plugin) AddNode(ctx context.Context, nodename string, resource plugintyp
 }
 
 func (p Plugin) RemoveNode(ctx context.Context, nodename string) (*plugintypes.RemoveNodeResponse, error) {
-	var err error
-	if _, err = p.store.Delete(ctx, fmt.Sprintf(nodeResourceInfoKey, nodename)); err != nil {
+	err := p.store.Delete(ctx, []string{fmt.Sprintf(nodeResourceInfoKey, nodename)})
+	if err != nil {
 		log.WithFunc("resource.cpumem.RemoveNode").WithField("node", nodename).Error(ctx, err, "failed to delete node")
 	}
 	return &plugintypes.RemoveNodeResponse{}, err
@@ -346,18 +346,18 @@ func (p Plugin) doGetNodesResourceInfo(ctx context.Context, nodenames []string) 
 	for _, nodename := range nodenames {
 		keys = append(keys, fmt.Sprintf(nodeResourceInfoKey, nodename))
 	}
-	resps, err := p.store.GetMulti(ctx, keys)
+	data, err := p.store.GetMulti(ctx, keys)
 	if err != nil {
 		return nil, err
 	}
 
-	result := make(map[string]*cpumemtypes.NodeResourceInfo, len(resps))
-	for _, resp := range resps {
+	result := make(map[string]*cpumemtypes.NodeResourceInfo, len(data))
+	for key, value := range data {
 		r := &cpumemtypes.NodeResourceInfo{}
-		if err := json.Unmarshal(resp.Value, r); err != nil {
+		if err := json.Unmarshal([]byte(value), r); err != nil {
 			return nil, err
 		}
-		result[utils.Tail(string(resp.Key))] = r
+		result[utils.Tail(key)] = r
 	}
 	return result, nil
 }
@@ -372,8 +372,7 @@ func (p Plugin) doSetNodeResourceInfo(ctx context.Context, nodename string, reso
 		return err
 	}
 
-	_, err = p.store.Put(ctx, fmt.Sprintf(nodeResourceInfoKey, nodename), string(data))
-	return err
+	return p.store.Put(ctx, map[string]string{fmt.Sprintf(nodeResourceInfoKey, nodename): string(data)})
 }
 
 func (p Plugin) doGetNodeDeployCapacity(nodeResourceInfo *cpumemtypes.NodeResourceInfo, req *cpumemtypes.WorkloadResourceRequest) *plugintypes.NodeDeployCapacity {

--- a/resource/plugins/cpumem/node_test.go
+++ b/resource/plugins/cpumem/node_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestAddNode(t *testing.T) {
 	ctx := t.Context()
-	cm := initCPUMEM(ctx, t)
+	cm := initCPUMEM(t)
 	nodes := generateNodes(ctx, t, cm, 1, 2, 4*units.GB, 100, 0)
 	node := nodes[0]
 	nodeForAdd := "test2"
@@ -38,7 +38,7 @@ func TestAddNode(t *testing.T) {
 
 func TestRemoveNode(t *testing.T) {
 	ctx := t.Context()
-	cm := initCPUMEM(ctx, t)
+	cm := initCPUMEM(t)
 	nodes := generateNodes(ctx, t, cm, 1, 2, 4*units.GB, 100, 0)
 	node := nodes[0]
 	nodeForDel := "test2"
@@ -51,7 +51,7 @@ func TestRemoveNode(t *testing.T) {
 
 func TestGetNodesDeployCapacityWithCPUBind(t *testing.T) {
 	ctx := t.Context()
-	cm := initCPUMEM(ctx, t)
+	cm := initCPUMEM(t)
 	nodes := generateNodes(ctx, t, cm, 2, 2, 4*units.GB, 100, 0)
 
 	req := plugintypes.WorkloadResourceRequest{
@@ -112,7 +112,7 @@ func TestGetNodesDeployCapacityWithCPUBind(t *testing.T) {
 
 func TestGetNodesDeployCapacityWithMemoryAndCPUBind(t *testing.T) {
 	ctx := t.Context()
-	cm := initCPUMEM(ctx, t)
+	cm := initCPUMEM(t)
 	nodes := generateNodes(ctx, t, cm, 2, 2, 1024, 100, 0)
 
 	req := plugintypes.WorkloadResourceRequest{
@@ -133,7 +133,7 @@ func TestGetNodesDeployCapacityWithMemoryAndCPUBind(t *testing.T) {
 
 func TestGetNodesDeployCapacityWithMaxShareLimit(t *testing.T) {
 	ctx := t.Context()
-	cm := initCPUMEM(ctx, t)
+	cm := initCPUMEM(t)
 	cm.config.Scheduler.MaxShare = 2
 	nodes := generateNodes(ctx, t, cm, 1, 6, 12*units.GB, 100, 0)
 	node := nodes[0]
@@ -170,7 +170,7 @@ func TestGetNodesDeployCapacityWithMaxShareLimit(t *testing.T) {
 
 func TestGetNodesDeployCapacityWithMemory(t *testing.T) {
 	ctx := t.Context()
-	cm := initCPUMEM(ctx, t)
+	cm := initCPUMEM(t)
 	nodes := generateNodes(ctx, t, cm, 2, 2, 4*units.GiB, 100, 0)
 
 	req := plugintypes.WorkloadResourceRequest{
@@ -214,7 +214,7 @@ func TestGetNodesDeployCapacityWithMemory(t *testing.T) {
 
 func TestSetNodeResourceCapacity(t *testing.T) {
 	ctx := t.Context()
-	cm := initCPUMEM(ctx, t)
+	cm := initCPUMEM(t)
 	nodes := generateNodes(ctx, t, cm, 1, 2, 2*units.GB, 100, 0)
 	node := nodes[0]
 
@@ -293,7 +293,7 @@ func TestSetNodeResourceCapacity(t *testing.T) {
 
 func TestGetAndFixNodeResourceInfo(t *testing.T) {
 	ctx := t.Context()
-	cm := initCPUMEM(ctx, t)
+	cm := initCPUMEM(t)
 	nodes := generateNodes(ctx, t, cm, 1, 2, 4*units.GB, 100, 0)
 	node := nodes[0]
 
@@ -330,7 +330,7 @@ func TestGetAndFixNodeResourceInfo(t *testing.T) {
 
 func TestSetNodeResourceInfo(t *testing.T) {
 	ctx := t.Context()
-	cm := initCPUMEM(ctx, t)
+	cm := initCPUMEM(t)
 	nodes := generateNodes(ctx, t, cm, 1, 2, 4*units.GB, 100, 0)
 	node := nodes[0]
 
@@ -343,7 +343,7 @@ func TestSetNodeResourceInfo(t *testing.T) {
 
 func TestSetNodeResourceUsage(t *testing.T) {
 	ctx := t.Context()
-	cm := initCPUMEM(ctx, t)
+	cm := initCPUMEM(t)
 	nodes := generateNodes(ctx, t, cm, 1, 2, 4*units.GB, 100, 0)
 	node := nodes[0]
 
@@ -419,7 +419,7 @@ func TestSetNodeResourceUsage(t *testing.T) {
 
 func TestGetMostIdleNode(t *testing.T) {
 	ctx := t.Context()
-	cm := initCPUMEM(ctx, t)
+	cm := initCPUMEM(t)
 	nodes := generateNodes(ctx, t, cm, 2, 2, 2*units.GB, 100, 0)
 	usage := plugintypes.NodeResourceRequest{"memory": "100"}
 
@@ -437,7 +437,7 @@ func TestGetMostIdleNode(t *testing.T) {
 
 func BenchmarkGetNodesCapacity(b *testing.B) {
 	ctx := b.Context()
-	cm := initCPUMEM(ctx, b)
+	cm := initCPUMEM(b)
 	nodes := generateNodes(ctx, b, cm, 1000, 24, 128*units.GB, 100, 0)
 	req := plugintypes.WorkloadResourceRequest{
 		"cpu-bind":       true,
@@ -453,7 +453,7 @@ func BenchmarkGetNodesCapacity(b *testing.B) {
 
 func TestAddNodeSplitsMemoryPerNUMANode(t *testing.T) {
 	ctx := t.Context()
-	cm := initCPUMEM(ctx, t)
+	cm := initCPUMEM(t)
 
 	req := plugintypes.NodeResourceRequest{
 		"cpu":      8,

--- a/store/mocks/Store.go
+++ b/store/mocks/Store.go
@@ -626,6 +626,74 @@ func (_c *Store_GetDeployStatus_Call) RunAndReturn(run func(ctx context.Context,
 	return _c
 }
 
+// GetMulti provides a mock function for the type Store
+func (_mock *Store) GetMulti(ctx context.Context, keys []string) (map[string]string, error) {
+	ret := _mock.Called(ctx, keys)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetMulti")
+	}
+
+	var r0 map[string]string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) (map[string]string, error)); ok {
+		return returnFunc(ctx, keys)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) map[string]string); ok {
+		r0 = returnFunc(ctx, keys)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]string)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, []string) error); ok {
+		r1 = returnFunc(ctx, keys)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Store_GetMulti_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetMulti'
+type Store_GetMulti_Call struct {
+	*mock.Call
+}
+
+// GetMulti is a helper method to define mock.On call
+//   - ctx context.Context
+//   - keys []string
+func (_e *Store_Expecter) GetMulti(ctx any, keys any) *Store_GetMulti_Call {
+	return &Store_GetMulti_Call{Call: _e.mock.On("GetMulti", ctx, keys)}
+}
+
+func (_c *Store_GetMulti_Call) Run(run func(ctx context.Context, keys []string)) *Store_GetMulti_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []string
+		if args[1] != nil {
+			arg1 = args[1].([]string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *Store_GetMulti_Call) Return(stringToString map[string]string, err error) *Store_GetMulti_Call {
+	_c.Call.Return(stringToString, err)
+	return _c
+}
+
+func (_c *Store_GetMulti_Call) RunAndReturn(run func(ctx context.Context, keys []string) (map[string]string, error)) *Store_GetMulti_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetNode provides a mock function for the type Store
 func (_mock *Store) GetNode(ctx context.Context, nodename string) (*types.Node, error) {
 	ret := _mock.Called(ctx, nodename)

--- a/store/store.go
+++ b/store/store.go
@@ -13,6 +13,7 @@ type Store interface {
 	NotFound(err error) bool
 	Put(ctx context.Context, data map[string]string) error
 	Delete(ctx context.Context, keys []string) error
+	GetMulti(ctx context.Context, keys []string) (map[string]string, error)
 	GetPrefix(ctx context.Context, prefix string, limit int64) (map[string]string, error)
 	ListPrefix(ctx context.Context, prefix string) ([]string, error)
 


### PR DESCRIPTION
## What

- `cpumem.NewPlugin(config, store)` takes a three-verb `Store` interface (`GetMulti`, `Put`, `Delete`) instead of dialing etcd with core's etcd config. `cobalt.LoadPlugins` takes that store; `calcium.New` passes the cluster store it already holds. The embedded cluster no longer reaches the resource manager.
- `store.Store` gains `GetMulti(ctx, keys) (map[string]string, error)`; both backends already implemented it through `common.KV`. Missing keys stay an error on both, so the plugin's strict lookups behave as before.
- Plugin tests run against a map store instead of an embedded etcd.
- Docs: a `store: redis` deployment no longer needs `etcd.machines`.

Keys and their prefix are unchanged on etcd (`<etcd.prefix>/resource/cpumem/<node>`), so existing records are read as before.

## Gates

`GOWORK=off go build ./...`, `go vet`, `go test -count=1 ./...` (all packages ok), `make lint fmt-check` on GOOS=linux and darwin (0 issues each), `asl ./...` both GOOS (no findings). `store/mocks/Store.go` regenerated with the pinned mockery.
