### PR TITLE
fix: bring the redis store to etcd's contract on create, status and prefix reads

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -57,7 +57,8 @@ One behaviour differs from etcd and is marked as such in the code: `Update` chec
 existence before writing rather than doing it in one transaction. `Create` and `CreateAndDecr`
 run as one Lua script, so a conflicting key writes nothing and the processing counter must exist,
 as on etcd. A status heartbeat that carries an unchanged value only refreshes the key's TTL, and
-TTL refreshes are not watch events, so streams see status changes rather than heartbeats. Tests
+TTL refreshes are not watch events, so streams see status changes rather than heartbeats. A status
+without a TTL whose entity core has not recorded is kept for an hour, as on etcd. Tests
 run against an embedded miniredis.
 
 Note that even with `store: redis`, the built-in cpumem resource plugin still uses the etcd

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -54,8 +54,11 @@ transactional pipelines, while multi-key reads and deletes are single `MGET` / `
 see status changes otherwise. Ephemeral keys are ordinary keys with a TTL, refreshed on a timer.
 
 One behaviour differs from etcd and is marked as such in the code: `Update` checks key
-existence before writing rather than doing it in one transaction. Tests run against an embedded
-miniredis.
+existence before writing rather than doing it in one transaction. `Create` and `CreateAndDecr`
+run as one Lua script, so a conflicting key writes nothing and the processing counter must exist,
+as on etcd. A status heartbeat that carries an unchanged value only refreshes the key's TTL, and
+TTL refreshes are not watch events, so streams see status changes rather than heartbeats. Tests
+run against an embedded miniredis.
 
 Note that even with `store: redis`, the built-in cpumem resource plugin still uses the etcd
 config for its own bookkeeping — see [Resource plugins](resource-plugins.md).

--- a/store/common/keys.go
+++ b/store/common/keys.go
@@ -3,12 +3,16 @@ package common
 import (
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/projecteru2/core/types"
 	"github.com/projecteru2/core/utils"
 )
 
 const (
+	// OrphanStatusTTL bounds a status reported before core recorded its entity, on every backend.
+	OrphanStatusTTL = int64(time.Hour / time.Second)
+
 	PodInfoKey       = "/pod/info/%s" // /pod/info/{podname}
 	ServiceStatusKey = "/services/%s" // /service/{ipv4:port}
 

--- a/store/redis/rediaron.go
+++ b/store/redis/rediaron.go
@@ -7,7 +7,6 @@ import (
 	"maps"
 	"slices"
 	"strings"
-	"time"
 
 	"github.com/cockroachdb/errors"
 	"github.com/panjf2000/ants/v2"
@@ -28,7 +27,6 @@ const (
 
 	replyExists  = "exists"
 	replyMissing = "missing"
-	replyChanged = "changed"
 
 	scanCount = 1000
 )
@@ -47,11 +45,19 @@ end
 if KEYS[1] ~= "" then redis.call("decr", KEYS[1]) end
 for i = 2, #KEYS do redis.call("set", KEYS[i], ARGV[i-1]) end
 return "ok"`)
