### PR TITLE
perf: release the resources of removed workloads in one plugin call per node

### DIFF
--- a/cluster/calcium/dissociate.go
+++ b/cluster/calcium/dissociate.go
@@ -33,7 +33,11 @@ func (c *Calcium) DissociateWorkload(ctx context.Context, IDs []string) (chan *t
 						logger.WithField("id", workloadID).Error(ctx, workloadErr, "failed to dissociate workload")
 						msg.Error = workloadErr
 					}
-					ch <- msg
+					select {
+					case ch <- msg:
+					case <-ctx.Done():
+						return ctx.Err()
+					}
 				}
 				c.invokePoolAsync(func() { c.RemapResourceAndLog(ctx, logger, node) })
 				return nil

--- a/cluster/calcium/lock.go
+++ b/cluster/calcium/lock.go
@@ -133,19 +133,21 @@ func (c *Calcium) withNodesLocked(ctx context.Context, nodeFilter *types.NodeFil
 		return err
 	}
 
-	var lock lock.DistributedLock
+	keys := make([]string, 0, len(ns))
 	for _, n := range ns {
-		key := genKey(n)
-		if _, ok := locks[key]; !ok {
-			lock, ctx, err = c.doLock(ctx, key, c.config.LockTimeout)
-			if err != nil {
-				return err
-			}
-			logger.Debugf(ctx, "key %s locked", key)
-			locks[key] = lock
-			lockKeys = append(lockKeys, key)
-		}
 		nodes[n.Name] = n
+		keys = append(keys, genKey(n))
+	}
+	slices.Sort(keys)
+	var lock lock.DistributedLock
+	for _, key := range slices.Compact(keys) {
+		lock, ctx, err = c.doLock(ctx, key, c.config.LockTimeout)
+		if err != nil {
+			return err
+		}
+		logger.Debugf(ctx, "key %s locked", key)
+		locks[key] = lock
+		lockKeys = append(lockKeys, key)
 	}
 	return f(ctx, nodes)
 }

