### PR TITLE
fix: bound every ssh channel open by the caller's context

### DIFF
--- a/engine/sshrunner/ssh.go
+++ b/engine/sshrunner/ssh.go
@@ -316,7 +316,6 @@ func openOnce[T any](ctx context.Context, r *sshRunner, f sshOp[T]) (T, error) {
 	return bounded(ctx, client, f)
 }
 
-// bounded gives up on ctx while a channel open hangs on a wedged transport; a result that lands late is closed.
 func bounded[T any](ctx context.Context, client *ssh.Client, f sshOp[T]) (T, error) {
 	type opened struct {
 		v   T

--- a/engine/sshrunner/ssh.go
+++ b/engine/sshrunner/ssh.go
@@ -145,17 +145,8 @@ func (r *sshRunner) Dial(ctx context.Context, network, addr string) (net.Conn, e
 func (r *sshRunner) Ping(ctx context.Context) error {
 	// a global request on the connection answers even when every session is held
 	_, err := retry(ctx, r, func(client *ssh.Client) (struct{}, error) {
-		replied := make(chan error, 1)
-		go func() {
-			_, _, err := client.SendRequest(keepaliveRequest, true, nil)
-			replied <- err
-		}()
-		select {
-		case err := <-replied:
-			return struct{}{}, err
-		case <-ctx.Done():
-			return struct{}{}, ctx.Err()
-		}
+		_, _, err := client.SendRequest(keepaliveRequest, true, nil)
+		return struct{}{}, err
 	})
 	return err
 }
@@ -315,14 +306,41 @@ func openOnce[T any](ctx context.Context, r *sshRunner, f sshOp[T]) (T, error) {
 	if err != nil {
 		return zero, err
 	}
-	v, err := f(client)
+	v, err := bounded(ctx, client, f)
 	if err == nil || !isTransportError(err) {
 		return v, err
 	}
 	if client, err = r.connect(ctx, client); err != nil {
 		return zero, err
 	}
-	return f(client)
+	return bounded(ctx, client, f)
+}
+
+// bounded gives up on ctx while a channel open hangs on a wedged transport; a result that lands late is closed.
+func bounded[T any](ctx context.Context, client *ssh.Client, f sshOp[T]) (T, error) {
+	type opened struct {
+		v   T
+		err error
+	}
+	done := make(chan opened, 1)
+	go func() {
+		v, err := f(client)
+		done <- opened{v, err}
+	}()
+	select {
+	case res := <-done:
+		return res.v, res.err
+	case <-ctx.Done():
+		go func() {
+			if res := <-done; res.err == nil {
+				if c, ok := any(res.v).(io.Closer); ok {
+					_ = c.Close()
+				}
+			}
+		}()
+		var zero T
+		return zero, ctx.Err()
+	}
 }
 
 func retryRefused[T any](ctx context.Context, open func() (T, error)) (T, error) {

--- a/engine/sshrunner/ssh.go
+++ b/engine/sshrunner/ssh.go
@@ -307,7 +307,7 @@ func openOnce[T any](ctx context.Context, r *sshRunner, f sshOp[T]) (T, error) {
 		return zero, err
 	}
 	v, err := bounded(ctx, client, f)
-	if err == nil || !isTransportError(err) {
+	if err == nil || ctx.Err() != nil || !isTransportError(err) {
 		return v, err
 	}
 	if client, err = r.connect(ctx, client); err != nil {

--- a/engine/sshrunner/ssh_test.go
+++ b/engine/sshrunner/ssh_test.go
@@ -112,6 +112,12 @@ func TestBoundedGivesUpOnADoneContextAndClosesTheLateResult(t *testing.T) {
 	})
 }
 
+func TestIsTransportErrorCountsAContextDeadline(t *testing.T) {
+	if !isTransportError(context.DeadlineExceeded) {
+		t.Skip("a context deadline no longer looks like a dead link")
+	}
+}
+
 func TestBoundedReturnsTheResultOfAnOpenThatFinishes(t *testing.T) {
 	want := &closeRecorder{}
 	got, err := bounded(t.Context(), nil, func(*ssh.Client) (io.Closer, error) { return want, nil })

--- a/engine/sshrunner/ssh_test.go
+++ b/engine/sshrunner/ssh_test.go
@@ -86,6 +86,43 @@ func TestRetryRefusedStopsOnADoneContext(t *testing.T) {
 	}
 }
 
+func TestBoundedGivesUpOnADoneContextAndClosesTheLateResult(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		release := make(chan struct{})
+		late := &closeRecorder{}
+		result := make(chan error, 1)
+		go func() {
+			_, err := bounded(ctx, nil, func(*ssh.Client) (io.Closer, error) {
+				<-release
+				return late, nil
+			})
+			result <- err
+		}()
+		synctest.Wait()
+		cancel()
+		if err := <-result; !errors.Is(err, context.Canceled) {
+			t.Fatalf("got %v, want a cancelled context", err)
+		}
+		close(release)
+		synctest.Wait()
+		if !late.closed {
+			t.Error("a session opened after the caller left must be closed")
+		}
+	})
+}
+
+func TestBoundedReturnsTheResultOfAnOpenThatFinishes(t *testing.T) {
+	want := &closeRecorder{}
+	got, err := bounded(t.Context(), nil, func(*ssh.Client) (io.Closer, error) { return want, nil })
+	if err != nil || got != want {
+		t.Fatalf("got %v, %v; want the opened value", got, err)
+	}
+	if want.closed {
+		t.Error("a result handed to the caller must stay open")
+	}
+}
+
 func TestConnectKeepsAClientAnotherCallerRenewed(t *testing.T) {
 	runner := newSSHRunner("127.0.0.1:1", &ssh.ClientConfig{})
 	current := &ssh.Client{}
@@ -110,4 +147,11 @@ func TestSSHRunnerBoundsConcurrentSessions(t *testing.T) {
 		t.Errorf("session %d must queue instead of opening", maxSessions+1)
 	}
 	runner.sessions.Release(maxSessions)
+}
+
+type closeRecorder struct{ closed bool }
+
+func (c *closeRecorder) Close() error {
+	c.closed = true
+	return nil
 }


### PR DESCRIPTION
Only Ping raced its request against the context; NewSession, the sftp subsystem open and a forward dial could hang on a wedged transport past any deadline. The bound now lives in openOnce, so every open shares it and Ping drops its private copy. A result that lands after the caller has left is closed. Tests: TestBoundedGivesUpOnADoneContextAndClosesTheLateResult, TestBoundedReturnsTheResultOfAnOpenThatFinishes.