-	refreshStatusScript = redis.NewScript(`
-if redis.call("exists", KEYS[1]) == 0 then return "missing" end
-if redis.call("get", KEYS[2]) ~= ARGV[1] then return "changed" end
-if tonumber(ARGV[2]) > 0 then redis.call("expire", KEYS[2], ARGV[2]) else redis.call("persist", KEYS[2]) end
-return "refreshed"`)
+	bindStatusScript = redis.NewScript(`
+local ttl = tonumber(ARGV[2])
+if redis.call("exists", KEYS[1]) == 0 then
+    if ttl > 0 then return "missing" end
+    redis.call("set", KEYS[2], ARGV[1], "EX", ARGV[3])
+    return "orphaned"
+end
+if redis.call("get", KEYS[2]) == ARGV[1] then
+    if ttl > 0 then redis.call("expire", KEYS[2], ARGV[2]) else redis.call("persist", KEYS[2]) end
+    return "refreshed"
+end
+if ttl > 0 then redis.call("set", KEYS[2], ARGV[1], "EX", ARGV[2]) else redis.call("set", KEYS[2], ARGV[1]) end
+return "written"`)
 
 	globMeta = strings.NewReplacer(`\`, `\\`, "*", `\*`, "?", `\?`, "[", `\[`, "]", `\]`)
 )
@@ -144,7 +150,7 @@ func (r *Rediaron) GetOne(ctx context.Context, key string) (string, error) {
 }
 
 func (r *Rediaron) GetPrefix(ctx context.Context, prefix string, limit int64) (map[string]string, error) {
-	keys, err := r.scanKeys(ctx, globPrefix(prefix), limit)
+	keys, err := r.scanKeys(ctx, prefix, limit)
 	if err != nil {
 		return nil, err
 	}
@@ -152,7 +158,7 @@ func (r *Rediaron) GetPrefix(ctx context.Context, prefix string, limit int64) (m
 }
 
 func (r *Rediaron) ListPrefix(ctx context.Context, prefix string) ([]string, error) {
-	return r.scanKeys(ctx, globPrefix(prefix), 0)
+	return r.scanKeys(ctx, prefix, 0)
 }
 
 func (r *Rediaron) NotFound(err error) bool {
@@ -243,15 +249,13 @@ func (r *Rediaron) Delete(ctx context.Context, keys []string) error {
 }
 
 func (r *Rediaron) BindStatus(ctx context.Context, entityKey, statusKey, statusValue string, ttl int64) error {
-	refreshed, err := refreshStatusScript.Run(ctx, r.cli, []string{entityKey, statusKey}, statusValue, ttl).Text()
-	switch {
-	case err != nil:
+	bound, err := bindStatusScript.Run(ctx, r.cli, []string{entityKey, statusKey}, statusValue, ttl, common.OrphanStatusTTL).Text()
+	if err != nil {
 		return err
-	// mirrors etcd: a missing entity key is an error
-	case refreshed == replyMissing:
+	}
+	// mirrors etcd: a missing entity key is an error for a status that carries a ttl
+	if bound == replyMissing {
 		return types.ErrInvaildCount
-	case refreshed == replyChanged:
-		return r.cli.Set(ctx, statusKey, statusValue, time.Duration(ttl)*time.Second).Err()
 	}
 	return nil
 }

--- a/store/redis/rediaron.go
+++ b/store/redis/rediaron.go
@@ -276,6 +276,10 @@ func (r *Rediaron) create(ctx context.Context, data map[string]string, decrKey s
 	return nil
 }
 
+func globPrefix(prefix string) string {
+	return globMeta.Replace(prefix) + "*"
+}
+
 // go-redis does not export proto.Error, so the message is the only signal.
 func isRedisNoKeyError(e error) bool {
 	return e != nil && strings.Contains(e.Error(), "redis: nil")

--- a/store/redis/rediaron.go
+++ b/store/redis/rediaron.go
@@ -22,17 +22,32 @@ import (
 const (
 	keyNotifyPrefix = "__keyspace@%d__:%s"
 
-	actionExpire  = "expire"
 	actionExpired = "expired"
 	actionSet     = "set"
 	actionDel     = "del"
+
+	createdExists  = "exists"
+	createdMissing = "missing"
+
+	scanCount = 1000
 )
 
 var (
-	// ErrAlreadyExists indicates SETNX found the key already set.
+	// ErrAlreadyExists indicates a create found one of its keys already set.
 	ErrAlreadyExists = errors.New("key already exists")
 	// ErrKeyNotExists indicates an update targeted a missing key, as the etcd store reports it.
 	ErrKeyNotExists = errors.New("key not exists")
+
+	createScript = redis.NewScript(`
+if KEYS[1] ~= "" and redis.call("exists", KEYS[1]) == 0 then return "missing" end
+for i = 2, #KEYS do
+    if redis.call("exists", KEYS[i]) == 1 then return "exists" end
+end
+if KEYS[1] ~= "" then redis.call("decr", KEYS[1]) end
+for i = 2, #KEYS do redis.call("set", KEYS[i], ARGV[i-1]) end
+return "ok"`)
+
+	globMeta = strings.NewReplacer(`\`, `\\`, "*", `\*`, "?", `\?`, "[", `\[`, "]", `\]`)
 )
 
 // Rediaron is a store implemented by redis
@@ -123,7 +138,7 @@ func (r *Rediaron) GetOne(ctx context.Context, key string) (string, error) {
 }
 
 func (r *Rediaron) GetPrefix(ctx context.Context, prefix string, limit int64) (map[string]string, error) {
-	keys, err := r.scanKeys(ctx, prefix+"*", limit)
+	keys, err := r.scanKeys(ctx, globPrefix(prefix), limit)
 	if err != nil {
 		return nil, err
 	}
@@ -131,7 +146,7 @@ func (r *Rediaron) GetPrefix(ctx context.Context, prefix string, limit int64) (m
 }
 
 func (r *Rediaron) ListPrefix(ctx context.Context, prefix string) ([]string, error) {
-	return r.scanKeys(ctx, prefix+"*", 0)
+	return r.scanKeys(ctx, globPrefix(prefix), 0)
 }
 
 func (r *Rediaron) NotFound(err error) bool {
@@ -139,17 +154,19 @@ func (r *Rediaron) NotFound(err error) bool {
 }
 
 func (r *Rediaron) Watch(ctx context.Context, prefix string) iter.Seq[common.Event] {
-	messages := r.KNotify(ctx, prefix+"*")
+	messages := r.KNotify(ctx, globPrefix(prefix))
 	return func(yield func(common.Event) bool) {
 		for message := range messages {
 			event := common.Event{Key: message.Key}
 			switch message.Action {
-			case actionSet, actionExpire:
+			case actionSet:
 				event.Type = common.EventPut
 			case actionDel:
 				event.Type = common.EventDelete
 			case actionExpired:
 				event.Type = common.EventExpire
+			default:
+				continue
 			}
 			if !yield(event) {
 				return
@@ -193,24 +210,7 @@ func (r *Rediaron) Update(ctx context.Context, data map[string]string) error {
 }
 
 func (r *Rediaron) Create(ctx context.Context, data map[string]string) error {
-	create := func(pipe redis.Pipeliner) error {
-		for key, value := range data {
-			pipe.SetNX(ctx, key, value, 0)
-		}
-		return nil
-	}
-
-	cmds, err := r.cli.TxPipelined(ctx, create)
-	if err != nil {
-		return err
-	}
-
-	for _, cmd := range cmds {
-		if created, _ := cmd.(*redis.BoolCmd).Result(); !created {
-			return ErrAlreadyExists
-		}
-	}
-	return nil
+	return r.create(ctx, data, "")
 }
 
 func (r *Rediaron) Put(ctx context.Context, data map[string]string) error {
@@ -225,16 +225,8 @@ func (r *Rediaron) Put(ctx context.Context, data map[string]string) error {
 	return err
 }
 
-func (r *Rediaron) CreateAndDecr(ctx context.Context, data map[string]string, decrKey string) (err error) {
-	batchCreateAndDecr := func(pipe redis.Pipeliner) error {
-		pipe.Decr(ctx, decrKey)
-		for key, value := range data {
-			pipe.SetNX(ctx, key, value, 0)
-		}
-		return nil
-	}
-	_, err = r.cli.TxPipelined(ctx, batchCreateAndDecr)
-	return err
+func (r *Rediaron) CreateAndDecr(ctx context.Context, data map[string]string, decrKey string) error {
+	return r.create(ctx, data, decrKey)
 }
 
 func (r *Rediaron) Delete(ctx context.Context, keys []string) error {
@@ -245,17 +237,50 @@ func (r *Rediaron) Delete(ctx context.Context, keys []string) error {
 }
 
 func (r *Rediaron) BindStatus(ctx context.Context, entityKey, statusKey, statusValue string, ttl int64) error {
-	count, err := r.cli.Exists(ctx, entityKey).Result()
-	if err != nil {
+	var entity *redis.IntCmd
+	var current *redis.StringCmd
+	_, err := r.cli.Pipelined(ctx, func(pipe redis.Pipeliner) error {
+		entity = pipe.Exists(ctx, entityKey)
+		current = pipe.Get(ctx, statusKey)
+		return nil
+	})
+	if err != nil && !isRedisNoKeyError(err) {
 		return err
 	}
 	// mirrors etcd: a missing entity key is an error
-	if count != 1 {
+	if entity.Val() != 1 {
 		return types.ErrInvaildCount
 	}
 
-	_, err = r.cli.Set(ctx, statusKey, statusValue, time.Duration(ttl)*time.Second).Result()
-	return err
+	expiry := time.Duration(ttl) * time.Second
+	switch {
+	case current.Err() != nil || current.Val() != statusValue:
+		return r.cli.Set(ctx, statusKey, statusValue, expiry).Err()
+	case ttl > 0:
+		return r.cli.Expire(ctx, statusKey, expiry).Err()
+	default:
+		return r.cli.Persist(ctx, statusKey).Err()
+	}
+}
+
+func (r *Rediaron) create(ctx context.Context, data map[string]string, decrKey string) error {
+	keys := []string{decrKey}
+	values := make([]any, 0, len(data))
+	for _, key := range slices.Sorted(maps.Keys(data)) {
+		keys = append(keys, key)
+		values = append(values, data[key])
+	}
+	created, err := createScript.Run(ctx, r.cli, keys, values...).Text()
+	if err != nil {
+		return err
+	}
+	switch created {
+	case createdExists:
+		return ErrAlreadyExists
+	case createdMissing:
+		return errors.Wrap(ErrKeyNotExists, decrKey)
+	}
+	return nil
 }
 
 // go-redis does not export proto.Error, so the message is the only signal.

--- a/store/redis/rediaron.go
+++ b/store/redis/rediaron.go
@@ -34,8 +34,6 @@ const (
 var (
 	// ErrAlreadyExists indicates a create found one of its keys already set.
 	ErrAlreadyExists = errors.New("key already exists")
-	// ErrKeyNotExists indicates an update targeted a missing key, as the etcd store reports it.
-	ErrKeyNotExists = errors.New("key not exists")
 
 	createScript = redis.NewScript(`
 if KEYS[1] ~= "" and redis.call("exists", KEYS[1]) == 0 then return "missing" end
@@ -215,7 +213,7 @@ func (r *Rediaron) Update(ctx context.Context, data map[string]string) error {
 		return err
 	}
 	if int(e) != len(keys) {
-		return ErrKeyNotExists
+		return types.ErrKeyNotExists
 	}
 
 	return r.Put(ctx, data)
@@ -275,7 +273,7 @@ func (r *Rediaron) create(ctx context.Context, data map[string]string, decrKey s
 	case replyExists:
 		return ErrAlreadyExists
 	case replyMissing:
-		return errors.Wrap(ErrKeyNotExists, decrKey)
+		return errors.Wrap(types.ErrKeyNotExists, decrKey)
 	}
 	return nil
 }

