### PR TITLE
fix: drop the conflict markers left by the plugin protocol merge

### DIFF
--- a/metrics/handler.go
+++ b/metrics/handler.go
@@ -4,10 +4,6 @@ import (
 	"context"
 	"net/http"
 
-<<<<<<< HEAD
-	"golang.org/x/sync/errgroup"
-=======
->>>>>>> 5350685c
 	"golang.org/x/sync/singleflight"
 
 	"github.com/projecteru2/core/cluster"
@@ -15,39 +11,13 @@ import (
 	"github.com/projecteru2/core/types"
 )
 
-<<<<<<< HEAD
-const scrapeFanout = 8
-
-// ResourceMiddleware refreshes node metrics before the wrapped handler runs; overlapping scrapes share one refresh, which outlives the scrape that started it.
-func (m *Metrics) ResourceMiddleware(cluster cluster.Cluster) func(http.Handler) http.Handler {
-=======
 // ResourceMiddleware refreshes node metrics before the wrapped handler runs; overlapping scrapes share one refresh, which runs under the server's context.
 func (m *Metrics) ResourceMiddleware(ctx context.Context, cluster cluster.Cluster) func(http.Handler) http.Handler {
->>>>>>> 5350685c
 	logger := log.WithFunc("metrics.ResourceMiddleware")
 	var scrapes singleflight.Group
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			refreshed := scrapes.DoChan("refresh", func() (any, error) {
-<<<<<<< HEAD
-				ctx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), m.Config.GlobalTimeout)
-				defer cancel()
-				nodes, err := cluster.ListPodNodes(ctx, &types.ListNodesOptions{All: true})
-				if err != nil {
-					logger.Error(ctx, err, "failed to list nodes")
-					return nil, err
-				}
-				var g errgroup.Group
-				g.SetLimit(scrapeFanout)
-				for node := range nodes {
-					g.Go(func() error {
-						m.SendPodNodeStatus(ctx, node)
-						m.SendNodeMetrics(ctx, node)
-						return nil
-					})
-				}
-				return nil, g.Wait()
-=======
 				refreshCtx, cancel := context.WithTimeout(ctx, m.Config.GlobalTimeout)
 				defer cancel()
 				nodeCh, err := cluster.ListPodNodes(refreshCtx, &types.ListNodesOptions{All: true})
@@ -62,7 +32,6 @@ func (m *Metrics) ResourceMiddleware(ctx context.Context, cluster cluster.Cluste
 				}
 				m.SendNodesMetrics(refreshCtx, nodes...)
 				return nil, nil
->>>>>>> 5350685c
 			})
 			select {
 			case <-refreshed:

--- a/metrics/handler_test.go
+++ b/metrics/handler_test.go
@@ -18,9 +18,6 @@ import (
 	"github.com/projecteru2/core/types"
 )
 
-<<<<<<< HEAD
-func TestResourceMiddlewareRefreshesNodesConcurrently(t *testing.T) {
-=======
 func TestResourceMiddlewareRefreshesEveryNodeInOneCall(t *testing.T) {
 	cluster := &clustermocks.Cluster{}
 	cluster.On("ListPodNodes", mock.Anything, mock.Anything).Return(twoNodes(), nil).Once()
@@ -39,27 +36,12 @@ func TestResourceMiddlewareRefreshesEveryNodeInOneCall(t *testing.T) {
 }
 
 func TestResourceMiddlewareSharesOneRefreshBetweenOverlappingScrapes(t *testing.T) {
->>>>>>> 5350685c
 	synctest.Test(t, func(t *testing.T) {
 		cluster := &clustermocks.Cluster{}
 		cluster.On("ListPodNodes", mock.Anything, mock.Anything).Return(twoNodes(), nil).Once()
 		rmgr := &resourcemocks.Manager{}
-<<<<<<< HEAD
-		firstStarted := make(chan struct{})
-		secondStarted := make(chan struct{})
-		releaseFirst := make(chan struct{})
-		rmgr.On("GetNodeMetrics", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
-			if args.Get(1).(*types.Node).Name == "n1" {
-				close(firstStarted)
-				<-releaseFirst
-				return
-			}
-			close(secondStarted)
-		}).Return(nil, nil).Twice()
-=======
 		release := make(chan struct{})
 		rmgr.On("GetNodesMetrics", mock.Anything, mock.Anything).Run(func(mock.Arguments) { <-release }).Return(nil, nil).Once()
->>>>>>> 5350685c
 
 		m := &Metrics{Config: types.Config{GlobalTimeout: time.Second}, rmgr: rmgr}
 		served := make(chan struct{}, 2)
@@ -96,90 +78,6 @@ func TestResourceMiddlewareRefreshOutlivesTheScrapeThatStartedIt(t *testing.T) {
 		m := &Metrics{Config: types.Config{GlobalTimeout: time.Second}, rmgr: rmgr}
 		served := make(chan struct{}, 2)
 		handler := m.ResourceMiddleware(t.Context(), cluster)(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
-			served <- struct{}{}
-		}))
-		leaderCtx, leaveLeader := context.WithCancel(t.Context())
-		go handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/metrics", nil).WithContext(leaderCtx))
-		synctest.Wait()
-		go handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/metrics", nil))
-		synctest.Wait()
-<<<<<<< HEAD
-		select {
-		case <-secondStarted:
-		default:
-			t.Error("second node refresh waited for the first")
-		}
-		select {
-		case <-served:
-			t.Error("scrape handler served before every node was refreshed")
-		default:
-		}
-=======
->>>>>>> 5350685c
-
-		leaveLeader()
-		synctest.Wait()
-<<<<<<< HEAD
-		select {
-		case <-served:
-		default:
-			t.Error("scrape handler was not served")
-		}
-=======
-		assert.Empty(t, served)
-
-		close(release)
-		synctest.Wait()
-		assert.Len(t, served, 1)
-		assert.Zero(t, cancelled.Load())
-		rmgr.AssertExpectations(t)
->>>>>>> 5350685c
-	})
-}
-
-func TestResourceMiddlewareSharesOneRefreshBetweenOverlappingScrapes(t *testing.T) {
-	synctest.Test(t, func(t *testing.T) {
-		cluster := &clustermocks.Cluster{}
-		cluster.On("ListPodNodes", mock.Anything, mock.Anything).Return(twoNodes(), nil).Once()
-		rmgr := &resourcemocks.Manager{}
-		release := make(chan struct{})
-		rmgr.On("GetNodeMetrics", mock.Anything, mock.Anything).Run(func(mock.Arguments) { <-release }).Return(nil, nil).Twice()
-
-		m := &Metrics{Config: types.Config{GlobalTimeout: time.Second}, rmgr: rmgr}
-		served := make(chan struct{}, 2)
-		handler := m.ResourceMiddleware(cluster)(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
-			served <- struct{}{}
-		}))
-		for range 2 {
-			go handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/metrics", nil))
-		}
-		synctest.Wait()
-		close(release)
-		synctest.Wait()
-
-		assert.Len(t, served, 2)
-		cluster.AssertExpectations(t)
-		rmgr.AssertExpectations(t)
-	})
-}
-
-func TestResourceMiddlewareRefreshOutlivesTheScrapeThatStartedIt(t *testing.T) {
-	synctest.Test(t, func(t *testing.T) {
-		cluster := &clustermocks.Cluster{}
-		cluster.On("ListPodNodes", mock.Anything, mock.Anything).Return(twoNodes(), nil).Once()
-		rmgr := &resourcemocks.Manager{}
-		release := make(chan struct{})
-		var cancelled atomic.Int32
-		rmgr.On("GetNodeMetrics", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
-			<-release
-			if args.Get(0).(context.Context).Err() != nil {
-				cancelled.Add(1)
-			}
-		}).Return(nil, nil).Twice()
-
-		m := &Metrics{Config: types.Config{GlobalTimeout: time.Second}, rmgr: rmgr}
-		served := make(chan struct{}, 2)
-		handler := m.ResourceMiddleware(cluster)(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
 			served <- struct{}{}
 		}))
 		leaderCtx, leaveLeader := context.WithCancel(t.Context())

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -938,20 +938,12 @@ func logUnsentMessages(ctx context.Context, msgType string, err error, msg any) 
 
 func recvStdin[T any](ctx context.Context, name string, open bool, recv func() (T, error), payload func(T) []byte) <-chan []byte {
 	inCh := make(chan []byte)
-<<<<<<< HEAD
 	if !open {
 		close(inCh)
 		return inCh
 	}
 	utils.SentryGo(func() {
 		defer close(inCh)
-=======
-	utils.SentryGo(func() {
-		defer close(inCh)
-		if !open {
-			return
-		}
->>>>>>> 5350685c
 		for {
 			msg, err := recv()
 			if err != nil {
@@ -970,11 +962,7 @@ func recvStdin[T any](ctx context.Context, name string, open bool, recv func() (
 	return inCh
 }
 
-<<<<<<< HEAD
 func drain[T, R any](t *task, name string, ch <-chan T, send sender[R], to converter[T, R]) {
-=======
-func drain[T, R any](t *task, name string, ch <-chan T, send func(R) error, to func(T) R) {
->>>>>>> 5350685c
 	for m := range ch {
 		if err := send(to(m)); err != nil {
 			logUnsentMessages(t.context, name, err, m)
@@ -982,11 +970,7 @@ func drain[T, R any](t *task, name string, ch <-chan T, send func(R) error, to f
 	}
 }
 
-<<<<<<< HEAD
 func drainUntilStop[T, R any](t *task, name string, code codes.Code, stop <-chan struct{}, ch <-chan T, send sender[R], to converter[T, R]) error {
-=======
-func drainUntilStop[T, R any](t *task, name string, code codes.Code, stop <-chan struct{}, ch <-chan T, send func(R) error, to func(T) R) error {
->>>>>>> 5350685c
 	for {
 		select {
 		case m, ok := <-ch:


### PR DESCRIPTION
master 17e09a5a does not build: the squash of #708 was taken against a base that no longer carried #702's final commits, and three files kept their conflict markers. This restores rpc/rpc.go, metrics/handler.go and metrics/handler_test.go to the state of the integration tree that ran the lane regression, and master then matches that tree file for file.