### PR TITLE
fix: let every calcium producer give up when its caller is gone

### DIFF
--- a/cluster/calcium/build.go
+++ b/cluster/calcium/build.go
@@ -149,7 +149,9 @@ func (c *Calcium) pushImageAndClean(ctx context.Context, resp io.ReadCloser, nod
 				logger.Errorf(ctx, err, "decode build image message failed, buffered: %s", malformed)
 				return
 			}
-			ch <- message
+			if send(ctx, ch, message) != nil {
+				return
+			}
 			lastMessage = message
 		}
 
@@ -163,15 +165,21 @@ func (c *Calcium) pushImageAndClean(ctx context.Context, resp io.ReadCloser, nod
 			rc, err := node.Engine.ImagePush(ctx, tag)
 			if err != nil {
 				logger.Error(ctx, err)
-				ch <- &types.BuildImageMessage{Error: err.Error()}
+				if send(ctx, ch, &types.BuildImageMessage{Error: err.Error()}) != nil {
+					return
+				}
 				continue
 			}
 
 			for message := range c.processBuildImageStream(ctx, rc) {
-				ch <- message
+				if send(ctx, ch, message) != nil {
+					return
+				}
 			}
 
-			ch <- &types.BuildImageMessage{Stream: fmt.Sprintf("finished %s\n", tag), Status: "finished", Progress: tag}
+			if send(ctx, ch, &types.BuildImageMessage{Stream: fmt.Sprintf("finished %s\n", tag), Status: "finished", Progress: tag}) != nil {
+				return
+			}
 		}
 		_ = c.pool.Invoke(func() {
 			cleanupNodeImages(ctx, node, tags, c.config.GlobalTimeout)

--- a/cluster/calcium/control.go
+++ b/cluster/calcium/control.go
@@ -57,11 +57,11 @@ func (c *Calcium) ControlWorkload(ctx context.Context, IDs []string, typ string,
 				} else {
 					logger.Error(ctx, err)
 				}
-				ch <- &types.ControlWorkloadMessage{
+				_ = send(ctx, ch, &types.ControlWorkloadMessage{
 					WorkloadID: ID,
 					Error:      err,
 					Hook:       message,
-				}
+				})
 			})
 		}
 	})