--- a/store/redis/rediaron.go
+++ b/store/redis/rediaron.go
@@ -26,8 +26,9 @@ const (
 	actionSet     = "set"
 	actionDel     = "del"
 
-	createdExists  = "exists"
-	createdMissing = "missing"
+	replyExists  = "exists"
+	replyMissing = "missing"
+	replyChanged = "changed"
 
 	scanCount = 1000
 )
@@ -46,6 +47,11 @@ end
 if KEYS[1] ~= "" then redis.call("decr", KEYS[1]) end
 for i = 2, #KEYS do redis.call("set", KEYS[i], ARGV[i-1]) end
 return "ok"`)
+	refreshStatusScript = redis.NewScript(`
+if redis.call("exists", KEYS[1]) == 0 then return "missing" end
+if redis.call("get", KEYS[2]) ~= ARGV[1] then return "changed" end
+if tonumber(ARGV[2]) > 0 then redis.call("expire", KEYS[2], ARGV[2]) else redis.call("persist", KEYS[2]) end
+return "refreshed"`)
 
 	globMeta = strings.NewReplacer(`\`, `\\`, "*", `\*`, "?", `\?`, "[", `\[`, "]", `\]`)
 )
@@ -237,30 +243,17 @@ func (r *Rediaron) Delete(ctx context.Context, keys []string) error {
 }
 
 func (r *Rediaron) BindStatus(ctx context.Context, entityKey, statusKey, statusValue string, ttl int64) error {
-	var entity *redis.IntCmd
-	var current *redis.StringCmd
-	_, err := r.cli.Pipelined(ctx, func(pipe redis.Pipeliner) error {
-		entity = pipe.Exists(ctx, entityKey)
-		current = pipe.Get(ctx, statusKey)
-		return nil
-	})
-	if err != nil && !isRedisNoKeyError(err) {
-		return err
-	}
-	// mirrors etcd: a missing entity key is an error
-	if entity.Val() != 1 {
-		return types.ErrInvaildCount
-	}
-
-	expiry := time.Duration(ttl) * time.Second
+	refreshed, err := refreshStatusScript.Run(ctx, r.cli, []string{entityKey, statusKey}, statusValue, ttl).Text()
 	switch {
-	case current.Err() != nil || current.Val() != statusValue:
-		return r.cli.Set(ctx, statusKey, statusValue, expiry).Err()
-	case ttl > 0:
-		return r.cli.Expire(ctx, statusKey, expiry).Err()
-	default:
-		return r.cli.Persist(ctx, statusKey).Err()
+	case err != nil:
+		return err
+	// mirrors etcd: a missing entity key is an error
+	case refreshed == replyMissing:
+		return types.ErrInvaildCount
+	case refreshed == replyChanged:
+		return r.cli.Set(ctx, statusKey, statusValue, time.Duration(ttl)*time.Second).Err()
 	}
+	return nil
 }
 
 func (r *Rediaron) create(ctx context.Context, data map[string]string, decrKey string) error {
@@ -275,9 +268,9 @@ func (r *Rediaron) create(ctx context.Context, data map[string]string, decrKey s
 		return err
 	}
 	switch created {
-	case createdExists:
+	case replyExists:
 		return ErrAlreadyExists
-	case createdMissing:
+	case replyMissing:
 		return errors.Wrap(ErrKeyNotExists, decrKey)
 	}
 	return nil

--- a/store/redis/rediaron_test.go
+++ b/store/redis/rediaron_test.go
@@ -179,6 +179,12 @@ func (s *RediaronTestSuite) TestBindStatusRefreshesAnUnchangedValueInPlace() {
 	s.NoError(s.rediaron.BindStatus(ctx, "entity", "status", "v2", 0))
 	s.Zero(s.rediserver.TTL("status"))
 	s.ErrorIs(s.rediaron.BindStatus(ctx, "absent", "status", "v2", 0), types.ErrInvaildCount)
+
+	s.NoError(s.rediaron.BindStatus(ctx, "entity", "status", "v2", 10))
+	s.rediserver.FastForward(11 * time.Second)
+	s.False(s.rediserver.Exists("status"))
+	s.NoError(s.rediaron.BindStatus(ctx, "entity", "status", "v2", 10))
+	s.Equal(10*time.Second, s.rediserver.TTL("status"))
 }
 
 func (s *RediaronTestSuite) TestPrefixReadsTakeGlobMetacharactersLiterally() {

--- a/store/redis/rediaron_test.go
+++ b/store/redis/rediaron_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/projecteru2/core/engine/factory"
+	"github.com/projecteru2/core/store/common"
 	"github.com/projecteru2/core/types"
 	"github.com/projecteru2/core/utils"
 )
@@ -133,6 +134,89 @@ func (s *RediaronTestSuite) TestKeyNotifyCancellationUnblocksPendingMessage() {
 	case <-time.After(time.Second):
 		s.FailNow("key notification did not stop")
 	}
+}
+
+func (s *RediaronTestSuite) TestCreateWritesNothingOnAConflict() {
+	ctx := s.T().Context()
+	s.NoError(s.rediaron.cli.Set(ctx, "b", "old", 0).Err())
+
+	s.ErrorIs(s.rediaron.Create(ctx, map[string]string{"a": "1", "b": "2"}), ErrAlreadyExists)
+	s.False(s.rediserver.Exists("a"))
+	value, _ := s.rediserver.Get("b")
+	s.Equal("old", value)
+}
+
+func (s *RediaronTestSuite) TestCreateAndDecrNeedsTheCounter() {
+	ctx := s.T().Context()
+	s.ErrorIs(s.rediaron.CreateAndDecr(ctx, map[string]string{"a": "1"}, "counter"), ErrKeyNotExists)
+	s.False(s.rediserver.Exists("a"))
+
+	s.NoError(s.rediaron.cli.Set(ctx, "counter", "2", 0).Err())
+	s.NoError(s.rediaron.CreateAndDecr(ctx, map[string]string{"a": "1"}, "counter"))
+	counter, _ := s.rediserver.Get("counter")
+	s.Equal("1", counter)
+
+	s.ErrorIs(s.rediaron.CreateAndDecr(ctx, map[string]string{"a": "1", "c": "3"}, "counter"), ErrAlreadyExists)
+	counter, _ = s.rediserver.Get("counter")
+	s.Equal("1", counter)
+	s.False(s.rediserver.Exists("c"))
+}
+
+func (s *RediaronTestSuite) TestBindStatusRefreshesAnUnchangedValueInPlace() {
+	ctx := s.T().Context()
+	s.NoError(s.rediaron.cli.Set(ctx, "entity", "1", 0).Err())
+
+	s.NoError(s.rediaron.BindStatus(ctx, "entity", "status", "v1", 10))
+	s.Equal(10*time.Second, s.rediserver.TTL("status"))
+	s.rediserver.FastForward(4 * time.Second)
+	s.NoError(s.rediaron.BindStatus(ctx, "entity", "status", "v1", 10))
+	s.Equal(10*time.Second, s.rediserver.TTL("status"))
+
+	s.NoError(s.rediaron.BindStatus(ctx, "entity", "status", "v2", 10))
+	value, _ := s.rediserver.Get("status")
+	s.Equal("v2", value)
+
+	s.NoError(s.rediaron.BindStatus(ctx, "entity", "status", "v2", 0))
+	s.Zero(s.rediserver.TTL("status"))
+	s.ErrorIs(s.rediaron.BindStatus(ctx, "absent", "status", "v2", 0), types.ErrInvaildCount)
+}
+
+func (s *RediaronTestSuite) TestPrefixReadsTakeGlobMetacharactersLiterally() {
+	ctx := s.T().Context()
+	s.NoError(s.rediaron.cli.MSet(ctx, "node/web-[01]/x", "1", "node/web-0/x", "2", "node/web-1/x", "3").Err())
+
+	keys, err := s.rediaron.ListPrefix(ctx, "node/web-[01]/")
+	s.NoError(err)
+	s.Equal([]string{"node/web-[01]/x"}, keys)
+
+	data, err := s.rediaron.GetPrefix(ctx, "node/web-", 0)
+	s.NoError(err)
+	s.Len(data, 3)
+}
+
+func (s *RediaronTestSuite) TestWatchSkipsTTLRefreshes() {
+	ctx, cancel := context.WithCancel(s.T().Context())
+	events := []common.Event{}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for event := range s.rediaron.Watch(ctx, "a") {
+			events = append(events, event)
+		}
+	}()
+	s.Require().Eventually(func() bool {
+		count, err := s.rediaron.cli.PubSubNumPat(s.T().Context()).Result()
+		return err == nil && count > 0
+	}, time.Second, 10*time.Millisecond)
+
+	triggerMockedKeyspaceNotification(s.rediaron.cli, "aaa", "expire")
+	triggerMockedKeyspaceNotification(s.rediaron.cli, "aab", actionSet)
+	triggerMockedKeyspaceNotification(s.rediaron.cli, "aaa", actionExpired)
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	s.Equal([]common.Event{{Key: "aab", Type: common.EventPut}, {Key: "aaa", Type: common.EventExpire}}, events)
 }
 
 func triggerMockedKeyspaceNotification(cli *redis.Client, key, action string) {

--- a/store/redis/rediaron_test.go
+++ b/store/redis/rediaron_test.go
@@ -178,7 +178,10 @@ func (s *RediaronTestSuite) TestBindStatusRefreshesAnUnchangedValueInPlace() {
 
 	s.NoError(s.rediaron.BindStatus(ctx, "entity", "status", "v2", 0))
 	s.Zero(s.rediserver.TTL("status"))
-	s.ErrorIs(s.rediaron.BindStatus(ctx, "absent", "status", "v2", 0), types.ErrInvaildCount)
+	s.ErrorIs(s.rediaron.BindStatus(ctx, "absent", "orphan", "v2", 10), types.ErrInvaildCount)
+	s.False(s.rediserver.Exists("orphan"))
+	s.NoError(s.rediaron.BindStatus(ctx, "absent", "orphan", "v2", 0))
+	s.Equal(time.Hour, s.rediserver.TTL("orphan"))
 
 	s.NoError(s.rediaron.BindStatus(ctx, "entity", "status", "v2", 10))
 	s.rediserver.FastForward(11 * time.Second)

--- a/store/redis/rediaron_test.go
+++ b/store/redis/rediaron_test.go
@@ -148,7 +148,7 @@ func (s *RediaronTestSuite) TestCreateWritesNothingOnAConflict() {
 
 func (s *RediaronTestSuite) TestCreateAndDecrNeedsTheCounter() {
 	ctx := s.T().Context()
-	s.ErrorIs(s.rediaron.CreateAndDecr(ctx, map[string]string{"a": "1"}, "counter"), ErrKeyNotExists)
+	s.ErrorIs(s.rediaron.CreateAndDecr(ctx, map[string]string{"a": "1"}, "counter"), types.ErrKeyNotExists)
 	s.False(s.rediserver.Exists("a"))
 
 	s.NoError(s.rediaron.cli.Set(ctx, "counter", "2", 0).Err())

--- a/store/redis/utils.go
+++ b/store/redis/utils.go
@@ -30,7 +30,3 @@ func (r *Rediaron) scanKeys(ctx context.Context, pattern string, limit int64) ([
 	}
 	return keys, nil
 }
-
-func globPrefix(prefix string) string {
-	return globMeta.Replace(prefix) + "*"
-}

--- a/store/redis/utils.go
+++ b/store/redis/utils.go
@@ -4,7 +4,8 @@ import (
 	"context"
 )
 
-func (r *Rediaron) scanKeys(ctx context.Context, pattern string, limit int64) ([]string, error) {
+func (r *Rediaron) scanKeys(ctx context.Context, prefix string, limit int64) ([]string, error) {
+	pattern := globPrefix(prefix)
 	var cursor uint64
 	seen := map[string]struct{}{}
 	keys := []string{}

--- a/store/redis/utils.go
+++ b/store/redis/utils.go
@@ -6,20 +6,31 @@ import (
 
 func (r *Rediaron) scanKeys(ctx context.Context, pattern string, limit int64) ([]string, error) {
 	var cursor uint64
+	seen := map[string]struct{}{}
 	keys := []string{}
 	for {
-		result, next, err := r.cli.Scan(ctx, cursor, pattern, 0).Result()
+		result, next, err := r.cli.Scan(ctx, cursor, pattern, scanCount).Result()
 		if err != nil {
 			return nil, err
 		}
 		cursor = next
-		keys = append(keys, result...)
+		for _, key := range result {
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			keys = append(keys, key)
+		}
 		if cursor == 0 || (limit > 0 && int64(len(keys)) >= limit) {
 			break
 		}
 	}
-	if limit > 0 && int64(len(keys)) >= limit {
+	if limit > 0 && int64(len(keys)) > limit {
 		keys = keys[:limit]
 	}
 	return keys, nil
+}
+
+func globPrefix(prefix string) string {
+	return globMeta.Replace(prefix) + "*"
 }


### PR DESCRIPTION
## What

- **Create / CreateAndDecr** ran SETNX pipelines that wrote the non-conflicting keys before the conflict was seen, and CreateAndDecr neither required the processing counter nor read the SETNX replies: a conflicting create was reported as success and a missing counter went negative. Both now run one Lua script that writes every key or none and refuses a missing counter, the etcd transaction's contract.
- **BindStatus** rewrote an unchanged status on every heartbeat, and every SET fanned out through the node and workload status streams as a change (one GetNode / GetWorkload per watcher per heartbeat). An unchanged value now only refreshes the TTL (or drops it for ttl 0), and TTL refreshes are no longer watch events, matching etcd where a lease keepalive makes no revision. The entity check and the status read share one pipeline round trip.
- **Prefix reads** scanned the whole keyspace ten keys at a time with a pattern that took node, pod and app names as globs. SCAN takes COUNT 1000, the prefix is escaped, and the duplicates SCAN may return are dropped so deploy counts stay exact.

## Tests

`TestCreateWritesNothingOnAConflict`, `TestCreateAndDecrNeedsTheCounter`, `TestBindStatusRefreshesAnUnchangedValueInPlace`, `TestPrefixReadsTakeGlobMetacharactersLiterally`, `TestWatchSkipsTTLRefreshes` in `store/redis`, against miniredis.

## Gates

`GOWORK=off go build ./...`, `go vet`, `go test -count=1 -race ./store/...`, full `go test -count=1 ./...` (all packages ok), `make lint fmt-check` on GOOS=linux and darwin (0 issues each), `asl ./...` both GOOS (no findings).