--- a/cluster/calcium/lock_test.go
+++ b/cluster/calcium/lock_test.go
@@ -174,6 +174,31 @@ func TestWithNodesPodLocked(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestWithNodesPodLockedTakesPodLocksInKeyOrder(t *testing.T) {
+	c := NewTestCluster()
+	store := c.store.(*storemocks.Store)
+	nodes := []*types.Node{
+		{NodeMeta: types.NodeMeta{Name: "a1", Podname: "podb"}, Available: true},
+		{NodeMeta: types.NodeMeta{Name: "b1", Podname: "poda"}, Available: true},
+		{NodeMeta: types.NodeMeta{Name: "c1", Podname: "podb"}, Available: true},
+	}
+	store.On("GetNodes", mock.Anything, mock.Anything).Return(nodes, nil)
+	lock := &lockmocks.DistributedLock{}
+	lock.On("Lock", mock.Anything).Return(t.Context(), nil)
+	lock.On("Unlock", mock.Anything).Return(nil)
+	keys := []string{}
+	store.On("CreateLock", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		keys = append(keys, args.String(0))
+	}).Return(lock, nil)
+
+	err := c.withNodesPodLocked(t.Context(), &types.NodeFilter{Includes: []string{"a1", "b1", "c1"}}, func(_ context.Context, locked map[string]*types.Node) error {
+		assert.Len(t, locked, 3)
+		return nil
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"plock_poda", "plock_podb"}, keys)
+}
+
 func TestWithNodePodLocked(t *testing.T) {
 	c := NewTestCluster()
 	ctx := t.Context()

--- a/cluster/calcium/node.go
+++ b/cluster/calcium/node.go
@@ -4,9 +4,9 @@ import (
 	"cmp"
 	"context"
 	"slices"
-	"sync"
 
 	"github.com/cockroachdb/errors"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/projecteru2/core/engine"
 	enginefactory "github.com/projecteru2/core/engine/factory"
@@ -18,6 +18,8 @@ import (
 	"github.com/projecteru2/core/types"
 	"github.com/projecteru2/core/utils"
 )
+
+const statusWriters = 32
 
 func (c *Calcium) AddNode(ctx context.Context, opts *types.AddNodeOptions) (*types.Node, error) {
 	logger := log.WithFunc("calcium.AddNode").WithField("opts", opts)
@@ -300,15 +302,14 @@ func (c *Calcium) setAllWorkloadsOnNodeDown(ctx context.Context, nodename string
 		return
 	}
 
-	wg := &sync.WaitGroup{}
-	wg.Add(len(workloads))
+	var g errgroup.Group
+	g.SetLimit(statusWriters)
 	for _, workload := range workloads {
-		_ = c.pool.Invoke(func() {
-			defer wg.Done()
+		g.Go(func() error {
 			appname, entrypoint, _, err := utils.ParseWorkloadName(workload.Name)
 			if err != nil {
 				logger.Errorf(ctx, err, "set workload %s on node %s as inactive failed", workload.ID, nodename)
-				return
+				return nil
 			}
 
 			if workload.StatusMeta == nil {
@@ -323,12 +324,13 @@ func (c *Calcium) setAllWorkloadsOnNodeDown(ctx context.Context, nodename string
 
 			if err = c.store.SetWorkloadStatus(ctx, workload.StatusMeta, 0); err != nil {
 				logger.Errorf(ctx, err, "set workload %s on node %s as inactive failed", workload.ID, nodename)
-				return
+				return nil
 			}
 			logger.Infof(ctx, "set workload %s on node %s as inactive", workload.ID, nodename)
+			return nil
 		})
 	}
-	wg.Wait()
+	_ = g.Wait()
 }
 
 func verifyNodeEngine(ctx context.Context, client engine.API) error {

--- a/cluster/calcium/node.go
+++ b/cluster/calcium/node.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"context"
 	"slices"
+	"sync"
 
 	"github.com/cockroachdb/errors"
 
@@ -232,7 +233,9 @@ func (c *Calcium) SetNode(ctx context.Context, opts *types.SetNodeOptions) (*typ
 					return updateErr
 				}
 				// capacity refresh is best effort; the store write already succeeded
-				_ = c.refreshResourceInfo(ctx, node)
+				if len(opts.Resources) != 0 {
+					_ = c.refreshResourceInfo(ctx, node)
+				}
 				c.invokePoolAsync(func() { c.doSendNodeMetrics(context.WithoutCancel(ctx), node) })
 				c.invokePoolAsync(func() { c.RemapResourceAndLog(ctx, logger, node) })
 				return nil
@@ -297,29 +300,35 @@ func (c *Calcium) setAllWorkloadsOnNodeDown(ctx context.Context, nodename string
 		return
 	}
 
+	wg := &sync.WaitGroup{}
+	wg.Add(len(workloads))
 	for _, workload := range workloads {
-		appname, entrypoint, _, err := utils.ParseWorkloadName(workload.Name)
-		if err != nil {
-			logger.Errorf(ctx, err, "set workload %s on node %s as inactive failed", workload.ID, nodename)
-			continue
-		}
+		_ = c.pool.Invoke(func() {
+			defer wg.Done()
+			appname, entrypoint, _, err := utils.ParseWorkloadName(workload.Name)
+			if err != nil {
+				logger.Errorf(ctx, err, "set workload %s on node %s as inactive failed", workload.ID, nodename)
+				return
+			}
 
-		if workload.StatusMeta == nil {
-			workload.StatusMeta = &types.StatusMeta{ID: workload.ID}
-		}
-		workload.StatusMeta.Running = false
-		workload.StatusMeta.Healthy = false
+			if workload.StatusMeta == nil {
+				workload.StatusMeta = &types.StatusMeta{ID: workload.ID}
+			}
+			workload.StatusMeta.Running = false
+			workload.StatusMeta.Healthy = false
 
-		workload.StatusMeta.Appname = appname
-		workload.StatusMeta.Nodename = workload.Nodename
-		workload.StatusMeta.Entrypoint = entrypoint
+			workload.StatusMeta.Appname = appname
+			workload.StatusMeta.Nodename = workload.Nodename
+			workload.StatusMeta.Entrypoint = entrypoint
 
-		if err = c.store.SetWorkloadStatus(ctx, workload.StatusMeta, 0); err != nil {
-			logger.Errorf(ctx, err, "set workload %s on node %s as inactive failed", workload.ID, nodename)
-		} else {
+			if err = c.store.SetWorkloadStatus(ctx, workload.StatusMeta, 0); err != nil {
+				logger.Errorf(ctx, err, "set workload %s on node %s as inactive failed", workload.ID, nodename)
+				return
+			}
 			logger.Infof(ctx, "set workload %s on node %s as inactive", workload.ID, nodename)
-		}
+		})
 	}
+	wg.Wait()
 }
 
 func verifyNodeEngine(ctx context.Context, client engine.API) error {

--- a/cluster/calcium/node_test.go
+++ b/cluster/calcium/node_test.go
@@ -290,6 +290,32 @@ func TestSetNode(t *testing.T) {
 	rmgr.AssertExpectations(t)
 }
 
+func TestSetWorkloadsDownDoesNotWaitForThePool(t *testing.T) {
+	c := NewTestCluster()
+	pool, err := utils.NewPool(1)
+	assert.NoError(t, err)
+	c.pool = pool
+	release := make(chan struct{})
+	defer close(release)
+	_ = c.pool.Invoke(func() { <-release })
+
+	store := c.store.(*storemocks.Store)
+	store.On("ListNodeWorkloads", mock.Anything, mock.Anything, mock.Anything).Return([]*types.Workload{{ID: "1", Name: "a_b_c"}, {ID: "2", Name: "a_b_d"}}, nil)
+	store.On("SetWorkloadStatus", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		c.setAllWorkloadsOnNodeDown(t.Context(), "node")
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("marking workloads down waited for a pool worker while holding the node lock")
+	}
+	store.AssertNumberOfCalls(t, "SetWorkloadStatus", 2)
+}
+
 func TestFilterNodes(t *testing.T) {
 	c := NewTestCluster()
 	ctx := t.Context()

--- a/cluster/calcium/remove.go
+++ b/cluster/calcium/remove.go
@@ -8,6 +8,8 @@ import (
 	"github.com/cockroachdb/errors"
 
 	"github.com/projecteru2/core/log"
+	"github.com/projecteru2/core/resource/plugins"
+	resourcetypes "github.com/projecteru2/core/resource/types"
 	"github.com/projecteru2/core/types"
 	"github.com/projecteru2/core/utils"
 )
@@ -31,32 +33,15 @@ func (c *Calcium) RemoveWorkload(ctx context.Context, IDs []string, force bool) 
 			_ = c.pool.Invoke(func() {
 				defer wg.Done()
 				if nodeErr := c.withNodePodLocked(ctx, nodename, func(ctx context.Context, node *types.Node) error {
-					for _, workloadID := range workloadIDs {
-						ret := &types.RemoveWorkloadMessage{WorkloadID: workloadID, Success: true, Hook: []*bytes.Buffer{}}
-						if workloadErr := c.withWorkloadLocked(ctx, workloadID, false, func(ctx context.Context, workload *types.Workload) error {
-							if err := c.doRemoveOneWorkload(ctx, node, workload, force); err != nil {
-								return err
-							}
-							logger.Infof(ctx, "workload %s removed", workload.ID)
-							return nil
-						}); workloadErr != nil {
-							logger.WithField("id", workloadID).Error(ctx, workloadErr, "failed to remove workload")
-							ret.Hook = append(ret.Hook, bytes.NewBufferString(workloadErr.Error()))
-							ret.Success = false
-						}
-						select {
-						case ch <- ret:
-						case <-ctx.Done():
-							return ctx.Err()
-						}
-					}
-					c.invokePoolAsync(func() { c.RemapResourceAndLog(ctx, logger, node) })
-					return nil
+					return c.doRemoveNodeWorkloads(ctx, node, workloadIDs, force, ch)
 				}); nodeErr != nil {
-					logger.WithField("node", nodename).Error(ctx, nodeErr, "failed to lock node")
-					select {
-					case ch <- &types.RemoveWorkloadMessage{Success: false}:
-					case <-ctx.Done():
+					logger.WithField("node", nodename).Error(ctx, nodeErr, "failed to remove the workloads of the node")
+					for _, workloadID := range workloadIDs {
+						select {
+						case ch <- &types.RemoveWorkloadMessage{WorkloadID: workloadID, Success: false, Hook: []*bytes.Buffer{bytes.NewBufferString(nodeErr.Error())}}:
+						case <-ctx.Done():
+							return
+						}
 					}
 				}
 			})
@@ -65,24 +50,67 @@ func (c *Calcium) RemoveWorkload(ctx context.Context, IDs []string, force bool) 
 	return ch, nil
 }
 
-func (c *Calcium) doRemoveOneWorkload(ctx context.Context, node *types.Node, workload *types.Workload, force bool) error {
-	logger := log.WithFunc("calcium.doRemoveOneWorkload").WithField("id", workload.ID)
-
+func (c *Calcium) doRemoveNodeWorkloads(ctx context.Context, node *types.Node, IDs []string, force bool, ch chan<- *types.RemoveWorkloadMessage) error {
+	logger := log.WithFunc("calcium.doRemoveNodeWorkloads").WithField("node", node.Name)
+	workloads, err := c.store.GetWorkloads(ctx, IDs)
+	if err != nil {
+		return err
+	}
 	nodeCommit, err := c.journal(ctx, logger, eventWorkloadResourceAllocated, []*types.Node{node})
 	if err != nil {
 		return err
 	}
 	defer nodeCommit()
 
+	resources := make([]resourcetypes.Resources, 0, len(workloads))
+	for _, workload := range workloads {
+		resources = append(resources, workload.Resources)
+	}
+	if _, _, err = c.rmgr.SetNodeResourceUsage(ctx, node.Name, nil, nil, resources, true, plugins.Decr); err != nil {
+		return err
+	}
+
+	kept := []resourcetypes.Resources{}
+	defer func() {
+		if len(kept) == 0 {
+			return
+		}
+		restoreCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), c.config.GlobalTimeout)
+		defer cancel()
+		if _, _, err := c.rmgr.SetNodeResourceUsage(restoreCtx, node.Name, nil, nil, kept, true, plugins.Incr); err != nil {
+			logger.Error(ctx, err, "failed to give the workloads that stay their resources back")
+		}
+	}()
+	for _, workload := range workloads {
+		ret := &types.RemoveWorkloadMessage{WorkloadID: workload.ID, Success: true, Hook: []*bytes.Buffer{}}
+		if workloadErr := c.withWorkloadLocked(ctx, workload.ID, false, func(ctx context.Context, workload *types.Workload) error {
+			return c.doRemoveOneWorkload(ctx, workload, force)
+		}); workloadErr != nil {
+			logger.WithField("id", workload.ID).Error(ctx, workloadErr, "failed to remove workload")
+			ret.Hook = append(ret.Hook, bytes.NewBufferString(workloadErr.Error()))
+			ret.Success = false
+			kept = append(kept, workload.Resources)
+		} else {
+			logger.Infof(ctx, "workload %s removed", workload.ID)
+		}
+		select {
+		case ch <- ret:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	c.invokePoolAsync(func() { c.RemapResourceAndLog(ctx, logger, node) })
+	return nil
+}
+
+func (c *Calcium) doRemoveOneWorkload(ctx context.Context, workload *types.Workload, force bool) error {
+	logger := log.WithFunc("calcium.doRemoveOneWorkload").WithField("id", workload.ID)
 	workloadCommit, err := c.journal(ctx, logger, eventWorkloadCreated, &types.Workload{ID: workload.ID, Name: workload.Name, Nodename: workload.Nodename})
 	if err != nil {
 		return err
 	}
 	defer workloadCommit()
-
-	return c.withResourceReleased(ctx, node, workload, func(ctx context.Context) error {
-		return c.doRemoveWorkload(ctx, workload, force)
-	})
+	return c.doRemoveWorkload(ctx, workload, force)
 }
 
 func (c *Calcium) doRemoveWorkload(ctx context.Context, workload *types.Workload, force bool) error {

--- a/cluster/calcium/remove.go
+++ b/cluster/calcium/remove.go
@@ -44,13 +44,20 @@ func (c *Calcium) RemoveWorkload(ctx context.Context, IDs []string, force bool) 
 							ret.Hook = append(ret.Hook, bytes.NewBufferString(workloadErr.Error()))
 							ret.Success = false
 						}
-						ch <- ret
+						select {
+						case ch <- ret:
+						case <-ctx.Done():
+							return ctx.Err()
+						}
 					}
 					c.invokePoolAsync(func() { c.RemapResourceAndLog(ctx, logger, node) })
 					return nil
 				}); nodeErr != nil {
 					logger.WithField("node", nodename).Error(ctx, nodeErr, "failed to lock node")
-					ch <- &types.RemoveWorkloadMessage{Success: false}
+					select {
+					case ch <- &types.RemoveWorkloadMessage{Success: false}:
+					case <-ctx.Done():
+					}
 				}
 			})
 		}

--- a/cluster/calcium/remove.go
+++ b/cluster/calcium/remove.go
@@ -3,6 +3,8 @@ package calcium
 import (
 	"bytes"
 	"context"
+	"maps"
+	"slices"
 	"sync"
 
 	"github.com/cockroachdb/errors"
@@ -62,22 +64,23 @@ func (c *Calcium) doRemoveNodeWorkloads(ctx context.Context, node *types.Node, I
 	}
 	defer nodeCommit()
 
+	staying := make(map[string]resourcetypes.Resources, len(workloads))
 	resources := make([]resourcetypes.Resources, 0, len(workloads))
 	for _, workload := range workloads {
+		staying[workload.ID] = workload.Resources
 		resources = append(resources, workload.Resources)
 	}
 	if _, _, err = c.rmgr.SetNodeResourceUsage(ctx, node.Name, nil, nil, resources, true, plugins.Decr); err != nil {
 		return err
 	}
 
-	kept := []resourcetypes.Resources{}
 	defer func() {
-		if len(kept) == 0 {
+		if len(staying) == 0 {
 			return
 		}
 		restoreCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), c.config.GlobalTimeout)
 		defer cancel()
-		if _, _, err := c.rmgr.SetNodeResourceUsage(restoreCtx, node.Name, nil, nil, kept, true, plugins.Incr); err != nil {
+		if _, _, err := c.rmgr.SetNodeResourceUsage(restoreCtx, node.Name, nil, nil, slices.Collect(maps.Values(staying)), true, plugins.Incr); err != nil {
 			logger.Error(ctx, err, "failed to give the workloads that stay their resources back")
 		}
 	}()
@@ -89,8 +92,8 @@ func (c *Calcium) doRemoveNodeWorkloads(ctx context.Context, node *types.Node, I
 			logger.WithField("id", workload.ID).Error(ctx, workloadErr, "failed to remove workload")
 			ret.Hook = append(ret.Hook, bytes.NewBufferString(workloadErr.Error()))
 			ret.Success = false
-			kept = append(kept, workload.Resources)
 		} else {
+			delete(staying, workload.ID)
 			logger.Infof(ctx, "workload %s removed", workload.ID)
 		}
 		select {

--- a/cluster/calcium/remove_test.go
+++ b/cluster/calcium/remove_test.go
@@ -11,6 +11,7 @@ import (
 	enginemocks "github.com/projecteru2/core/engine/mocks"
 	lockmocks "github.com/projecteru2/core/lock/mocks"
 	resourcemocks "github.com/projecteru2/core/resource/mocks"
+	"github.com/projecteru2/core/resource/plugins"
 	plugintypes "github.com/projecteru2/core/resource/plugins/types"
 	resourcetypes "github.com/projecteru2/core/resource/types"
 	storemocks "github.com/projecteru2/core/store/mocks"
@@ -84,6 +85,42 @@ func TestRemoveWorkload(t *testing.T) {
 		assert.True(t, r.Success)
 	}
 	store.AssertExpectations(t)
+}
+
+func TestRemoveWorkloadReleasesResourcesOnce(t *testing.T) {
+	c := NewTestCluster()
+	ctx := t.Context()
+	lock := &lockmocks.DistributedLock{}
+	lock.On("Lock", mock.Anything).Return(ctx, nil)
+	lock.On("Unlock", mock.Anything).Return(nil)
+	engine := &enginemocks.API{}
+	engine.On("VirtualizationRemove", mock.Anything, "a", mock.Anything, mock.Anything).Return(nil)
+	engine.On("VirtualizationRemove", mock.Anything, "b", mock.Anything, mock.Anything).Return(types.ErrMockError)
+	workloads := []*types.Workload{
+		{ID: "a", Name: "test", Nodename: "test", Engine: engine, Resources: resourcetypes.Resources{"cpumem": {"cpu": 1}}},
+		{ID: "b", Name: "test", Nodename: "test", Engine: engine, Resources: resourcetypes.Resources{"cpumem": {"cpu": 2}}},
+	}
+	store := c.store.(*storemocks.Store)
+	store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
+	store.On("GetWorkloads", mock.Anything, mock.Anything).Return(workloads, nil)
+	store.On("GetNode", mock.Anything, mock.Anything).Return(&types.Node{NodeMeta: types.NodeMeta{Name: "test"}}, nil)
+	store.On("RemoveWorkload", mock.Anything, mock.Anything).Return(nil)
+	store.On("AddWorkload", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	store.On("ListNodeWorkloads", mock.Anything, mock.Anything, mock.Anything).Return(nil, types.ErrMockError)
+	rmgr := c.rmgr.(*resourcemocks.Manager)
+	released := mock.MatchedBy(func(r []resourcetypes.Resources) bool { return len(r) == 2 })
+	rmgr.On("SetNodeResourceUsage", mock.Anything, "test", mock.Anything, mock.Anything, released, true, plugins.Decr).Return(nil, nil, nil).Once()
+	restored := mock.MatchedBy(func(r []resourcetypes.Resources) bool { return len(r) == 1 && r[0]["cpumem"]["cpu"] == 2 })
+	rmgr.On("SetNodeResourceUsage", mock.Anything, "test", mock.Anything, mock.Anything, restored, true, plugins.Incr).Return(nil, nil, nil).Once()
+
+	ch, err := c.RemoveWorkload(ctx, []string{"a", "b"}, false)
+	assert.NoError(t, err)
+	results := map[string]bool{}
+	for r := range ch {
+		results[r.WorkloadID] = r.Success
+	}
+	assert.Equal(t, map[string]bool{"a": true, "b": false}, results)
+	rmgr.AssertExpectations(t)
 }
 
 func TestRemoveWorkloadJournalsRepairEntries(t *testing.T) {

--- a/cluster/calcium/remove_test.go
+++ b/cluster/calcium/remove_test.go
@@ -1,6 +1,7 @@
 package calcium
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -120,6 +121,38 @@ func TestRemoveWorkloadReleasesResourcesOnce(t *testing.T) {
 		results[r.WorkloadID] = r.Success
 	}
 	assert.Equal(t, map[string]bool{"a": true, "b": false}, results)
+	rmgr.AssertExpectations(t)
+}
+
+func TestRemoveWorkloadGivesUnvisitedWorkloadsTheirResourcesBack(t *testing.T) {
+	c := NewTestCluster()
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	lock := &lockmocks.DistributedLock{}
+	lock.On("Lock", mock.Anything).Return(ctx, nil)
+	lock.On("Unlock", mock.Anything).Return(nil)
+	engine := &enginemocks.API{}
+	engine.On("VirtualizationRemove", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	workloads := []*types.Workload{
+		{ID: "a", Name: "test", Nodename: "test", Engine: engine, Resources: resourcetypes.Resources{"cpumem": {"cpu": 1}}},
+		{ID: "b", Name: "test", Nodename: "test", Engine: engine, Resources: resourcetypes.Resources{"cpumem": {"cpu": 2}}},
+	}
+	store := c.store.(*storemocks.Store)
+	store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
+	store.On("GetWorkloads", mock.Anything, mock.Anything).Return(workloads, nil)
+	store.On("GetNode", mock.Anything, mock.Anything).Return(&types.Node{NodeMeta: types.NodeMeta{Name: "test"}}, nil)
+	store.On("RemoveWorkload", mock.Anything, mock.Anything).Return(nil)
+	rmgr := c.rmgr.(*resourcemocks.Manager)
+	released := mock.MatchedBy(func(r []resourcetypes.Resources) bool { return len(r) == 2 })
+	rmgr.On("SetNodeResourceUsage", mock.Anything, "test", mock.Anything, mock.Anything, released, true, plugins.Decr).Run(func(mock.Arguments) { cancel() }).Return(nil, nil, nil).Once()
+	restored := mock.MatchedBy(func(r []resourcetypes.Resources) bool { return len(r) == 1 && r[0]["cpumem"]["cpu"] == 2 })
+	rmgr.On("SetNodeResourceUsage", mock.Anything, "test", mock.Anything, mock.Anything, restored, true, plugins.Incr).Return(nil, nil, nil).Once()
+
+	ch, err := c.RemoveWorkload(ctx, []string{"a", "b"}, false)
+	assert.NoError(t, err)
+	time.Sleep(500 * time.Millisecond)
+	for range ch { //nolint:revive
+	}
 	rmgr.AssertExpectations(t)
 }
 

--- a/cluster/calcium/wal_test.go
+++ b/cluster/calcium/wal_test.go
@@ -373,7 +373,7 @@ func TestHandleCreateLambda(t *testing.T) {
 		Once()
 	store.On("GetWorkloads", mock.Anything, []string{wrk.ID}).
 		Return([]*types.Workload{wrk}, nil).
-		Twice()
+		Times(3)
 	store.On("RemoveWorkload", mock.Anything, wrk).
 		Return(nil).
 		Once()

--- a/selfmon/selfmon.go
+++ b/selfmon/selfmon.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/projecteru2/core/cluster"
 	"github.com/projecteru2/core/log"
@@ -15,7 +16,11 @@ import (
 	"github.com/projecteru2/core/wal"
 )
 
-const ActiveKey = "/selfmon/active"
+const (
+	ActiveKey = "/selfmon/active"
+
+	nodeStatusHandlers = 16
+)
 
 // NodeStatusWatcher watches node status changes.
 type NodeStatusWatcher struct {
@@ -166,13 +171,19 @@ func (n *NodeStatusWatcher) monitor(ctx context.Context) error {
 	logger.Info(ctx, "watch node status started")
 	defer logger.Info(ctx, "stop watching node status")
 
+	var handlers errgroup.Group
+	handlers.SetLimit(nodeStatusHandlers)
+	defer func() { _ = handlers.Wait() }()
 	for {
 		select {
 		case message, ok := <-messageChan:
 			if !ok {
 				return types.ErrMessageChanClosed
 			}
-			go n.dealNodeStatusMessage(ctx, message)
+			handlers.Go(func() error {
+				n.dealNodeStatusMessage(ctx, message)
+				return nil
+			})
 		case <-ctx.Done():
 			return ctx.Err()
 		}


### PR DESCRIPTION
Stacked on #703 (the calcium round); rebases to one commit once #703 lands.

## What

`RemoveWorkload` released resources one workload at a time through `withResourceReleased`, and every release fans out to every plugin: removing N workloads from one node cost N exec pairs per binary plugin and 2N store round trips for cpumem (C1-05, the mechanism behind the ~1.2ms/workload attributed to plugin exec on the testbed).

Per node, under the pod lock: the workloads are re-read (so a realloc that landed before the lock is seen), their resources are released in **one** `SetNodeResourceUsage(Decr)`, each workload is removed under its own lock as before, and the ones that could not be removed get their resources back in **one** `SetNodeResourceUsage(Incr)`, run off the request context with `GlobalTimeout` so a caller that left mid-way cannot leave them unaccounted. A node whose lock or resource release fails reports every workload of that node as failed, with the error, instead of one anonymous failure.

`withResourceReleased` stays for `DissociateWorkload`.

## Tests

`TestRemoveWorkloadReleasesResourcesOnce`: two workloads, one engine removal fails; one Decr with both resources, one Incr with the failed workload's resources, per-workload results. Existing journal test still sees `allocate-workload` then `create-workload`.

## Gates

`GOWORK=off go build ./...`, `go vet`, `go test -count=1 -race ./cluster/calcium/`, `make lint fmt-check` on GOOS=linux and darwin (0 issues each), `asl ./...` both GOOS (no findings), zero comments added.