--- a/cluster/calcium/copy.go
+++ b/cluster/calcium/copy.go
@@ -33,10 +33,8 @@ func (c *Calcium) Copy(ctx context.Context, opts *types.CopyOptions) (chan *type
 				if err != nil {
 					logger.Error(ctx, err)
 					for _, path := range paths {
-						ch <- &types.CopyMessage{
-							ID:    ID,
-							Path:  path,
-							Error: err,
+						if send(ctx, ch, &types.CopyMessage{ID: ID, Path: path, Error: err}) != nil {
+							return
 						}
 					}
 					return
@@ -44,7 +42,7 @@ func (c *Calcium) Copy(ctx context.Context, opts *types.CopyOptions) (chan *type
 
 				for _, path := range paths {
 					content, uid, gid, mode, err := workload.Engine.VirtualizationCopyFrom(ctx, workload.ID, path)
-					ch <- &types.CopyMessage{
+					if send(ctx, ch, &types.CopyMessage{
 						ID:       ID,
 						Path:     path,
 						Error:    err,
@@ -53,6 +51,8 @@ func (c *Calcium) Copy(ctx context.Context, opts *types.CopyOptions) (chan *type
 						UID:      uid,
 						GID:      gid,
 						Mode:     mode,
+					}) != nil {
+						return
 					}
 				}
 			})

--- a/cluster/calcium/create.go
+++ b/cluster/calcium/create.go
@@ -50,6 +50,7 @@ func (c *Calcium) doCreateWorkloads(ctx context.Context, opts *types.DeployOptio
 		workloadResourcesMap = map[string][]resourcetypes.Resources{}
 	)
 
+	caller := ctx
 	utils.SentryGo(func() {
 		var resourceCommit func()
 		var processingCommits map[string]func()
@@ -76,7 +77,7 @@ func (c *Calcium) doCreateWorkloads(ctx context.Context, opts *types.DeployOptio
 				defer func() {
 					if err != nil {
 						logger.Error(ctx, err)
-						ch <- &types.CreateWorkloadMessage{Error: err}
+						_ = send(caller, ch, &types.CreateWorkloadMessage{Error: err})
 					}
 				}()
 				return c.withNodesPodLocked(ctx, opts.NodeFilter, func(ctx context.Context, nodeMap map[string]*types.Node) (err error) {
@@ -116,7 +117,7 @@ func (c *Calcium) doCreateWorkloads(ctx context.Context, opts *types.DeployOptio
 			},
 
 			func(ctx context.Context) (err error) {
-				rollbackMap, err = c.doDeployWorkloads(ctx, ch, opts, engineParamsMap, workloadResourcesMap, deployMap)
+				rollbackMap, err = c.doDeployWorkloads(ctx, func(msg *types.CreateWorkloadMessage) { _ = send(caller, ch, msg) }, opts, engineParamsMap, workloadResourcesMap, deployMap)
 				return err
 			},
 
@@ -153,7 +154,7 @@ func (c *Calcium) doCreateWorkloads(ctx context.Context, opts *types.DeployOptio
 }
 
 func (c *Calcium) doDeployWorkloads(ctx context.Context,
-	ch chan *types.CreateWorkloadMessage,
+	emit func(*types.CreateWorkloadMessage),
 	opts *types.DeployOptions,
 	engineParamsMap map[string][]resourcetypes.Resources,
 	workloadResourcesMap map[string][]resourcetypes.Resources,
@@ -176,7 +177,7 @@ func (c *Calcium) doDeployWorkloads(ctx context.Context,
 		seq += deploy
 		wg.Go(func() {
 			defer log.SentryDefer()
-			if indices, deployErr := c.doDeployWorkloadsOnNode(ctx, ch, nodename, opts, deploy, engineParamsMap[nodename], workloadResourcesMap[nodename], start); deployErr != nil {
+			if indices, deployErr := c.doDeployWorkloadsOnNode(ctx, emit, nodename, opts, deploy, engineParamsMap[nodename], workloadResourcesMap[nodename], start); deployErr != nil {
 				rollbackLock.Lock()
 				rollbackMap[nodename] = indices
 				rollbackLock.Unlock()
@@ -193,7 +194,7 @@ func (c *Calcium) doDeployWorkloads(ctx context.Context,
 }
 
 func (c *Calcium) doDeployWorkloadsOnNode(ctx context.Context,
-	ch chan *types.CreateWorkloadMessage,
+	emit func(*types.CreateWorkloadMessage),
 	nodename string,
 	opts *types.DeployOptions,
 	deploy int,
@@ -206,7 +207,7 @@ func (c *Calcium) doDeployWorkloadsOnNode(ctx context.Context,
 	if err != nil {
 		logger.Error(ctx, err)
 		for range deploy {
-			ch <- &types.CreateWorkloadMessage{Error: err}
+			emit(&types.CreateWorkloadMessage{Error: err})
 		}
 		return utils.Range(deploy), err
 	}
@@ -233,7 +234,7 @@ func (c *Calcium) doDeployWorkloadsOnNode(ctx context.Context,
 					indices = append(indices, idx)
 					appendLock.Unlock()
 				}
-				ch <- createMsg
+				emit(createMsg)
 			}()
 
 			createMsg.EngineParams = engineParams[idx]

--- a/cluster/calcium/create_test.go
+++ b/cluster/calcium/create_test.go
@@ -353,7 +353,7 @@ func TestDoDeployWorkloadsOnNodeErrorPerWorkload(t *testing.T) {
 	ch := make(chan *types.CreateWorkloadMessage, deploy)
 	params := make([]resourcetypes.Resources, deploy)
 
-	indices, err := c.doDeployWorkloadsOnNode(ctx, ch, node.Name, opts, deploy, params, params, 0)
+	indices, err := c.doDeployWorkloadsOnNode(ctx, func(m *types.CreateWorkloadMessage) { ch <- m }, node.Name, opts, deploy, params, params, 0)
 	close(ch)
 
 	assert.Error(t, err)

--- a/cluster/calcium/image.go
+++ b/cluster/calcium/image.go
@@ -28,7 +28,9 @@ func (c *Calcium) CacheImage(ctx context.Context, opts *types.ImageOptions) (cha
 				m.Success = false
 				m.Message = err.Error()
 			}
-			ch <- m
+			if send(ctx, ch, m) != nil {
+				return
+			}
 		}
 	}), nil
 }
@@ -56,7 +58,9 @@ func (c *Calcium) RemoveImage(ctx context.Context, opts *types.ImageOptions) (ch
 					m.Messages = append(m.Messages, fmt.Sprintf("Clean: %s", item))
 				}
 			}
-			ch <- m
+			if send(ctx, ch, m) != nil {
+				return
+			}
 		}
 		if opts.Prune {
 			if err := node.Engine.ImagesPrune(ctx); err != nil {
@@ -92,7 +96,7 @@ func (c *Calcium) ListImage(ctx context.Context, opts *types.ImageOptions) (chan
 				})
 			}
 		}
-		ch <- msg
+		_ = send(ctx, ch, msg)
 	}), nil
 }
 

--- a/cluster/calcium/lambda.go
+++ b/cluster/calcium/lambda.go
@@ -40,7 +40,7 @@ func (c *Calcium) RunAndWait(ctx context.Context, opts *types.DeployOptions, inC
 
 	lambda := func(message *types.CreateWorkloadMessage) (attachMessage *types.AttachWorkloadMessage) {
 		defer func() {
-			runMsgCh <- attachMessage
+			_ = send(ctx, runMsgCh, attachMessage)
 		}()
 
 		if message.Error != nil || message.WorkloadID == "" {
@@ -96,10 +96,12 @@ func (c *Calcium) RunAndWait(ctx context.Context, opts *types.DeployOptions, inC
 		}
 
 		for m := range c.processStdStream(ctx, stdout, stderr, splitFunc, split) {
-			runMsgCh <- &types.AttachWorkloadMessage{
+			if send(ctx, runMsgCh, &types.AttachWorkloadMessage{
 				WorkloadID:    message.WorkloadID,
 				Data:          m.Data,
 				StdStreamType: m.StdStreamType,
+			}) != nil {
+				break
 			}
 		}
 

--- a/cluster/calcium/log.go
+++ b/cluster/calcium/log.go
@@ -18,7 +18,7 @@ func (c *Calcium) LogStream(ctx context.Context, opts *types.LogStreamOptions) (
 		workload, err := c.GetWorkload(ctx, opts.ID)
 		if err != nil {
 			logger.Error(ctx, err)
-			ch <- &types.LogStreamMessage{ID: opts.ID, Error: err}
+			_ = send(ctx, ch, &types.LogStreamMessage{ID: opts.ID, Error: err})
 			return
 		}
 
@@ -33,12 +33,14 @@ func (c *Calcium) LogStream(ctx context.Context, opts *types.LogStreamOptions) (
 		})
 		logger.Error(ctx, err)
 		if err != nil {
-			ch <- &types.LogStreamMessage{ID: opts.ID, Error: err}
+			_ = send(ctx, ch, &types.LogStreamMessage{ID: opts.ID, Error: err})
 			return
 		}
 
 		for m := range c.processStdStream(ctx, stdout, stderr, bufio.ScanLines, byte('\n')) {
-			ch <- &types.LogStreamMessage{ID: opts.ID, Data: m.Data, StdStreamType: m.StdStreamType}
+			if send(ctx, ch, &types.LogStreamMessage{ID: opts.ID, Data: m.Data, StdStreamType: m.StdStreamType}) != nil {
+				return
+			}
 		}
 	})
 

--- a/cluster/calcium/log_test.go
+++ b/cluster/calcium/log_test.go
@@ -2,8 +2,10 @@ package calcium
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"testing"
+	"testing/synctest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -47,4 +49,25 @@ func TestLogStream(t *testing.T) {
 		assert.Equal(t, c.ID, ID)
 		assert.NotEmpty(t, c.Data)
 	}
+}
+
+func TestLogStreamStopsWhenTheCallerLeaves(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		c := NewTestCluster()
+		defer c.pool.Release()
+		store := c.store.(*storemocks.Store)
+		engine := &enginemocks.API{}
+		store.On("GetWorkload", mock.Anything, mock.Anything).Return(&types.Workload{ID: "test", Engine: engine}, nil)
+		engine.On("VirtualizationLogs", mock.Anything, mock.Anything).Return(io.NopCloser(bytes.NewBufferString("aaaa\nbbbb\n")), nil, nil)
+		ctx, cancel := context.WithCancel(t.Context())
+
+		ch, err := c.LogStream(ctx, &types.LogStreamOptions{ID: "test"})
+		assert.NoError(t, err)
+		synctest.Wait()
+		cancel()
+		synctest.Wait()
+
+		_, open := <-ch
+		assert.False(t, open, "the stream must close once its reader is gone")
+	})
 }

--- a/cluster/calcium/node.go
+++ b/cluster/calcium/node.go
@@ -151,7 +151,7 @@ func (c *Calcium) ListPodNodes(ctx context.Context, opts *types.ListNodesOptions
 				logger.Errorf(ctx, err, "failed to get node %s info", node.Name)
 			}
 		}
-		ch <- node
+		_ = send(ctx, ch, node)
 	}), nil
 }
 

--- a/cluster/calcium/replace.go
+++ b/cluster/calcium/replace.go
@@ -77,7 +77,7 @@ func (c *Calcium) ReplaceWorkload(ctx context.Context, opts *types.ReplaceOption
 				} else {
 					logger.Infof(ctx, "replaced workload %s with %s", ID, createMessage.WorkloadID)
 				}
-				ch <- &types.ReplaceWorkloadMessage{Create: createMessage, Remove: removeMessage, Error: err}
+				_ = send(ctx, ch, &types.ReplaceWorkloadMessage{Create: createMessage, Remove: removeMessage, Error: err})
 			})
 		}
 	})

