### PR TITLE
refactor: use the shared orphan status ttl in the etcd store

### DIFF
--- a/store/etcdv3/meta/etcd.go
+++ b/store/etcdv3/meta/etcd.go
@@ -20,6 +20,7 @@ import (
 	"github.com/projecteru2/core/lock/etcdlock"
 	"github.com/projecteru2/core/log"
 	embedded "github.com/projecteru2/core/store/etcdv3/embedded"
+	"github.com/projecteru2/core/store/common"
 	"github.com/projecteru2/core/types"
 )
 
@@ -31,7 +32,6 @@ const (
 
 	txnLimit = 125
 
-	orphanStatusTTL = int64(time.Hour / time.Second)
 )
 
 // ETCDClientV3 is the etcd client surface the store depends on.
@@ -331,7 +331,7 @@ func (e *ETCD) bindStatusWithoutTTL(ctx context.Context, entityKey, statusKey, s
 		return nil
 	}
 
-	lease, err := e.cliv3.Grant(ctx, orphanStatusTTL)
+	lease, err := e.cliv3.Grant(ctx, common.OrphanStatusTTL)
 	if err != nil {
 		return err
 	}
@@ -349,7 +349,7 @@ func (e *ETCD) bindStatusWithoutTTL(ctx context.Context, entityKey, statusKey, s
 		logger.Infof(ctx, "put: key %s value %s", statusKey, statusValue)
 		return nil
 	}
-	logger.Infof(ctx, "put: key %s value %s, leased %ds without %s", statusKey, statusValue, orphanStatusTTL, entityKey)
+	logger.Infof(ctx, "put: key %s value %s, leased %ds without %s", statusKey, statusValue, common.OrphanStatusTTL, entityKey)
 	return nil
 }
 

--- a/store/etcdv3/meta/etcd.go
+++ b/store/etcdv3/meta/etcd.go
@@ -19,8 +19,8 @@ import (
 	"github.com/projecteru2/core/lock"
 	"github.com/projecteru2/core/lock/etcdlock"
 	"github.com/projecteru2/core/log"
-	embedded "github.com/projecteru2/core/store/etcdv3/embedded"
 	"github.com/projecteru2/core/store/common"
+	embedded "github.com/projecteru2/core/store/etcdv3/embedded"
 	"github.com/projecteru2/core/types"
 )
 
@@ -31,7 +31,6 @@ const (
 	cmpValue   = "value"
 
 	txnLimit = 125
-
 )
 
 // ETCDClientV3 is the etcd client surface the store depends on.


### PR DESCRIPTION
store/common.OrphanStatusTTL already bounds a status reported before its entity on the redis backend; the etcd store kept a private constant with the same value. One definition now; no behavior change.