### PR TITLE
feat: plugin protocol round: verbs handshake, batched get-metrics, split streams

### DIFF
--- a/cluster/calcium/metrics.go
+++ b/cluster/calcium/metrics.go
@@ -26,7 +26,7 @@ func (c *Calcium) InitMetrics(ctx context.Context) {
 }
 
 func (c *Calcium) doSendNodeMetrics(ctx context.Context, node *types.Node) {
-	nodeMetrics, err := c.rmgr.GetNodeMetrics(ctx, node)
+	nodeMetrics, err := c.rmgr.GetNodesMetrics(ctx, []*types.Node{node})
 	if err != nil {
 		log.WithFunc("calcium.doSendNodeMetrics").Errorf(ctx, err, "convert node %s resource info to metrics failed", node.Name)
 		return

--- a/cluster/calcium/metrics_test.go
+++ b/cluster/calcium/metrics_test.go
@@ -1,0 +1,20 @@
+package calcium
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+
+	resourcemocks "github.com/projecteru2/core/resource/mocks"
+	plugintypes "github.com/projecteru2/core/resource/plugins/types"
+	"github.com/projecteru2/core/types"
+)
+
+func TestSendNodeMetricsSurvivesUninitializedMetrics(t *testing.T) {
+	c := NewTestCluster()
+	rmgr := c.rmgr.(*resourcemocks.Manager)
+	rmgr.On("GetNodesMetrics", mock.Anything, mock.Anything).Return([]*plugintypes.Metrics{{Name: "cpu_used"}}, nil).Once()
+
+	c.doSendNodeMetrics(t.Context(), &types.Node{NodeMeta: types.NodeMeta{Name: "n1"}})
+	rmgr.AssertExpectations(t)
+}

--- a/cluster/calcium/node_test.go
+++ b/cluster/calcium/node_test.go
@@ -14,7 +14,6 @@ import (
 	enginetypes "github.com/projecteru2/core/engine/types"
 	lockmocks "github.com/projecteru2/core/lock/mocks"
 	resourcemocks "github.com/projecteru2/core/resource/mocks"
-	plugintypes "github.com/projecteru2/core/resource/plugins/types"
 	resourcetypes "github.com/projecteru2/core/resource/types"
 	storemocks "github.com/projecteru2/core/store/mocks"
 	"github.com/projecteru2/core/types"
@@ -59,7 +58,6 @@ func TestAddNode(t *testing.T) {
 		},
 	}
 	store.On("AddNode", mock.Anything, mock.Anything).Return(node, nil)
-	rmgr.On("GetNodeMetrics", mock.Anything, mock.Anything).Return([]*plugintypes.Metrics{}, nil)
 	n, err := c.AddNode(ctx, opts)
 	assert.NoError(t, err)
 	assert.Equal(t, n.Name, name)
@@ -81,7 +79,6 @@ func TestAddNodeRedoesTheStalePluginMetadata(t *testing.T) {
 	rmgr.On("AddNode", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, types.ErrNodeExists).Once()
 	rmgr.On("RemoveNode", mock.Anything, nodename).Return(nil).Once()
 	rmgr.On("AddNode", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(resourcetypes.Resources{}, nil).Once()
-	rmgr.On("GetNodeMetrics", mock.Anything, mock.Anything).Return([]*plugintypes.Metrics{}, nil).Maybe()
 
 	store := c.store.(*storemocks.Store)
 	store.On("GetNode", mock.Anything, nodename).Return(nil, types.ErrMockError).Once()
@@ -279,7 +276,6 @@ func TestSetNode(t *testing.T) {
 	_, err = c.SetNode(ctx, opts)
 	assert.Error(t, err)
 	store.On("UpdateNodes", mock.Anything, mock.Anything).Return(nil)
-	rmgr.On("GetNodeMetrics", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]*plugintypes.Metrics{}, nil)
 
 	node, err = c.SetNode(ctx, opts)
 	assert.NoError(t, err)

--- a/cluster/calcium/realloc_test.go
+++ b/cluster/calcium/realloc_test.go
@@ -12,7 +12,6 @@ import (
 	enginetypes "github.com/projecteru2/core/engine/types"
 	lockmocks "github.com/projecteru2/core/lock/mocks"
 	resourcemocks "github.com/projecteru2/core/resource/mocks"
-	plugintypes "github.com/projecteru2/core/resource/plugins/types"
 	resourcetypes "github.com/projecteru2/core/resource/types"
 	storemocks "github.com/projecteru2/core/store/mocks"
 	"github.com/projecteru2/core/types"
@@ -26,7 +25,6 @@ func TestRealloc(t *testing.T) {
 	store := c.store.(*storemocks.Store)
 	rmgr := c.rmgr.(*resourcemocks.Manager)
 	rmgr.On("GetNodeResourceInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil, nil, nil)
-	rmgr.On("GetNodeMetrics", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]*plugintypes.Metrics{}, nil)
 	c.config.Scheduler.ShareBase = 100
 
 	lock := &lockmocks.DistributedLock{}

--- a/cluster/calcium/remove_test.go
+++ b/cluster/calcium/remove_test.go
@@ -12,7 +12,6 @@ import (
 	enginemocks "github.com/projecteru2/core/engine/mocks"
 	lockmocks "github.com/projecteru2/core/lock/mocks"
 	resourcemocks "github.com/projecteru2/core/resource/mocks"
-	plugintypes "github.com/projecteru2/core/resource/plugins/types"
 	resourcetypes "github.com/projecteru2/core/resource/types"
 	storemocks "github.com/projecteru2/core/store/mocks"
 	"github.com/projecteru2/core/types"
@@ -34,7 +33,6 @@ func TestRemoveWorkload(t *testing.T) {
 		resourcetypes.Resources{},
 		nil,
 	)
-	rmgr.On("GetNodeMetrics", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]*plugintypes.Metrics{}, nil)
 
 	store.On("GetWorkloads", mock.Anything, mock.Anything).Return(nil, types.ErrMockError).Once()
 	ch, err := c.RemoveWorkload(ctx, []string{"xx"}, false)

--- a/cluster/calcium/wal_test.go
+++ b/cluster/calcium/wal_test.go
@@ -16,7 +16,6 @@ import (
 	enginetypes "github.com/projecteru2/core/engine/types"
 	lockmocks "github.com/projecteru2/core/lock/mocks"
 	resourcemocks "github.com/projecteru2/core/resource/mocks"
-	plugintypes "github.com/projecteru2/core/resource/plugins/types"
 	resourcetypes "github.com/projecteru2/core/resource/types"
 	storemocks "github.com/projecteru2/core/store/mocks"
 	"github.com/projecteru2/core/types"
@@ -341,7 +340,6 @@ func TestHandleCreateLambda(t *testing.T) {
 		resourcetypes.Resources{},
 		nil,
 	)
-	rmgr.On("GetNodeMetrics", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]*plugintypes.Metrics{}, nil)
 	rmgr.On("Remap", mock.Anything, mock.Anything, mock.Anything).Return(
 		resourcetypes.Resources{},
 		nil,

--- a/core.go
+++ b/core.go
@@ -96,7 +96,7 @@ func serve(ctx context.Context, _ *cli.Command) error {
 	})
 
 	if config.Profile != "" {
-		http.Handle("/metrics", metrics.Client.ResourceMiddleware(cluster)(promhttp.Handler()))
+		http.Handle("/metrics", metrics.Client.ResourceMiddleware(ctx, cluster)(promhttp.Handler()))
 		utils.SentryGo(func() {
 			server := &http.Server{
 				Addr:              config.Profile,

--- a/docs/resource-plugins.md
+++ b/docs/resource-plugins.md
@@ -91,14 +91,19 @@ The contract is a subcommand plus JSON:
 ```
 
 - The request is one JSON object on stdin.
-- The response is one JSON object on stdout. Core reads combined output, so anything written to
-  stderr becomes part of what it tries to parse — keep it quiet on success.
-- Empty output is accepted and leaves the response zero-valued.
+- The response is one JSON object on stdout. stderr is the plugin's log: core logs it at debug on
+  success and with the error on failure.
+- Empty stdout is an error. A verb with nothing to report writes its empty response: `{}` for an
+  object, `[]` for `get-metrics-description` and `get-metrics`.
+- Core runs `verbs` once at load, and the plugin answers with the JSON array of the verbs it
+  implements. A verb outside that list never spawns the plugin, and the plugin takes no part in
+  that call.
 - The working directory is `resource_plugin.dir`.
 - Each invocation is killed after `resource_plugin.call_timeout`.
 
 | Subcommand | Method |
 | --- | --- |
+| `verbs` | — |
 | `calculate-deploy` | `CalculateDeploy` |
 | `calculate-realloc` | `CalculateRealloc` |
 | `calculate-remap` | `CalculateRemap` |
@@ -117,6 +122,8 @@ The contract is a subcommand plus JSON:
 Response shapes are the JSON encodings of the types in `resource/plugins/types/`, e.g.
 `calculate-deploy` returns `{"engines_params": [...], "workloads_resource": [...]}` and
 `get-nodes-deploy-capacity` returns `{"nodes_deploy_capacity_map": {...}, "total": n}`.
+`get-metrics` takes every node in one call, `{"nodes": [{"podname": ..., "nodename": ...}, ...]}`,
+and returns the metrics of all of them.
 
 [resource-extend](https://github.com/projecteru2/resource-extend) implements gpu and storage
 plugins this way.

--- a/metrics/handler.go
+++ b/metrics/handler.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"net/http"
 
+<<<<<<< HEAD
 	"golang.org/x/sync/errgroup"
+=======
+>>>>>>> 5350685c
 	"golang.org/x/sync/singleflight"
 
 	"github.com/projecteru2/core/cluster"
@@ -12,15 +15,21 @@ import (
 	"github.com/projecteru2/core/types"
 )
 
+<<<<<<< HEAD
 const scrapeFanout = 8
 
 // ResourceMiddleware refreshes node metrics before the wrapped handler runs; overlapping scrapes share one refresh, which outlives the scrape that started it.
 func (m *Metrics) ResourceMiddleware(cluster cluster.Cluster) func(http.Handler) http.Handler {
+=======
+// ResourceMiddleware refreshes node metrics before the wrapped handler runs; overlapping scrapes share one refresh, which runs under the server's context.
+func (m *Metrics) ResourceMiddleware(ctx context.Context, cluster cluster.Cluster) func(http.Handler) http.Handler {
+>>>>>>> 5350685c
 	logger := log.WithFunc("metrics.ResourceMiddleware")
 	var scrapes singleflight.Group
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			refreshed := scrapes.DoChan("refresh", func() (any, error) {
+<<<<<<< HEAD
 				ctx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), m.Config.GlobalTimeout)
 				defer cancel()
 				nodes, err := cluster.ListPodNodes(ctx, &types.ListNodesOptions{All: true})
@@ -38,6 +47,22 @@ func (m *Metrics) ResourceMiddleware(cluster cluster.Cluster) func(http.Handler)
 					})
 				}
 				return nil, g.Wait()
+=======
+				refreshCtx, cancel := context.WithTimeout(ctx, m.Config.GlobalTimeout)
+				defer cancel()
+				nodeCh, err := cluster.ListPodNodes(refreshCtx, &types.ListNodesOptions{All: true})
+				if err != nil {
+					logger.Error(refreshCtx, err, "failed to list nodes")
+					return nil, err
+				}
+				var nodes []*types.Node
+				for node := range nodeCh {
+					m.SendPodNodeStatus(refreshCtx, node)
+					nodes = append(nodes, node)
+				}
+				m.SendNodesMetrics(refreshCtx, nodes...)
+				return nil, nil
+>>>>>>> 5350685c
 			})
 			select {
 			case <-refreshed:

--- a/metrics/handler_test.go
+++ b/metrics/handler_test.go
@@ -18,11 +18,33 @@ import (
 	"github.com/projecteru2/core/types"
 )
 
+<<<<<<< HEAD
 func TestResourceMiddlewareRefreshesNodesConcurrently(t *testing.T) {
+=======
+func TestResourceMiddlewareRefreshesEveryNodeInOneCall(t *testing.T) {
+	cluster := &clustermocks.Cluster{}
+	cluster.On("ListPodNodes", mock.Anything, mock.Anything).Return(twoNodes(), nil).Once()
+	rmgr := &resourcemocks.Manager{}
+	rmgr.On("GetNodesMetrics", mock.Anything, mock.MatchedBy(func(nodes []*types.Node) bool { return len(nodes) == 2 })).Return(nil, nil).Once()
+
+	m := &Metrics{Config: types.Config{GlobalTimeout: time.Second}, rmgr: rmgr}
+	served := false
+	handler := m.ResourceMiddleware(t.Context(), cluster)(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		served = true
+	}))
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/metrics", nil))
+
+	assert.True(t, served)
+	rmgr.AssertExpectations(t)
+}
+
+func TestResourceMiddlewareSharesOneRefreshBetweenOverlappingScrapes(t *testing.T) {
+>>>>>>> 5350685c
 	synctest.Test(t, func(t *testing.T) {
 		cluster := &clustermocks.Cluster{}
 		cluster.On("ListPodNodes", mock.Anything, mock.Anything).Return(twoNodes(), nil).Once()
 		rmgr := &resourcemocks.Manager{}
+<<<<<<< HEAD
 		firstStarted := make(chan struct{})
 		secondStarted := make(chan struct{})
 		releaseFirst := make(chan struct{})
@@ -34,16 +56,54 @@ func TestResourceMiddlewareRefreshesNodesConcurrently(t *testing.T) {
 			}
 			close(secondStarted)
 		}).Return(nil, nil).Twice()
+=======
+		release := make(chan struct{})
+		rmgr.On("GetNodesMetrics", mock.Anything, mock.Anything).Run(func(mock.Arguments) { <-release }).Return(nil, nil).Once()
+>>>>>>> 5350685c
 
 		m := &Metrics{Config: types.Config{GlobalTimeout: time.Second}, rmgr: rmgr}
-		served := make(chan struct{})
-		handler := m.ResourceMiddleware(cluster)(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
-			close(served)
+		served := make(chan struct{}, 2)
+		handler := m.ResourceMiddleware(t.Context(), cluster)(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+			served <- struct{}{}
 		}))
-		go handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/metrics", nil))
-
-		<-firstStarted
+		for range 2 {
+			go handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/metrics", nil))
+		}
 		synctest.Wait()
+		close(release)
+		synctest.Wait()
+
+		assert.Len(t, served, 2)
+		cluster.AssertExpectations(t)
+		rmgr.AssertExpectations(t)
+	})
+}
+
+func TestResourceMiddlewareRefreshOutlivesTheScrapeThatStartedIt(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		cluster := &clustermocks.Cluster{}
+		cluster.On("ListPodNodes", mock.Anything, mock.Anything).Return(twoNodes(), nil).Once()
+		rmgr := &resourcemocks.Manager{}
+		release := make(chan struct{})
+		var cancelled atomic.Int32
+		rmgr.On("GetNodesMetrics", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+			<-release
+			if args.Get(0).(context.Context).Err() != nil {
+				cancelled.Add(1)
+			}
+		}).Return(nil, nil).Once()
+
+		m := &Metrics{Config: types.Config{GlobalTimeout: time.Second}, rmgr: rmgr}
+		served := make(chan struct{}, 2)
+		handler := m.ResourceMiddleware(t.Context(), cluster)(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+			served <- struct{}{}
+		}))
+		leaderCtx, leaveLeader := context.WithCancel(t.Context())
+		go handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/metrics", nil).WithContext(leaderCtx))
+		synctest.Wait()
+		go handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/metrics", nil))
+		synctest.Wait()
+<<<<<<< HEAD
 		select {
 		case <-secondStarted:
 		default:
@@ -54,14 +114,26 @@ func TestResourceMiddlewareRefreshesNodesConcurrently(t *testing.T) {
 			t.Error("scrape handler served before every node was refreshed")
 		default:
 		}
+=======
+>>>>>>> 5350685c
 
-		close(releaseFirst)
+		leaveLeader()
 		synctest.Wait()
+<<<<<<< HEAD
 		select {
 		case <-served:
 		default:
 			t.Error("scrape handler was not served")
 		}
+=======
+		assert.Empty(t, served)
+
+		close(release)
+		synctest.Wait()
+		assert.Len(t, served, 1)
+		assert.Zero(t, cancelled.Load())
+		rmgr.AssertExpectations(t)
+>>>>>>> 5350685c
 	})
 }
 
@@ -134,7 +206,7 @@ func TestResourceMiddlewareListNodesFailed(t *testing.T) {
 
 	m := &Metrics{Config: types.Config{GlobalTimeout: time.Second}}
 	served := make(chan struct{})
-	handler := m.ResourceMiddleware(cluster)(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+	handler := m.ResourceMiddleware(t.Context(), cluster)(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
 		close(served)
 	}))
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -105,11 +105,11 @@ func (m *Metrics) SendMetrics(ctx context.Context, metrics ...*plugintypes.Metri
 	}
 }
 
-// SendNodeMetrics refreshes a node's resource metrics and pushes them.
-func (m *Metrics) SendNodeMetrics(ctx context.Context, node *types.Node) {
-	nodeMetrics, err := m.rmgr.GetNodeMetrics(ctx, node)
+// SendNodesMetrics refreshes the resource metrics of the nodes in one plugin call and pushes them.
+func (m *Metrics) SendNodesMetrics(ctx context.Context, nodes ...*types.Node) {
+	nodeMetrics, err := m.rmgr.GetNodesMetrics(ctx, nodes)
 	if err != nil {
-		log.WithFunc("metrics.SendNodeMetrics").Errorf(ctx, err, "convert node %s resource info to metrics failed", node.Name)
+		log.WithFunc("metrics.SendNodesMetrics").Error(ctx, err, "convert node resource info to metrics failed")
 		return
 	}
 	m.SendMetrics(ctx, nodeMetrics...)

--- a/resource/cobalt/alloc.go
+++ b/resource/cobalt/alloc.go
@@ -26,11 +26,7 @@ func (m *Manager) Alloc(ctx context.Context, nodename string, deployCount int, o
 	return workloadsParams, engineParams, utils.PCR(ctx,
 		func(ctx context.Context) error {
 			resps, err := call(ctx, m.plugins, func(plugin plugins.Plugin) (*plugintypes.CalculateDeployResponse, error) {
-				resp, err := plugin.CalculateDeploy(ctx, nodename, deployCount, opts[plugin.Name()])
-				if err != nil {
-					logger.Errorf(ctx, err, "plugin %+v failed to compute alloc args, request %+v, node %+v, deploy count %+v", plugin.Name(), opts, nodename, deployCount)
-				}
-				return resp, err
+				return plugin.CalculateDeploy(ctx, nodename, deployCount, opts[plugin.Name()])
 			})
 			if err != nil {
 				return err

--- a/resource/cobalt/call.go
+++ b/resource/cobalt/call.go
@@ -16,9 +16,7 @@ func call[T any](ctx context.Context, ps []plugins.Plugin, f func(plugins.Plugin
 	errs := make([]error, len(ps))
 	for i, p := range ps {
 		wg.Go(func() {
-			if results[i], errs[i] = f(p); errs[i] != nil {
-				log.WithFunc("resource.cobalt.call").Errorf(ctx, errs[i], "failed to call plugin %+v", p.Name())
-			}
+			results[i], errs[i] = f(p)
 		})
 	}
 	wg.Wait()
@@ -26,7 +24,11 @@ func call[T any](ctx context.Context, ps []plugins.Plugin, f func(plugins.Plugin
 	var combinedErr error
 	ans := make(map[plugins.Plugin]T, len(ps))
 	for i, p := range ps {
+		if errors.Is(errs[i], plugins.ErrVerbNotSupported) {
+			continue
+		}
 		if errs[i] != nil {
+			log.WithFunc("resource.cobalt.call").Errorf(ctx, errs[i], "failed to call plugin %+v", p.Name())
 			combinedErr = errors.CombineErrors(combinedErr, errs[i])
 			continue
 		}

--- a/resource/cobalt/metrics.go
+++ b/resource/cobalt/metrics.go
@@ -7,6 +7,7 @@ import (
 	"github.com/projecteru2/core/resource/plugins"
 	plugintypes "github.com/projecteru2/core/resource/plugins/types"
 	"github.com/projecteru2/core/types"
+	"github.com/projecteru2/core/utils"
 )
 
 func (m *Manager) GetMetricsDescription(ctx context.Context) ([]*plugintypes.MetricsDescription, error) {
@@ -25,19 +26,20 @@ func (m *Manager) GetMetricsDescription(ctx context.Context) ([]*plugintypes.Met
 	return metricsDescriptions, nil
 }
 
-func (m *Manager) GetNodeMetrics(ctx context.Context, node *types.Node) ([]*plugintypes.Metrics, error) {
-	logger := log.WithFunc("resource.cobalt.GetNodeMetrics").WithField("node", node.Name)
+func (m *Manager) GetNodesMetrics(ctx context.Context, nodes []*types.Node) ([]*plugintypes.Metrics, error) {
+	if len(nodes) == 0 {
+		return nil, nil
+	}
+	refs := utils.Map(nodes, func(node *types.Node) plugintypes.NodeRef {
+		return plugintypes.NodeRef{Podname: node.Podname, Nodename: node.Name}
+	})
 
 	var metrics []*plugintypes.Metrics
 	resps, err := call(ctx, m.plugins, func(plugin plugins.Plugin) (*plugintypes.GetMetricsResponse, error) {
-		resp, err := plugin.GetMetrics(ctx, node.Podname, node.Name)
-		if err != nil {
-			logger.Errorf(ctx, err, "plugin %+v failed to convert node resource info to metrics", plugin.Name())
-		}
-		return resp, err
+		return plugin.GetMetrics(ctx, refs)
 	})
 	if err != nil {
-		logger.Error(ctx, err, "failed to convert node resource info to metrics")
+		log.WithFunc("resource.cobalt.GetNodesMetrics").Error(ctx, err, "failed to convert node resource info to metrics")
 		return nil, err
 	}
 

--- a/resource/cobalt/metrics_test.go
+++ b/resource/cobalt/metrics_test.go
@@ -1,0 +1,28 @@
+package cobalt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/projecteru2/core/resource/plugins"
+	pluginmocks "github.com/projecteru2/core/resource/plugins/mocks"
+	plugintypes "github.com/projecteru2/core/resource/plugins/types"
+	coretypes "github.com/projecteru2/core/types"
+)
+
+func TestGetNodesMetricsLeavesOutAPluginWithoutTheVerb(t *testing.T) {
+	m := New(coretypes.Config{})
+	cpumem := pluginmocks.NewPlugin(t)
+	cpumem.On("Name").Return("cpumem").Maybe()
+	cpumem.On("GetMetrics", mock.Anything, mock.Anything).Return(&plugintypes.GetMetricsResponse{{Name: "cpu_used"}}, nil)
+	gpu := pluginmocks.NewPlugin(t)
+	gpu.On("Name").Return("gpu").Maybe()
+	gpu.On("GetMetrics", mock.Anything, mock.Anything).Return(nil, plugins.ErrVerbNotSupported)
+	m.AddPlugins(cpumem, gpu)
+
+	metrics, err := m.GetNodesMetrics(t.Context(), []*coretypes.Node{{NodeMeta: coretypes.NodeMeta{Name: "n1", Podname: "p"}}})
+	assert.NoError(t, err)
+	assert.Len(t, metrics, 1)
+}

--- a/resource/cobalt/node.go
+++ b/resource/cobalt/node.go
@@ -30,11 +30,7 @@ func (m *Manager) AddNode(ctx context.Context, nodename string, opts resourcetyp
 				r := opts[plugin.Name()]
 				// plugins run even for a nil request: they read config from engine info and seed an empty etcd entry
 				logger.WithField("plugin", plugin.Name()).Debugf(ctx, "add node request %v", litter.Sdump(r))
-				resp, err := plugin.AddNode(ctx, nodename, r, nodeInfo)
-				if err != nil {
-					logger.Errorf(ctx, err, "node %+v plugin %+v failed to add node, req: %+v", nodename, plugin.Name(), litter.Sdump(r))
-				}
-				return resp, err
+				return plugin.AddNode(ctx, nodename, r, nodeInfo)
 			})
 			if err != nil {
 				rollbackPlugins = slices.Collect(maps.Keys(resps))
@@ -47,7 +43,7 @@ func (m *Manager) AddNode(ctx context.Context, nodename string, opts resourcetyp
 			return nil
 		},
 		func(ctx context.Context) error {
-			err := rollbackNodeResource(ctx, logger, nodename, rollbackPlugins, func(plugin plugins.Plugin) (*plugintypes.RemoveNodeResponse, error) {
+			err := rollbackNodeResource(ctx, rollbackPlugins, func(plugin plugins.Plugin) (*plugintypes.RemoveNodeResponse, error) {
 				return plugin.RemoveNode(ctx, nodename)
 			})
 			if err != nil {
@@ -77,11 +73,7 @@ func (m *Manager) RemoveNode(ctx context.Context, nodename string) error {
 		},
 		func(ctx context.Context) error {
 			resps, err := call(ctx, m.plugins, func(plugin plugins.Plugin) (*plugintypes.RemoveNodeResponse, error) {
-				resp, err := plugin.RemoveNode(ctx, nodename)
-				if err != nil {
-					logger.Errorf(ctx, err, "plugin %+v failed to remove node", plugin.Name())
-				}
-				return resp, err
+				return plugin.RemoveNode(ctx, nodename)
 			})
 			if err != nil {
 				rollbackPlugins = slices.Collect(maps.Keys(resps))
@@ -91,7 +83,7 @@ func (m *Manager) RemoveNode(ctx context.Context, nodename string) error {
 			return nil
 		},
 		func(ctx context.Context) error {
-			err := rollbackNodeResource(ctx, logger, nodename, rollbackPlugins, func(plugin plugins.Plugin) (*plugintypes.SetNodeResourceInfoResponse, error) {
+			err := rollbackNodeResource(ctx, rollbackPlugins, func(plugin plugins.Plugin) (*plugintypes.SetNodeResourceInfoResponse, error) {
 				return plugin.SetNodeResourceInfo(ctx, nodename, nodeCapacity[plugin.Name()], nodeUsage[plugin.Name()])
 			})
 			if err != nil {
@@ -110,11 +102,7 @@ func (m *Manager) GetMostIdleNode(ctx context.Context, nodenames []string) (stri
 	}
 
 	resps, err := call(ctx, m.plugins, func(plugin plugins.Plugin) (*plugintypes.GetMostIdleNodeResponse, error) {
-		resp, err := plugin.GetMostIdleNode(ctx, nodenames)
-		if err != nil {
-			logger.Errorf(ctx, err, "plugin %+v failed to get the most idle node of %+v", plugin.Name(), nodenames)
-		}
-		return resp, err
+		return plugin.GetMostIdleNode(ctx, nodenames)
 	})
 	if err != nil {
 		logger.Errorf(ctx, err, "failed to get the most idle node of %+v", nodenames)
@@ -176,7 +164,7 @@ func (m *Manager) SetNodeResourceUsage(ctx context.Context, nodename string, nod
 			return err
 		},
 		func(ctx context.Context) error {
-			return rollbackNodeResource(ctx, logger, nodename, rollbackPlugins, func(plugin plugins.Plugin) (*plugintypes.SetNodeResourceUsageResponse, error) {
+			return rollbackNodeResource(ctx, rollbackPlugins, func(plugin plugins.Plugin) (*plugintypes.SetNodeResourceUsageResponse, error) {
 				return plugin.SetNodeResourceUsage(ctx, nodename, before[plugin.Name()], nil, nil, false, false)
 			})
 		},
@@ -187,15 +175,10 @@ func (m *Manager) SetNodeResourceUsage(ctx context.Context, nodename string, nod
 // GetNodesDeployCapacity returns the nodes meeting every plugin's requirements, and their total capacity.
 // the caller must hold the node locks
 func (m *Manager) GetNodesDeployCapacity(ctx context.Context, nodenames []string, opts resourcetypes.Resources) (map[string]*plugintypes.NodeDeployCapacity, int, error) {
-	logger := log.WithFunc("resource.cobalt.GetNodesDeployCapacity")
 	var resp map[string]*plugintypes.NodeDeployCapacity
 
 	resps, err := call(ctx, m.plugins, func(plugin plugins.Plugin) (*plugintypes.GetNodesDeployCapacityResponse, error) {
-		resp, err := plugin.GetNodesDeployCapacity(ctx, nodenames, opts[plugin.Name()])
-		if err != nil {
-			logger.Errorf(ctx, err, "plugin %+v failed to get available nodenames, request %+v", plugin.Name(), opts[plugin.Name()])
-		}
-		return resp, err
+		return plugin.GetNodesDeployCapacity(ctx, nodenames, opts[plugin.Name()])
 	})
 	if err != nil {
 		return nil, 0, err
@@ -234,11 +217,7 @@ func (m *Manager) SetNodeResourceCapacity(ctx context.Context, nodename string, 
 				if nodeResource[plugin.Name()] == nil && nodeResourceRequest[plugin.Name()] == nil {
 					return nil, nil
 				}
-				resp, err := plugin.SetNodeResourceCapacity(ctx, nodename, nodeResource[plugin.Name()], nodeResourceRequest[plugin.Name()], delta, incr)
-				if err != nil {
-					logger.Errorf(ctx, err, "plugin %+v failed to set node resource capacity", plugin.Name())
-				}
-				return resp, err
+				return plugin.SetNodeResourceCapacity(ctx, nodename, nodeResource[plugin.Name()], nodeResourceRequest[plugin.Name()], delta, incr)
 			})
 			for plugin, resp := range resps {
 				if resp == nil {
@@ -257,7 +236,7 @@ func (m *Manager) SetNodeResourceCapacity(ctx context.Context, nodename string, 
 			return nil
 		},
 		func(ctx context.Context) error {
-			return rollbackNodeResource(ctx, logger, nodename, rollbackPlugins, func(plugin plugins.Plugin) (*plugintypes.SetNodeResourceCapacityResponse, error) {
+			return rollbackNodeResource(ctx, rollbackPlugins, func(plugin plugins.Plugin) (*plugintypes.SetNodeResourceCapacityResponse, error) {
 				return plugin.SetNodeResourceCapacity(ctx, nodename, nil, before[plugin.Name()], false, false)
 			})
 		},
@@ -284,9 +263,6 @@ func (m *Manager) getNodeResourceInfo(ctx context.Context, nodename string, ps [
 			resp, err = plugin.FixNodeResource(ctx, nodename, wrks)
 		} else {
 			resp, err = plugin.GetNodeResourceInfo(ctx, nodename, wrks)
-		}
-		if err != nil {
-			log.WithFunc("resource.cobalt.GetNodeResourceInfo").WithField("node", nodename).Errorf(ctx, err, "plugin %+v failed to get node resource", plugin.Name())
 		}
 		return resp, err
 	})
@@ -332,13 +308,7 @@ func mergeCapacity(m1, m2 map[string]*plugintypes.NodeDeployCapacity) map[string
 }
 
 // rollbackNodeResource restores every plugin that applied a failed set of the node's resources.
-func rollbackNodeResource[T any](ctx context.Context, logger *log.Fields, nodename string, ps []plugins.Plugin, restore func(plugins.Plugin) (T, error)) error {
-	_, err := call(ctx, ps, func(plugin plugins.Plugin) (T, error) {
-		resp, err := restore(plugin)
-		if err != nil {
-			logger.Errorf(ctx, err, "node %+v plugin %+v failed to rollback", nodename, plugin.Name())
-		}
-		return resp, err
-	})
+func rollbackNodeResource[T any](ctx context.Context, ps []plugins.Plugin, restore func(plugins.Plugin) (T, error)) error {
+	_, err := call(ctx, ps, func(plugin plugins.Plugin) (T, error) { return restore(plugin) })
 	return err
 }

--- a/resource/cobalt/realloc.go
+++ b/resource/cobalt/realloc.go
@@ -20,11 +20,7 @@ func (m *Manager) Realloc(ctx context.Context, nodename string, nodeResource, op
 	return engineParams, deltaResources, workloadResource, utils.PCR(ctx,
 		func(ctx context.Context) error {
 			resps, err := call(ctx, m.plugins, func(plugin plugins.Plugin) (*plugintypes.CalculateReallocResponse, error) {
-				resp, err := plugin.CalculateRealloc(ctx, nodename, nodeResource[plugin.Name()], opts[plugin.Name()])
-				if err != nil {
-					logger.Errorf(ctx, err, "plugin %+v failed to calculate realloc args", plugin.Name())
-				}
-				return resp, err
+				return plugin.CalculateRealloc(ctx, nodename, nodeResource[plugin.Name()], opts[plugin.Name()])
 			})
 			if err != nil {
 				logger.Errorf(ctx, err, "realloc failed, origin: %+v, opts: %+v", nodeResource, opts)

--- a/resource/cobalt/remap.go
+++ b/resource/cobalt/remap.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"maps"
 
-	"github.com/projecteru2/core/log"
 	"github.com/projecteru2/core/resource/plugins"
 	plugintypes "github.com/projecteru2/core/resource/plugins/types"
 	resourcetypes "github.com/projecteru2/core/resource/types"
@@ -14,18 +13,13 @@ import (
 // Remap returns engine params per workload, format: {"workload-1": {"cpus": ["1-3"]}}.
 // remap never changes resource params
 func (m *Manager) Remap(ctx context.Context, nodename string, workloads []*types.Workload) (map[string]resourcetypes.Resources, error) {
-	logger := log.WithFunc("resource.cobalt.Remap").WithField("node", nodename)
 	resps, err := call(ctx, m.plugins, func(plugin plugins.Plugin) (*plugintypes.CalculateRemapResponse, error) {
 		name := plugin.Name()
 		workloadsResourceMap := make(map[string]plugintypes.WorkloadResource, len(workloads))
 		for _, workload := range workloads {
 			workloadsResourceMap[workload.ID] = workload.Resources[name]
 		}
-		resp, err := plugin.CalculateRemap(ctx, nodename, workloadsResourceMap)
-		if err != nil {
-			logger.Errorf(ctx, err, "plugin %+v node %+v failed to remap", plugin.Name(), nodename)
-		}
-		return resp, err
+		return plugin.CalculateRemap(ctx, nodename, workloadsResourceMap)
 	})
 	if err != nil {
 		return nil, err

--- a/resource/cobalt/remap_test.go
+++ b/resource/cobalt/remap_test.go
@@ -1,0 +1,31 @@
+package cobalt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/projecteru2/core/resource/plugins"
+	pluginmocks "github.com/projecteru2/core/resource/plugins/mocks"
+	plugintypes "github.com/projecteru2/core/resource/plugins/types"
+	resourcetypes "github.com/projecteru2/core/resource/types"
+	coretypes "github.com/projecteru2/core/types"
+)
+
+func TestRemapLeavesOutAPluginWithoutTheVerb(t *testing.T) {
+	m := New(coretypes.Config{})
+	cpumem := pluginmocks.NewPlugin(t)
+	cpumem.On("Name").Return("cpumem").Maybe()
+	cpumem.On("CalculateRemap", mock.Anything, mock.Anything, mock.Anything).Return(&plugintypes.CalculateRemapResponse{
+		EngineParamsMap: map[string]resourcetypes.RawParams{"w1": {"cpus": "1-3"}},
+	}, nil)
+	gpu := pluginmocks.NewPlugin(t)
+	gpu.On("Name").Return("gpu").Maybe()
+	gpu.On("CalculateRemap", mock.Anything, mock.Anything, mock.Anything).Return(nil, plugins.ErrVerbNotSupported)
+	m.AddPlugins(cpumem, gpu)
+
+	params, err := m.Remap(t.Context(), "n1", []*coretypes.Workload{{ID: "w1"}})
+	assert.NoError(t, err)
+	assert.Equal(t, resourcetypes.Resources{"cpumem": {"cpus": "1-3"}}, params["w1"])
+}

--- a/resource/manager.go
+++ b/resource/manager.go
@@ -25,6 +25,6 @@ type Manager interface {
 	RollbackRealloc(context.Context, string, resourcetypes.Resources) error
 	Remap(context.Context, string, []*types.Workload) (map[string]resourcetypes.Resources, error)
 
-	GetNodeMetrics(context.Context, *types.Node) ([]*plugintypes.Metrics, error)
+	GetNodesMetrics(context.Context, []*types.Node) ([]*plugintypes.Metrics, error)
 	GetMetricsDescription(context.Context) ([]*plugintypes.MetricsDescription, error)
 }

--- a/resource/mocks/Manager.go
+++ b/resource/mocks/Manager.go
@@ -337,74 +337,6 @@ func (_c *Manager_GetMostIdleNode_Call) RunAndReturn(run func(context1 context.C
 	return _c
 }
 
-// GetNodeMetrics provides a mock function for the type Manager
-func (_mock *Manager) GetNodeMetrics(context1 context.Context, node *types2.Node) ([]*types1.Metrics, error) {
-	ret := _mock.Called(context1, node)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetNodeMetrics")
-	}
-
-	var r0 []*types1.Metrics
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *types2.Node) ([]*types1.Metrics, error)); ok {
-		return returnFunc(context1, node)
-	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *types2.Node) []*types1.Metrics); ok {
-		r0 = returnFunc(context1, node)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]*types1.Metrics)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, *types2.Node) error); ok {
-		r1 = returnFunc(context1, node)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// Manager_GetNodeMetrics_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetNodeMetrics'
-type Manager_GetNodeMetrics_Call struct {
-	*mock.Call
-}
-
-// GetNodeMetrics is a helper method to define mock.On call
-//   - context1 context.Context
-//   - node *types2.Node
-func (_e *Manager_Expecter) GetNodeMetrics(context1 any, node any) *Manager_GetNodeMetrics_Call {
-	return &Manager_GetNodeMetrics_Call{Call: _e.mock.On("GetNodeMetrics", context1, node)}
-}
-
-func (_c *Manager_GetNodeMetrics_Call) Run(run func(context1 context.Context, node *types2.Node)) *Manager_GetNodeMetrics_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 *types2.Node
-		if args[1] != nil {
-			arg1 = args[1].(*types2.Node)
-		}
-		run(
-			arg0,
-			arg1,
-		)
-	})
-	return _c
-}
-
-func (_c *Manager_GetNodeMetrics_Call) Return(metricss []*types1.Metrics, err error) *Manager_GetNodeMetrics_Call {
-	_c.Call.Return(metricss, err)
-	return _c
-}
-
-func (_c *Manager_GetNodeMetrics_Call) RunAndReturn(run func(context1 context.Context, node *types2.Node) ([]*types1.Metrics, error)) *Manager_GetNodeMetrics_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // GetNodeResourceInfo provides a mock function for the type Manager
 func (_mock *Manager) GetNodeResourceInfo(context1 context.Context, s string, workloads []*types2.Workload, b bool) (types.Resources, types.Resources, []string, error) {
 	ret := _mock.Called(context1, s, workloads, b)
@@ -577,6 +509,74 @@ func (_c *Manager_GetNodesDeployCapacity_Call) Return(stringToNodeDeployCapacity
 }
 
 func (_c *Manager_GetNodesDeployCapacity_Call) RunAndReturn(run func(context1 context.Context, strings []string, resources types.Resources) (map[string]*types1.NodeDeployCapacity, int, error)) *Manager_GetNodesDeployCapacity_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetNodesMetrics provides a mock function for the type Manager
+func (_mock *Manager) GetNodesMetrics(context1 context.Context, nodes []*types2.Node) ([]*types1.Metrics, error) {
+	ret := _mock.Called(context1, nodes)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetNodesMetrics")
+	}
+
+	var r0 []*types1.Metrics
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []*types2.Node) ([]*types1.Metrics, error)); ok {
+		return returnFunc(context1, nodes)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []*types2.Node) []*types1.Metrics); ok {
+		r0 = returnFunc(context1, nodes)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*types1.Metrics)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, []*types2.Node) error); ok {
+		r1 = returnFunc(context1, nodes)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Manager_GetNodesMetrics_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetNodesMetrics'
+type Manager_GetNodesMetrics_Call struct {
+	*mock.Call
+}
+
+// GetNodesMetrics is a helper method to define mock.On call
+//   - context1 context.Context
+//   - nodes []*types2.Node
+func (_e *Manager_Expecter) GetNodesMetrics(context1 any, nodes any) *Manager_GetNodesMetrics_Call {
+	return &Manager_GetNodesMetrics_Call{Call: _e.mock.On("GetNodesMetrics", context1, nodes)}
+}
+
+func (_c *Manager_GetNodesMetrics_Call) Run(run func(context1 context.Context, nodes []*types2.Node)) *Manager_GetNodesMetrics_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []*types2.Node
+		if args[1] != nil {
+			arg1 = args[1].([]*types2.Node)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *Manager_GetNodesMetrics_Call) Return(metricss []*types1.Metrics, err error) *Manager_GetNodesMetrics_Call {
+	_c.Call.Return(metricss, err)
+	return _c
+}
+
+func (_c *Manager_GetNodesMetrics_Call) RunAndReturn(run func(context1 context.Context, nodes []*types2.Node) ([]*types1.Metrics, error)) *Manager_GetNodesMetrics_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/resource/plugins/binary/binary.go
+++ b/resource/plugins/binary/binary.go
@@ -5,6 +5,7 @@ import (
 	ppath "path"
 	"path/filepath"
 
+	"github.com/projecteru2/core/log"
 	coretypes "github.com/projecteru2/core/types"
 )
 
@@ -13,14 +14,21 @@ type Plugin struct {
 	name   string
 	path   string
 	config coretypes.Config
+	verbs  []string
 }
 
-func NewPlugin(_ context.Context, path string, config coretypes.Config) (*Plugin, error) {
+// NewPlugin asks the binary which verbs it implements, so a verb it lacks never spawns it.
+func NewPlugin(ctx context.Context, path string, config coretypes.Config) (*Plugin, error) {
 	p, err := filepath.Abs(path)
 	if err != nil {
 		return nil, err
 	}
-	return &Plugin{name: ppath.Base(path), path: p, config: config}, nil
+	plugin := &Plugin{name: ppath.Base(path), path: p, config: config, verbs: []string{VerbsCommand}}
+	if err := plugin.call(ctx, VerbsCommand, struct{}{}, &plugin.verbs); err != nil {
+		return nil, err
+	}
+	log.WithFunc("resource.binary.NewPlugin").WithField("plugin", plugin.name).Infof(ctx, "verbs %v", plugin.verbs)
+	return plugin, nil
 }
 
 func (p Plugin) Name() string {

--- a/resource/plugins/binary/call.go
+++ b/resource/plugins/binary/call.go
@@ -5,14 +5,22 @@ import (
 	"context"
 	"encoding/json"
 	"os/exec"
+	"slices"
+	"strings"
+
+	"github.com/cockroachdb/errors"
 
 	"github.com/projecteru2/core/log"
+	"github.com/projecteru2/core/resource/plugins"
 )
 
 func (p Plugin) call(ctx context.Context, cmd string, req, resp any) error {
+	if !slices.Contains(p.verbs, cmd) {
+		return plugins.ErrVerbNotSupported
+	}
 	ctx, cancel := context.WithTimeout(ctx, p.config.ResourcePlugin.CallTimeout)
 	defer cancel()
-	logger := log.WithFunc("resource.binary.call")
+	logger := log.WithFunc("resource.binary.call").WithField("plugin", p.name).WithField("cmd", cmd)
 
 	command := exec.CommandContext(ctx, p.path, cmd) //nolint:gosec // the plugin path comes from the operator's own config
 	command.Dir = p.config.ResourcePlugin.Dir
@@ -22,17 +30,20 @@ func (p Plugin) call(ctx context.Context, cmd string, req, resp any) error {
 		return err
 	}
 	if cmd != GetMetricsCommand {
-		logger.WithField("in", string(b)).WithField("cmd", command.String()).Debug(ctx, "call params")
+		logger.WithField("in", string(b)).Debug(ctx, "call params")
 	}
 	command.Stdin = bytes.NewBuffer(b)
-	out, err := command.CombinedOutput()
-	if err != nil {
-		logger.Error(ctx, err, string(out))
-		return err
+	var stdout, stderr bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+	if err := command.Run(); err != nil {
+		return errors.Wrapf(err, "plugin %s %s: %s", p.name, cmd, strings.TrimSpace(stderr.String()))
 	}
-
-	if len(out) == 0 {
-		return nil
+	if stderr.Len() > 0 {
+		logger.Debug(ctx, stderr.String())
 	}
-	return json.Unmarshal(out, resp)
+	if stdout.Len() == 0 {
+		return errors.Newf("plugin %s wrote no response for %s", p.name, cmd)
+	}
+	return json.Unmarshal(stdout.Bytes(), resp)
 }

--- a/resource/plugins/binary/call_test.go
+++ b/resource/plugins/binary/call_test.go
@@ -1,0 +1,60 @@
+package binary
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/projecteru2/core/resource/plugins"
+	plugintypes "github.com/projecteru2/core/resource/plugins/types"
+	coretypes "github.com/projecteru2/core/types"
+)
+
+const fakePlugin = `#!/bin/sh
+case "$1" in
+verbs) echo '["remove-node", "get-metrics"]' ;;
+remove-node) echo 'a log line' >&2; echo '{}' ;;
+get-metrics) cat >&2 ;;
+esac
+`
+
+func TestCallSpawnsOnlyAdvertisedVerbs(t *testing.T) {
+	p := newFakePlugin(t)
+	_, err := p.RemoveNode(t.Context(), "n1")
+	assert.NoError(t, err)
+
+	_, err = p.AddNode(t.Context(), "n1", nil, nil)
+	assert.ErrorIs(t, err, plugins.ErrVerbNotSupported)
+}
+
+func TestCallRejectsAnEmptyResponse(t *testing.T) {
+	p := newFakePlugin(t)
+	_, err := p.GetMetrics(t.Context(), []plugintypes.NodeRef{{Podname: "p", Nodename: "n1"}})
+	assert.ErrorContains(t, err, "no response")
+}
+
+func TestNewPluginNeedsTheVerbList(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "resource-silent")
+	require.NoError(t, os.WriteFile(path, []byte("#!/bin/sh\nexit 1\n"), 0o755))
+
+	_, err := NewPlugin(t.Context(), path, pluginConfig(dir))
+	assert.Error(t, err)
+}
+
+func newFakePlugin(t *testing.T) *Plugin {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "resource-fake")
+	require.NoError(t, os.WriteFile(path, []byte(fakePlugin), 0o755))
+	p, err := NewPlugin(t.Context(), path, pluginConfig(dir))
+	require.NoError(t, err)
+	return p
+}
+
+func pluginConfig(dir string) coretypes.Config {
+	return coretypes.Config{ResourcePlugin: coretypes.ResourcePluginConfig{Dir: dir, CallTimeout: 5 * time.Second}}
+}

--- a/resource/plugins/binary/commands.go
+++ b/resource/plugins/binary/commands.go
@@ -1,6 +1,8 @@
 package binary
 
 const (
+	VerbsCommand = "verbs"
+
 	CalculateDeployCommand  = "calculate-deploy"
 	CalculateReallocCommand = "calculate-realloc"
 	CalculateRemapCommand   = "calculate-remap"

--- a/resource/plugins/binary/metrics.go
+++ b/resource/plugins/binary/metrics.go
@@ -13,11 +13,8 @@ func (p Plugin) GetMetricsDescription(ctx context.Context) (*plugintypes.GetMetr
 	return resp, p.call(ctx, GetMetricsDescriptionCommand, req, resp)
 }
 
-func (p Plugin) GetMetrics(ctx context.Context, podname, nodename string) (*plugintypes.GetMetricsResponse, error) {
-	req := &binarytypes.GetMetricsRequest{
-		Podname:  podname,
-		Nodename: nodename,
-	}
+func (p Plugin) GetMetrics(ctx context.Context, nodes []plugintypes.NodeRef) (*plugintypes.GetMetricsResponse, error) {
+	req := &binarytypes.GetMetricsRequest{Nodes: nodes}
 	resp := &plugintypes.GetMetricsResponse{}
 	return resp, p.call(ctx, GetMetricsCommand, req, resp)
 }

--- a/resource/plugins/binary/types/metrics.go
+++ b/resource/plugins/binary/types/metrics.go
@@ -1,8 +1,9 @@
 package types
 
+import plugintypes "github.com/projecteru2/core/resource/plugins/types"
+
 type GetMetricsDescriptionRequest struct{}
 
 type GetMetricsRequest struct {
-	Podname  string `json:"podname"`
-	Nodename string `json:"nodename"`
+	Nodes []plugintypes.NodeRef `json:"nodes"`
 }

--- a/resource/plugins/cpumem/metrics.go
+++ b/resource/plugins/cpumem/metrics.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"strings"
 
+	cpumemtypes "github.com/projecteru2/core/resource/plugins/cpumem/types"
 	plugintypes "github.com/projecteru2/core/resource/plugins/types"
 	resourcetypes "github.com/projecteru2/core/resource/types"
+	"github.com/projecteru2/core/utils"
 )
 
 const (
@@ -14,8 +16,6 @@ const (
 	fieldHelp   = "help"
 	fieldType   = "type"
 	fieldLabels = "labels"
-	fieldValue  = "value"
-	fieldKey    = "key"
 
 	gaugeType = "gauge"
 
@@ -54,42 +54,33 @@ func (p Plugin) GetMetricsDescription(context.Context) (*plugintypes.GetMetricsD
 	}, resp)
 }
 
-func (p Plugin) GetMetrics(ctx context.Context, podname, nodename string) (*plugintypes.GetMetricsResponse, error) {
-	nodeResourceInfo, err := p.doGetNodeResourceInfo(ctx, nodename)
+func (p Plugin) GetMetrics(ctx context.Context, nodes []plugintypes.NodeRef) (*plugintypes.GetMetricsResponse, error) {
+	infos, err := p.doGetNodesResourceInfo(ctx, utils.Map(nodes, func(node plugintypes.NodeRef) string { return node.Nodename }))
 	if err != nil {
 		return nil, err
 	}
-	safeNodename := strings.ReplaceAll(nodename, ".", "_")
-	metrics := []map[string]any{
-		{
-			fieldName:   "memory_capacity",
-			fieldLabels: []string{podname, nodename},
-			fieldValue:  fmt.Sprintf("%+v", nodeResourceInfo.Capacity.Memory),
-			fieldKey:    fmt.Sprintf("core.node.%s.memory", safeNodename),
-		},
-		{
-			fieldName:   "memory_used",
-			fieldLabels: []string{podname, nodename},
-			fieldValue:  fmt.Sprintf("%+v", nodeResourceInfo.Usage.Memory),
-			fieldKey:    fmt.Sprintf("core.node.%s.memory.used", safeNodename),
-		},
-		{
-			fieldName:   "cpu_used",
-			fieldLabels: []string{podname, nodename},
-			fieldValue:  fmt.Sprintf("%+v", nodeResourceInfo.Usage.CPU),
-			fieldKey:    fmt.Sprintf("core.node.%s.cpu.used", safeNodename),
-		},
+	metrics := plugintypes.GetMetricsResponse{}
+	for _, node := range nodes {
+		metrics = append(metrics, nodeMetrics(node, infos[node.Nodename])...)
 	}
+	return &metrics, nil
+}
 
-	for cpuID, pieces := range nodeResourceInfo.Usage.CPUMap {
-		metrics = append(metrics, map[string]any{
-			fieldName:   "cpu_map",
-			fieldLabels: []string{podname, nodename, cpuID},
-			fieldValue:  fmt.Sprintf("%+v", pieces),
-			fieldKey:    fmt.Sprintf("core.node.%s.cpu.%s", safeNodename, cpuID),
+func nodeMetrics(node plugintypes.NodeRef, info *cpumemtypes.NodeResourceInfo) []*plugintypes.Metrics {
+	labels := []string{node.Podname, node.Nodename}
+	safeNodename := strings.ReplaceAll(node.Nodename, ".", "_")
+	metrics := []*plugintypes.Metrics{
+		{Name: "memory_capacity", Labels: labels, Value: fmt.Sprintf("%+v", info.Capacity.Memory), Key: fmt.Sprintf("core.node.%s.memory", safeNodename)},
+		{Name: "memory_used", Labels: labels, Value: fmt.Sprintf("%+v", info.Usage.Memory), Key: fmt.Sprintf("core.node.%s.memory.used", safeNodename)},
+		{Name: "cpu_used", Labels: labels, Value: fmt.Sprintf("%+v", info.Usage.CPU), Key: fmt.Sprintf("core.node.%s.cpu.used", safeNodename)},
+	}
+	for cpuID, pieces := range info.Usage.CPUMap {
+		metrics = append(metrics, &plugintypes.Metrics{
+			Name:   "cpu_map",
+			Labels: []string{node.Podname, node.Nodename, cpuID},
+			Value:  fmt.Sprintf("%+v", pieces),
+			Key:    fmt.Sprintf("core.node.%s.cpu.%s", safeNodename, cpuID),
 		})
 	}
-
-	resp := &plugintypes.GetMetricsResponse{}
-	return resp, resourcetypes.Decode(metrics, resp)
+	return metrics
 }

--- a/resource/plugins/cpumem/metrics_test.go
+++ b/resource/plugins/cpumem/metrics_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/docker/go-units"
 	"github.com/stretchr/testify/assert"
+
+	plugintypes "github.com/projecteru2/core/resource/plugins/types"
 )
 
 func TestGetMetricsDescription(t *testing.T) {
@@ -19,10 +21,11 @@ func TestGetMetricsDescription(t *testing.T) {
 func TestGetMetrics(t *testing.T) {
 	ctx := t.Context()
 	cm := initCPUMEM(t)
-	_, err := cm.GetMetrics(ctx, "", "")
+	_, err := cm.GetMetrics(ctx, []plugintypes.NodeRef{{}})
 	assert.Error(t, err)
 
-	nodes := generateNodes(ctx, t, cm, 1, 2, units.GB, 100, -1)
-	_, err = cm.GetMetrics(ctx, "testpod", nodes[0])
+	nodes := generateNodes(ctx, t, cm, 2, 2, units.GB, 100, -1)
+	metrics, err := cm.GetMetrics(ctx, []plugintypes.NodeRef{{Podname: "testpod", Nodename: nodes[0]}, {Podname: "testpod", Nodename: nodes[1]}})
 	assert.NoError(t, err)
+	assert.Len(t, *metrics, 10)
 }

--- a/resource/plugins/mocks/Plugin.go
+++ b/resource/plugins/mocks/Plugin.go
@@ -428,8 +428,8 @@ func (_c *Plugin_FixNodeResource_Call) RunAndReturn(run func(ctx context.Context
 }
 
 // GetMetrics provides a mock function for the type Plugin
-func (_mock *Plugin) GetMetrics(ctx context.Context, podname string, nodename string) (*types.GetMetricsResponse, error) {
-	ret := _mock.Called(ctx, podname, nodename)
+func (_mock *Plugin) GetMetrics(ctx context.Context, nodes []types.NodeRef) (*types.GetMetricsResponse, error) {
+	ret := _mock.Called(ctx, nodes)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetMetrics")
@@ -437,18 +437,18 @@ func (_mock *Plugin) GetMetrics(ctx context.Context, podname string, nodename st
 
 	var r0 *types.GetMetricsResponse
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (*types.GetMetricsResponse, error)); ok {
-		return returnFunc(ctx, podname, nodename)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []types.NodeRef) (*types.GetMetricsResponse, error)); ok {
+		return returnFunc(ctx, nodes)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) *types.GetMetricsResponse); ok {
-		r0 = returnFunc(ctx, podname, nodename)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []types.NodeRef) *types.GetMetricsResponse); ok {
+		r0 = returnFunc(ctx, nodes)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*types.GetMetricsResponse)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
-		r1 = returnFunc(ctx, podname, nodename)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, []types.NodeRef) error); ok {
+		r1 = returnFunc(ctx, nodes)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -462,30 +462,24 @@ type Plugin_GetMetrics_Call struct {
 
 // GetMetrics is a helper method to define mock.On call
 //   - ctx context.Context
-//   - podname string
-//   - nodename string
-func (_e *Plugin_Expecter) GetMetrics(ctx any, podname any, nodename any) *Plugin_GetMetrics_Call {
-	return &Plugin_GetMetrics_Call{Call: _e.mock.On("GetMetrics", ctx, podname, nodename)}
+//   - nodes []types.NodeRef
+func (_e *Plugin_Expecter) GetMetrics(ctx any, nodes any) *Plugin_GetMetrics_Call {
+	return &Plugin_GetMetrics_Call{Call: _e.mock.On("GetMetrics", ctx, nodes)}
 }
 
-func (_c *Plugin_GetMetrics_Call) Run(run func(ctx context.Context, podname string, nodename string)) *Plugin_GetMetrics_Call {
+func (_c *Plugin_GetMetrics_Call) Run(run func(ctx context.Context, nodes []types.NodeRef)) *Plugin_GetMetrics_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 string
+		var arg1 []types.NodeRef
 		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		var arg2 string
-		if args[2] != nil {
-			arg2 = args[2].(string)
+			arg1 = args[1].([]types.NodeRef)
 		}
 		run(
 			arg0,
 			arg1,
-			arg2,
 		)
 	})
 	return _c
@@ -496,7 +490,7 @@ func (_c *Plugin_GetMetrics_Call) Return(getMetricsResponse *types.GetMetricsRes
 	return _c
 }
 
-func (_c *Plugin_GetMetrics_Call) RunAndReturn(run func(ctx context.Context, podname string, nodename string) (*types.GetMetricsResponse, error)) *Plugin_GetMetrics_Call {
+func (_c *Plugin_GetMetrics_Call) RunAndReturn(run func(ctx context.Context, nodes []types.NodeRef) (*types.GetMetricsResponse, error)) *Plugin_GetMetrics_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/resource/plugins/plugin.go
+++ b/resource/plugins/plugin.go
@@ -3,6 +3,8 @@ package plugins
 import (
 	"context"
 
+	"github.com/cockroachdb/errors"
+
 	enginetypes "github.com/projecteru2/core/engine/types"
 	plugintypes "github.com/projecteru2/core/resource/plugins/types"
 )
@@ -12,22 +14,20 @@ const (
 	Decr = false
 )
 
+// ErrVerbNotSupported marks a verb the plugin did not advertise; cobalt leaves the plugin out of that call.
+var ErrVerbNotSupported = errors.New("verb not supported by the plugin")
+
 type Plugin interface {
-	// CalculateDeploy allocates resource and returns per-workload engine and resource params, format: [{"cpus": 1.2}, {"cpus": 1.2}]
-	// pure calculation
+	// CalculateDeploy plans per-workload engine and resource params without writing anything.
 	CalculateDeploy(ctx context.Context, nodename string, deployCount int, resourceRequest plugintypes.WorkloadResourceRequest) (*plugintypes.CalculateDeployResponse, error)
 
-	// CalculateRealloc tries to reallocate resource, returns engine params, delta resource params and final resource params.
-	// should return error if resource of some node is not enough for the realloc operation.
-	// pure calculation
+	// CalculateRealloc plans a workload's new engine params, delta and final resource without writing anything.
 	CalculateRealloc(ctx context.Context, nodename string, resource plugintypes.WorkloadResource, resourceRequest plugintypes.WorkloadResourceRequest) (*plugintypes.CalculateReallocResponse, error)
 
-	// CalculateRemap tries to remap resource based on workload metadata and node resource usage, then returns engine params for workloads.
-	// pure calculation; the map key is the workload ID
+	// CalculateRemap plans engine params per workload ID from the node's usage without writing anything.
 	CalculateRemap(ctx context.Context, nodename string, workloadsResource map[string]plugintypes.WorkloadResource) (*plugintypes.CalculateRemapResponse, error)
 
-	// AddNode adds a node with requested resource, returns resource capacity and (empty) resource usage
-	// should return error if the node already exists
+	// AddNode records a node's capacity and an empty usage, and fails on a node it already has.
 	AddNode(ctx context.Context, nodename string, resource plugintypes.NodeResourceRequest, info *enginetypes.Info) (*plugintypes.AddNodeResponse, error)
 
 	RemoveNode(ctx context.Context, nodename string) (*plugintypes.RemoveNodeResponse, error)
@@ -39,8 +39,7 @@ type Plugin interface {
 	// GetNodeResourceInfo returns total resource info and available resource info of the node, format: {"cpu": 2}
 	GetNodeResourceInfo(ctx context.Context, nodename string, workloadsResource []plugintypes.WorkloadResource) (*plugintypes.GetNodeResourceInfoResponse, error)
 
-	// SetNodeResourceInfo sets both total node resource info and allocated resource info
-	// values are absolute, not deltas
+	// SetNodeResourceInfo stores a node's capacity and usage as absolute values.
 	SetNodeResourceInfo(ctx context.Context, nodename string, capacity, usage plugintypes.NodeResource) (*plugintypes.SetNodeResourceInfoResponse, error)
 
 	SetNodeResourceUsage(ctx context.Context, nodename string, resource plugintypes.NodeResource, resourceRequest plugintypes.NodeResourceRequest, workloadsResource []plugintypes.WorkloadResource, delta, incr bool) (*plugintypes.SetNodeResourceUsageResponse, error)
@@ -51,7 +50,7 @@ type Plugin interface {
 
 	GetMetricsDescription(ctx context.Context) (*plugintypes.GetMetricsDescriptionResponse, error)
 
-	GetMetrics(ctx context.Context, podname, nodename string) (*plugintypes.GetMetricsResponse, error)
+	GetMetrics(ctx context.Context, nodes []plugintypes.NodeRef) (*plugintypes.GetMetricsResponse, error)
 
 	Name() string
 }

--- a/resource/plugins/types/metrics.go
+++ b/resource/plugins/types/metrics.go
@@ -1,5 +1,11 @@
 package types
 
+// NodeRef names one node in a metrics request.
+type NodeRef struct {
+	Podname  string `json:"podname"`
+	Nodename string `json:"nodename"`
+}
+
 type MetricsDescription struct {
 	Name   string   `json:"name"`
 	Help   string   `json:"help"`

--- a/resource/plugins/types/node.go
+++ b/resource/plugins/types/node.go
@@ -16,13 +16,13 @@ type AddNodeResponse struct {
 type RemoveNodeResponse struct{}
 
 type NodeDeployCapacity struct {
-	Capacity int
+	Capacity int `json:"capacity"`
 	// Usage is the used fraction of the node's total, 0..1
-	Usage float64
+	Usage float64 `json:"usage"`
 	// Rate proportion of requested resources to total
-	Rate float64
+	Rate float64 `json:"rate"`
 	// Weight used for weighted average
-	Weight float64
+	Weight float64 `json:"weight"`
 }
 
 type GetNodesDeployCapacityResponse struct {

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -938,12 +938,20 @@ func logUnsentMessages(ctx context.Context, msgType string, err error, msg any) 
 
 func recvStdin[T any](ctx context.Context, name string, open bool, recv func() (T, error), payload func(T) []byte) <-chan []byte {
 	inCh := make(chan []byte)
+<<<<<<< HEAD
 	if !open {
 		close(inCh)
 		return inCh
 	}
 	utils.SentryGo(func() {
 		defer close(inCh)
+=======
+	utils.SentryGo(func() {
+		defer close(inCh)
+		if !open {
+			return
+		}
+>>>>>>> 5350685c
 		for {
 			msg, err := recv()
 			if err != nil {
@@ -962,7 +970,11 @@ func recvStdin[T any](ctx context.Context, name string, open bool, recv func() (
 	return inCh
 }
 
+<<<<<<< HEAD
 func drain[T, R any](t *task, name string, ch <-chan T, send sender[R], to converter[T, R]) {
+=======
+func drain[T, R any](t *task, name string, ch <-chan T, send func(R) error, to func(T) R) {
+>>>>>>> 5350685c
 	for m := range ch {
 		if err := send(to(m)); err != nil {
 			logUnsentMessages(t.context, name, err, m)
@@ -970,7 +982,11 @@ func drain[T, R any](t *task, name string, ch <-chan T, send sender[R], to conve
 	}
 }
 
+<<<<<<< HEAD
 func drainUntilStop[T, R any](t *task, name string, code codes.Code, stop <-chan struct{}, ch <-chan T, send sender[R], to converter[T, R]) error {
+=======
+func drainUntilStop[T, R any](t *task, name string, code codes.Code, stop <-chan struct{}, ch <-chan T, send func(R) error, to func(T) R) error {
+>>>>>>> 5350685c
 	for {
 		select {
 		case m, ok := <-ch:


### PR DESCRIPTION
Stacked on #702 (the metrics handler it rewrites); rebases to one commit once #702 lands.

## Protocol changes (binary plugins)

- **`verbs`**: core runs it once at load; the plugin answers with the JSON array of verbs it implements. A verb outside the list never spawns the plugin, and cobalt leaves that plugin out of the call (`plugins.ErrVerbNotSupported`). A plugin that cannot answer `verbs` fails to load.
- **`get-metrics`** takes `{"nodes": [{"podname", "nodename"}, ...]}` and returns the metrics of all of them: one exec per plugin per scrape instead of one per node per plugin. `resource.Manager.GetNodesMetrics` replaces `GetNodeMetrics`; the scrape middleware lists the nodes and makes one call.
- **stdout / stderr**: stdout is the response, stderr is the plugin's log (debug on success, with the error on failure). **Empty stdout is an error** instead of a zero-valued success.
- `NodeDeployCapacity` gets json tags (`capacity`, `usage`, `rate`, `weight`), so the v1 and v2 decoders agree.

The built-in cpumem plugin implements the batched `get-metrics` over one multi-key read. resource-extend follows in its own PR (verb list, batched metrics, `calculate-remap` left out by gpu and storage).

## Tests

- `resource/plugins/binary`: a shell-script plugin — advertised verbs only, empty response rejected, a binary without `verbs` fails to load.
- `resource/cobalt`: a plugin without the verb is left out without failing the call.
- `metrics`: every node refreshed in one call; overlapping scrapes share it; the refresh outlives the scrape that started it.
- `cpumem`: two nodes, ten metrics.

## Gates

`GOWORK=off go build ./...`, `go vet`, `go test -count=1 -race` on resource/metrics, full `go test -count=1 ./...` (all packages ok), `make lint fmt-check` on GOOS=linux and darwin (0 issues each), `asl ./...` both GOOS (no findings). Mocks regenerated with the pinned mockery.