--- a/cluster/calcium/send.go
+++ b/cluster/calcium/send.go
@@ -18,6 +18,7 @@ func (c *Calcium) Send(ctx context.Context, opts *types.SendOptions) (chan *type
 		return nil, err
 	}
 	ch := make(chan *types.SendMessage)
+	caller := ctx
 	utils.SentryGo(func() {
 		defer close(ch)
 		wg := &sync.WaitGroup{}
@@ -31,12 +32,14 @@ func (c *Calcium) Send(ctx context.Context, opts *types.SendOptions) (chan *type
 					for _, file := range opts.Files {
 						err := c.doSendFileToWorkload(ctx, workload.Engine, workload.ID, file)
 						logger.Error(ctx, err)
-						ch <- &types.SendMessage{ID: ID, Path: file.Filename, Error: err}
+						if gone := send(caller, ch, &types.SendMessage{ID: ID, Path: file.Filename, Error: err}); gone != nil {
+							return gone
+						}
 					}
 					return nil
 				}); err != nil {
 					logger.Error(ctx, err)
-					ch <- &types.SendMessage{ID: ID, Error: err}
+					_ = send(caller, ch, &types.SendMessage{ID: ID, Error: err})
 				}
 			})
 		}

--- a/cluster/calcium/sendlarge.go
+++ b/cluster/calcium/sendlarge.go
@@ -39,6 +39,7 @@ func (c *Calcium) SendLargeFile(ctx context.Context, inputChan chan *types.SendL
 
 func (c *Calcium) newWorkloadSender(ctx context.Context, ID string, resp chan *types.SendMessage, wg *sync.WaitGroup) chan *types.SendLargeFileOptions {
 	logger := log.WithFunc("calcium.newWorkloadSender")
+	caller := ctx
 	buffer := make(chan *types.SendLargeFileOptions, 10)
 	utils.SentryGo(func() {
 		defer wg.Done()
@@ -60,10 +61,10 @@ func (c *Calcium) newWorkloadSender(ctx context.Context, ID string, resp chan *t
 					defer func() { _ = pr.Close() }()
 					if err := c.withWorkloadLocked(ctx, ID, false, func(ctx context.Context, workload *types.Workload) error {
 						err := errors.WithStack(workload.Engine.VirtualizationCopyChunkTo(ctx, ID, curFile, data.Size, pr, data.UID, data.GID, data.Mode))
-						resp <- &types.SendMessage{ID: ID, Path: curFile, Error: err}
+						_ = send(caller, resp, &types.SendMessage{ID: ID, Path: curFile, Error: err})
 						return nil
 					}); err != nil {
-						resp <- &types.SendMessage{ID: ID, Error: err}
+						_ = send(caller, resp, &types.SendMessage{ID: ID, Error: err})
 					}
 				})
 			}

--- a/cluster/calcium/stream.go
+++ b/cluster/calcium/stream.go
@@ -135,7 +135,9 @@ func (c *Calcium) processVirtualizationOutStream(
 			if split != 0 {
 				bs = append(bs, split)
 			}
-			outCh <- bs
+			if send(ctx, outCh, bs) != nil {
+				return
+			}
 		}
 		if err := scanner.Err(); err != nil {
 			log.WithFunc("calcium.processVirtualizationOutStream").Warnf(ctx, "failed to read output from output stream: %+v", err)
@@ -158,11 +160,13 @@ func (c *Calcium) processBuildImageStream(ctx context.Context, reader io.ReadClo
 					malformed, _ := io.ReadAll(decoder.Buffered())
 					log.WithFunc("calcium.processBuildImageStream").Errorf(ctx, err, "decode image message failed, buffered: %s", string(malformed))
 					message.Error = err.Error()
-					ch <- message
+					_ = send(ctx, ch, message)
 				}
 				break
 			}
-			ch <- message
+			if send(ctx, ch, message) != nil {
+				return
+			}
 		}
 	})
 	return ch
