### PR TITLE
fix: drop the status read helper the lease merges left unused

### DIFF
--- a/store/etcdv3/meta/etcd.go
+++ b/store/etcdv3/meta/etcd.go
@@ -266,29 +266,6 @@ func (e *ETCD) batchPut(ctx context.Context, data map[string]string, cond *txnCo
 	return e.doBatchOp(ctx, txnes)
 }
 
-func (e *ETCD) currentStatus(ctx context.Context, key string, ttl int64) (*mvccpb.KeyValue, bool, error) {
-	kv, err := e.GetOne(ctx, key)
-	if err != nil {
-		if errors.Is(err, types.ErrInvaildCount) {
-			return nil, ttl != 0, nil
-		}
-		return nil, false, err
-	}
-	if kv.Lease == 0 {
-		return kv, ttl != 0, nil
-	}
-
-	granted, err := e.cliv3.TimeToLive(ctx, clientv3.LeaseID(kv.Lease))
-	if err != nil {
-		return nil, false, err
-	}
-	changed := granted.GrantedTTL != ttl
-	if changed {
-		log.WithFunc("store.etcdv3.meta.currentStatus").Infof(ctx, "key %+v ttl changed from %+v to %+v", key, granted.GrantedTTL, ttl)
-	}
-	return kv, changed, nil
-}
-
 func (e *ETCD) bindStatusWithTTL(ctx context.Context, entityKey, statusKey, statusValue string, ttl int64) error {
 	logger := log.WithFunc("store.etcdv3.meta.bindStatusWithTTL")
 	renewed, err := e.cliv3.Txn(ctx).


### PR DESCRIPTION
The merge of #704 with #700 kept #700's no-ttl path, so `currentStatus` in store/etcdv3/meta/etcd.go has no caller left and `make lint` fails on master with one unused finding. This removes the helper; no behavior change.