@@ -180,7 +184,9 @@ func (c *Calcium) processStdStream(ctx context.Context, stdout, stderr io.ReadCl
 		wg.Go(func() {
 			defer log.SentryDefer()
 			for data := range c.processVirtualizationOutStream(ctx, source.stream, splitFunc, split) {
-				ch <- types.StdStreamMessage{Data: data, StdStreamType: source.typ}
+				if send(ctx, ch, types.StdStreamMessage{Data: data, StdStreamType: source.typ}) != nil {
+					return
+				}
 			}
 		})
 	}

--- a/cluster/calcium/stream_test.go
+++ b/cluster/calcium/stream_test.go
@@ -3,12 +3,32 @@ package calcium
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"testing"
+	"testing/synctest"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestProcessStdStreamStopsWhenTheCallerLeaves(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		c := NewTestCluster()
+		defer c.pool.Release()
+		ctx, cancel := context.WithCancel(t.Context())
+		stdout := io.NopCloser(bytes.NewBufferString("aaaa\nbbbb\ncccc\n"))
+		stderr := io.NopCloser(bytes.NewBufferString("dddd\n"))
+
+		ch := c.processStdStream(ctx, stdout, stderr, bufio.ScanLines, byte('\n'))
+		synctest.Wait()
+		cancel()
+		synctest.Wait()
+
+		_, open := <-ch
+		require.False(t, open, "the merged stream must close once its reader is gone")
+	})
+}
 
 func TestProcessVirtualizationOutStreamCopiesTokens(t *testing.T) {
 	c := NewTestCluster()


### PR DESCRIPTION
Twenty-five sends in calcium blocked forever once the gRPC stream behind them had ended; remove and dissociate already went through `send` with the request context (#703). Every producer now does, keyed on the caller's context where a lock or transaction context shadows it, and create hands its deploy path an emitter for the same reason. PodResource keeps its bare sends: its channel is buffered to the node count. Tests: TestProcessStdStreamStopsWhenTheCallerLeaves, TestLogStreamStopsWhenTheCallerLeaves.