### PR TITLE
test: wait on the bubble instead of sleeping in the calcium remove, dissociate, set-node and lambda tests

### DIFF
--- a/cluster/calcium/dissociate_test.go
+++ b/cluster/calcium/dissociate_test.go
@@ -2,7 +2,7 @@ package calcium
 
 import (
 	"testing"
-	"time"
+	"testing/synctest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -15,64 +15,67 @@ import (
 )
 
 func TestDissociateWorkload(t *testing.T) {
-	c := NewTestCluster()
-	ctx := t.Context()
-	store := c.store.(*storemocks.Store)
-	rmgr := c.rmgr.(*resourcemocks.Manager)
+	synctest.Test(t, func(t *testing.T) {
+		c := NewTestCluster()
+		defer c.pool.Release()
+		ctx := t.Context()
+		store := c.store.(*storemocks.Store)
+		rmgr := c.rmgr.(*resourcemocks.Manager)
 
-	lock := &lockmocks.DistributedLock{}
-	lock.On("Lock", mock.Anything).Return(ctx, nil)
-	lock.On("Unlock", mock.Anything).Return(nil)
+		lock := &lockmocks.DistributedLock{}
+		lock.On("Lock", mock.Anything).Return(ctx, nil)
+		lock.On("Unlock", mock.Anything).Return(nil)
 
-	c1 := &types.Workload{
-		Resources: resourcetypes.Resources{},
-		ID:        "c1",
-		Podname:   "p1",
-		Nodename:  "node1",
-	}
+		c1 := &types.Workload{
+			Resources: resourcetypes.Resources{},
+			ID:        "c1",
+			Podname:   "p1",
+			Nodename:  "node1",
+		}
 
-	node1 := &types.Node{
-		NodeMeta: types.NodeMeta{
-			Name:     "node1",
-			Endpoint: "http://1.1.1.1:1",
-		},
-	}
+		node1 := &types.Node{
+			NodeMeta: types.NodeMeta{
+				Name:     "node1",
+				Endpoint: "http://1.1.1.1:1",
+			},
+		}
 
-	store.On("GetWorkloads", mock.Anything, mock.Anything).Return([]*types.Workload{c1}, nil)
-	rmgr.On("GetNodeResourceInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
-		nil, nil, nil, nil,
-	)
-	store.On("GetNode", mock.Anything, "node1").Return(node1, nil)
-	store.On("CreateLock", mock.Anything, mock.Anything).Return(nil, types.ErrMockError).Once()
-	ch, err := c.DissociateWorkload(ctx, []string{"c1"})
-	assert.NoError(t, err)
-	for r := range ch {
-		assert.Error(t, r.Error)
-	}
-	store.AssertExpectations(t)
+		store.On("GetWorkloads", mock.Anything, mock.Anything).Return([]*types.Workload{c1}, nil)
+		rmgr.On("GetNodeResourceInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+			nil, nil, nil, nil,
+		)
+		store.On("GetNode", mock.Anything, "node1").Return(node1, nil)
+		store.On("CreateLock", mock.Anything, mock.Anything).Return(nil, types.ErrMockError).Once()
+		ch, err := c.DissociateWorkload(ctx, []string{"c1"})
+		assert.NoError(t, err)
+		for r := range ch {
+			assert.Error(t, r.Error)
+		}
+		store.AssertExpectations(t)
 
-	store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
-	rmgr.On("SetNodeResourceUsage", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
-		resourcetypes.Resources{},
-		resourcetypes.Resources{},
-		nil,
-	)
-	store.On("RemoveWorkload", mock.Anything, mock.Anything).Return(types.ErrMockError).Once()
-	store.On("ListNodeWorkloads", mock.Anything, mock.Anything, mock.Anything).Return(nil, types.ErrMockError)
-	ch, err = c.DissociateWorkload(ctx, []string{"c1"})
-	assert.NoError(t, err)
-	for r := range ch {
-		assert.Error(t, r.Error)
-	}
-	time.Sleep(time.Second)
-	store.AssertExpectations(t)
+		store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
+		rmgr.On("SetNodeResourceUsage", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+			resourcetypes.Resources{},
+			resourcetypes.Resources{},
+			nil,
+		)
+		store.On("RemoveWorkload", mock.Anything, mock.Anything).Return(types.ErrMockError).Once()
+		store.On("ListNodeWorkloads", mock.Anything, mock.Anything, mock.Anything).Return(nil, types.ErrMockError)
+		ch, err = c.DissociateWorkload(ctx, []string{"c1"})
+		assert.NoError(t, err)
+		for r := range ch {
+			assert.Error(t, r.Error)
+		}
+		synctest.Wait()
+		store.AssertExpectations(t)
 
-	store.On("RemoveWorkload", mock.Anything, mock.Anything).Return(nil)
+		store.On("RemoveWorkload", mock.Anything, mock.Anything).Return(nil)
 
-	ch, err = c.DissociateWorkload(ctx, []string{"c1"})
-	assert.NoError(t, err)
-	for r := range ch {
-		assert.NoError(t, r.Error)
-	}
-	store.AssertExpectations(t)
+		ch, err = c.DissociateWorkload(ctx, []string{"c1"})
+		assert.NoError(t, err)
+		for r := range ch {
+			assert.NoError(t, r.Error)
+		}
+		store.AssertExpectations(t)
+	})
 }

--- a/cluster/calcium/node_test.go
+++ b/cluster/calcium/node_test.go
@@ -227,7 +227,9 @@ func TestGetNodeEngine(t *testing.T) {
 }
 
 func TestSetNode(t *testing.T) {
-	factory.InitEngineCache(t.Context(), types.Config{MaxConcurrency: 1, ConnectionTimeout: time.Second}, nil)
+	config := NewTestCluster().config
+	config.ConnectionTimeout = time.Second
+	factory.InitEngineCache(t.Context(), config, nil)
 	synctest.Test(t, func(t *testing.T) {
 		c := NewTestCluster()
 		defer c.pool.Release()

--- a/cluster/calcium/node_test.go
+++ b/cluster/calcium/node_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -226,64 +227,68 @@ func TestGetNodeEngine(t *testing.T) {
 }
 
 func TestSetNode(t *testing.T) {
-	c := NewTestCluster()
-	ctx := t.Context()
+	factory.InitEngineCache(t.Context(), types.Config{MaxConcurrency: 1, ConnectionTimeout: time.Second}, nil)
+	synctest.Test(t, func(t *testing.T) {
+		c := NewTestCluster()
+		defer c.pool.Release()
+		ctx := t.Context()
 
-	opts := &types.SetNodeOptions{}
+		opts := &types.SetNodeOptions{}
 
-	_, err := c.SetNode(ctx, opts)
-	assert.Error(t, err)
+		_, err := c.SetNode(ctx, opts)
+		assert.Error(t, err)
 
-	store := c.store.(*storemocks.Store)
-	lock := &lockmocks.DistributedLock{}
-	lock.On("Lock", mock.Anything).Return(ctx, nil)
-	lock.On("Unlock", mock.Anything).Return(nil)
-	store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
-	name := "test"
-	opts.Nodename = name
-	node := &types.Node{NodeMeta: types.NodeMeta{Name: name}}
-	store.On("GetNode", mock.Anything, mock.Anything).Return(node, nil)
+		store := c.store.(*storemocks.Store)
+		lock := &lockmocks.DistributedLock{}
+		lock.On("Lock", mock.Anything).Return(ctx, nil)
+		lock.On("Unlock", mock.Anything).Return(nil)
+		store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
+		name := "test"
+		opts.Nodename = name
+		node := &types.Node{NodeMeta: types.NodeMeta{Name: name}}
+		store.On("GetNode", mock.Anything, mock.Anything).Return(node, nil)
 
-	rmgr := c.rmgr.(*resourcemocks.Manager)
-	rmgr.On("GetNodeResourceInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil, nil, types.ErrMockError).Once()
-	_, err = c.SetNode(ctx, opts)
-	assert.Error(t, err)
-	rmgr.On("GetNodeResourceInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil, nil, nil)
+		rmgr := c.rmgr.(*resourcemocks.Manager)
+		rmgr.On("GetNodeResourceInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil, nil, types.ErrMockError).Once()
+		_, err = c.SetNode(ctx, opts)
+		assert.Error(t, err)
+		rmgr.On("GetNodeResourceInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil, nil, nil)
 
-	opts.Bypass = types.TriTrue
-	opts.WorkloadsDown = true
-	workloads := []*types.Workload{{ID: "1", Name: "wrong_name"}, {ID: "2", Name: "a_b_c"}}
-	store.On("ListNodeWorkloads", mock.Anything, mock.Anything, mock.Anything).Return(workloads, nil)
-	store.On("SetWorkloadStatus", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		opts.Bypass = types.TriTrue
+		opts.WorkloadsDown = true
+		workloads := []*types.Workload{{ID: "1", Name: "wrong_name"}, {ID: "2", Name: "a_b_c"}}
+		store.On("ListNodeWorkloads", mock.Anything, mock.Anything, mock.Anything).Return(workloads, nil)
+		store.On("SetWorkloadStatus", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
-	endpoint := "mock://test2"
-	opts.Endpoint = endpoint
+		endpoint := "mock://test2"
+		opts.Endpoint = endpoint
 
-	labels := map[string]string{"a": "1", "b": "2"}
-	opts.Labels = labels
+		labels := map[string]string{"a": "1", "b": "2"}
+		opts.Labels = labels
 
-	opts.Resources = resourcetypes.Resources{"a": {"a": 1}}
-	rmgr.On("SetNodeResourceCapacity", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
-		nil, nil, types.ErrMockError,
-	).Once()
-	_, err = c.SetNode(ctx, opts)
-	assert.Error(t, err)
-	rmgr.On("SetNodeResourceCapacity", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
-		nil, nil, nil,
-	)
+		opts.Resources = resourcetypes.Resources{"a": {"a": 1}}
+		rmgr.On("SetNodeResourceCapacity", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+			nil, nil, types.ErrMockError,
+		).Once()
+		_, err = c.SetNode(ctx, opts)
+		assert.Error(t, err)
+		rmgr.On("SetNodeResourceCapacity", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+			nil, nil, nil,
+		)
 
-	store.On("UpdateNodes", mock.Anything, mock.Anything).Return(types.ErrMockError).Once()
-	_, err = c.SetNode(ctx, opts)
-	assert.Error(t, err)
-	store.On("UpdateNodes", mock.Anything, mock.Anything).Return(nil)
+		store.On("UpdateNodes", mock.Anything, mock.Anything).Return(types.ErrMockError).Once()
+		_, err = c.SetNode(ctx, opts)
+		assert.Error(t, err)
+		store.On("UpdateNodes", mock.Anything, mock.Anything).Return(nil)
 
-	node, err = c.SetNode(ctx, opts)
-	assert.NoError(t, err)
-	assert.Equal(t, node.Endpoint, endpoint)
-	assert.Equal(t, labels["a"], node.Labels["a"])
-	store.AssertExpectations(t)
-	time.Sleep(100 * time.Millisecond)
-	rmgr.AssertExpectations(t)
+		node, err = c.SetNode(ctx, opts)
+		assert.NoError(t, err)
+		assert.Equal(t, node.Endpoint, endpoint)
+		assert.Equal(t, labels["a"], node.Labels["a"])
+		store.AssertExpectations(t)
+		synctest.Wait()
+		rmgr.AssertExpectations(t)
+	})
 }
 
 func TestSetWorkloadsDownDoesNotWaitForThePool(t *testing.T) {

--- a/cluster/calcium/remove_test.go
+++ b/cluster/calcium/remove_test.go
@@ -3,7 +3,7 @@ package calcium
 import (
 	"context"
 	"testing"
-	"time"
+	"testing/synctest"
 
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
@@ -20,69 +20,72 @@ import (
 )
 
 func TestRemoveWorkload(t *testing.T) {
-	c := NewTestCluster()
-	ctx := t.Context()
-	lock := &lockmocks.DistributedLock{}
-	lock.On("Lock", mock.Anything).Return(ctx, nil)
-	lock.On("Unlock", mock.Anything).Return(nil)
-	store := c.store.(*storemocks.Store)
-	rmgr := c.rmgr.(*resourcemocks.Manager)
-	rmgr.On("GetNodeResourceInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil, nil, nil)
-	rmgr.On("SetNodeResourceUsage", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
-		resourcetypes.Resources{},
-		resourcetypes.Resources{},
-		nil,
-	)
+	synctest.Test(t, func(t *testing.T) {
+		c := NewTestCluster()
+		defer c.pool.Release()
+		ctx := t.Context()
+		lock := &lockmocks.DistributedLock{}
+		lock.On("Lock", mock.Anything).Return(ctx, nil)
+		lock.On("Unlock", mock.Anything).Return(nil)
+		store := c.store.(*storemocks.Store)
+		rmgr := c.rmgr.(*resourcemocks.Manager)
+		rmgr.On("GetNodeResourceInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil, nil, nil)
+		rmgr.On("SetNodeResourceUsage", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+			resourcetypes.Resources{},
+			resourcetypes.Resources{},
+			nil,
+		)
 
-	store.On("GetWorkloads", mock.Anything, mock.Anything).Return(nil, types.ErrMockError).Once()
-	ch, err := c.RemoveWorkload(ctx, []string{"xx"}, false)
-	assert.True(t, errors.Is(err, types.ErrMockError))
-	store.AssertExpectations(t)
+		store.On("GetWorkloads", mock.Anything, mock.Anything).Return(nil, types.ErrMockError).Once()
+		ch, err := c.RemoveWorkload(ctx, []string{"xx"}, false)
+		assert.True(t, errors.Is(err, types.ErrMockError))
+		store.AssertExpectations(t)
 
-	workload := &types.Workload{
-		ID:       "xx",
-		Name:     "test",
-		Nodename: "test",
-	}
-	store.On("GetWorkloads", mock.Anything, mock.Anything).Return([]*types.Workload{workload}, nil)
-	store.On("GetNode", mock.Anything, mock.Anything).Return(nil, types.ErrMockError).Once()
-	ch, err = c.RemoveWorkload(ctx, []string{"xx"}, false)
-	assert.NoError(t, err)
-	for r := range ch {
-		assert.False(t, r.Success)
-	}
-	time.Sleep(time.Second)
-	store.AssertExpectations(t)
+		workload := &types.Workload{
+			ID:       "xx",
+			Name:     "test",
+			Nodename: "test",
+		}
+		store.On("GetWorkloads", mock.Anything, mock.Anything).Return([]*types.Workload{workload}, nil)
+		store.On("GetNode", mock.Anything, mock.Anything).Return(nil, types.ErrMockError).Once()
+		ch, err = c.RemoveWorkload(ctx, []string{"xx"}, false)
+		assert.NoError(t, err)
+		for r := range ch {
+			assert.False(t, r.Success)
+		}
+		synctest.Wait()
+		store.AssertExpectations(t)
 
-	store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
-	node := &types.Node{
-		NodeMeta: types.NodeMeta{
-			Name: "test",
-		},
-	}
-	store.On("GetNode", mock.Anything, mock.Anything).Return(node, nil)
-	store.On("RemoveWorkload", mock.Anything, mock.Anything).Return(types.ErrMockError).Twice()
-	store.On("ListNodeWorkloads", mock.Anything, mock.Anything, mock.Anything).Return(nil, types.ErrMockError)
-	ch, err = c.RemoveWorkload(ctx, []string{"xx"}, false)
-	assert.NoError(t, err)
-	for r := range ch {
-		assert.False(t, r.Success)
-	}
-	assert.Error(t, c.doRemoveWorkloadSync(ctx, []string{"xx"}))
-	time.Sleep(time.Second)
-	store.AssertExpectations(t)
+		store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
+		node := &types.Node{
+			NodeMeta: types.NodeMeta{
+				Name: "test",
+			},
+		}
+		store.On("GetNode", mock.Anything, mock.Anything).Return(node, nil)
+		store.On("RemoveWorkload", mock.Anything, mock.Anything).Return(types.ErrMockError).Twice()
+		store.On("ListNodeWorkloads", mock.Anything, mock.Anything, mock.Anything).Return(nil, types.ErrMockError)
+		ch, err = c.RemoveWorkload(ctx, []string{"xx"}, false)
+		assert.NoError(t, err)
+		for r := range ch {
+			assert.False(t, r.Success)
+		}
+		assert.Error(t, c.doRemoveWorkloadSync(ctx, []string{"xx"}))
+		synctest.Wait()
+		store.AssertExpectations(t)
 
-	engine := &enginemocks.API{}
-	workload.Engine = engine
-	engine.On("VirtualizationRemove", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-	store.On("GetWorkloads", mock.Anything, mock.Anything).Return([]*types.Workload{workload}, nil)
-	store.On("RemoveWorkload", mock.Anything, mock.Anything).Return(nil)
-	ch, err = c.RemoveWorkload(ctx, []string{"xx"}, false)
-	assert.NoError(t, err)
-	for r := range ch {
-		assert.True(t, r.Success)
-	}
-	store.AssertExpectations(t)
+		engine := &enginemocks.API{}
+		workload.Engine = engine
+		engine.On("VirtualizationRemove", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		store.On("GetWorkloads", mock.Anything, mock.Anything).Return([]*types.Workload{workload}, nil)
+		store.On("RemoveWorkload", mock.Anything, mock.Anything).Return(nil)
+		ch, err = c.RemoveWorkload(ctx, []string{"xx"}, false)
+		assert.NoError(t, err)
+		for r := range ch {
+			assert.True(t, r.Success)
+		}
+		store.AssertExpectations(t)
+	})
 }
 
 func TestRemoveWorkloadReportsEveryWorkloadAfterTheLockIsLost(t *testing.T) {

--- a/cluster/calcium/wal_test.go
+++ b/cluster/calcium/wal_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
+	"testing/synctest"
 
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/mock"
@@ -326,85 +326,91 @@ func TestHandleReallocWorkloadOnAnEngineThatCannotReplayIt(t *testing.T) {
 }
 
 func TestHandleCreateLambda(t *testing.T) {
-	c := NewTestCluster()
-	enableTestWAL(t, c)
-	rmgr := c.rmgr.(*resourcemocks.Manager)
-	rmgr.On("GetNodeResourceInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
-		resourcetypes.Resources{},
-		resourcetypes.Resources{},
-		[]string{},
-		nil,
-	)
-	rmgr.On("SetNodeResourceUsage", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
-		resourcetypes.Resources{},
-		resourcetypes.Resources{},
-		nil,
-	)
-	rmgr.On("Remap", mock.Anything, mock.Anything, mock.Anything).Return(
-		resourcetypes.Resources{},
-		nil,
-	)
+	synctest.Test(t, func(t *testing.T) {
+		c := NewTestCluster()
+		defer c.pool.Release()
+		enableTestWAL(t, c)
+		rmgr := c.rmgr.(*resourcemocks.Manager)
+		rmgr.On("GetNodeResourceInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+			resourcetypes.Resources{},
+			resourcetypes.Resources{},
+			[]string{},
+			nil,
+		)
+		rmgr.On("SetNodeResourceUsage", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+			resourcetypes.Resources{},
+			resourcetypes.Resources{},
+			nil,
+		)
+		rmgr.On("Remap", mock.Anything, mock.Anything, mock.Anything).Return(
+			resourcetypes.Resources{},
+			nil,
+		)
 
-	_, err := c.wal.Log(eventCreateLambda, "workloadid")
-	require.NoError(t, err)
+		_, err := c.wal.Log(eventCreateLambda, "workloadid")
+		require.NoError(t, err)
 
-	node := &types.Node{
-		NodeMeta: types.NodeMeta{Name: "nodename"},
-		Engine:   &enginemocks.API{},
-	}
-	wrk := &types.Workload{
-		ID:       "workloadid",
-		Nodename: node.Name,
-		Engine:   node.Engine,
-	}
+		node := &types.Node{
+			NodeMeta: types.NodeMeta{Name: "nodename"},
+			Engine:   &enginemocks.API{},
+		}
+		wrk := &types.Workload{
+			ID:       "workloadid",
+			Nodename: node.Name,
+			Engine:   node.Engine,
+		}
 
-	store := c.store.(*storemocks.Store)
-	store.On("GetWorkload", mock.Anything, mock.Anything).
-		Return(wrk, nil).
-		Once()
-	store.On("GetNode", mock.Anything, wrk.Nodename).
-		Return(node, nil)
-	eng := wrk.Engine.(*enginemocks.API)
-	eng.On("VirtualizationWait", mock.Anything, wrk.ID, "").Return(&enginetypes.VirtualizationWaitResult{Code: 0}, nil).Once()
-	eng.On("VirtualizationRemove", mock.Anything, wrk.ID, true, true).
-		Return(nil).
-		Once()
-	store.On("GetWorkloads", mock.Anything, []string{wrk.ID}).
-		Return([]*types.Workload{wrk}, nil).
-		Twice()
-	store.On("RemoveWorkload", mock.Anything, wrk).
-		Return(nil).
-		Once()
-	store.On("ListNodeWorkloads", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil).Once()
-	lock := &lockmocks.DistributedLock{}
-	lock.On("Lock", mock.Anything).Return(t.Context(), nil)
-	lock.On("Unlock", mock.Anything).Return(nil)
-	store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
+		store := c.store.(*storemocks.Store)
+		store.On("GetWorkload", mock.Anything, mock.Anything).
+			Return(wrk, nil).
+			Once()
+		store.On("GetNode", mock.Anything, wrk.Nodename).
+			Return(node, nil)
+		eng := wrk.Engine.(*enginemocks.API)
+		eng.On("VirtualizationWait", mock.Anything, wrk.ID, "").Return(&enginetypes.VirtualizationWaitResult{Code: 0}, nil).Once()
+		eng.On("VirtualizationRemove", mock.Anything, wrk.ID, true, true).
+			Return(nil).
+			Once()
+		store.On("GetWorkloads", mock.Anything, []string{wrk.ID}).
+			Return([]*types.Workload{wrk}, nil).
+			Twice()
+		store.On("RemoveWorkload", mock.Anything, wrk).
+			Return(nil).
+			Once()
+		store.On("ListNodeWorkloads", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil).Once()
+		lock := &lockmocks.DistributedLock{}
+		lock.On("Lock", mock.Anything).Return(t.Context(), nil)
+		lock.On("Unlock", mock.Anything).Return(nil)
+		store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
 
-	c.wal.Recover(t.Context())
-	time.Sleep(500 * time.Millisecond)
-	c.wal.Recover(t.Context())
-	time.Sleep(500 * time.Millisecond)
-	store.AssertExpectations(t)
-	eng.AssertExpectations(t)
+		c.wal.Recover(t.Context())
+		synctest.Wait()
+		c.wal.Recover(t.Context())
+		synctest.Wait()
+		store.AssertExpectations(t)
+		eng.AssertExpectations(t)
+	})
 }
 
 func TestHandleCreateLambdaKeepsEntryUntilRemoved(t *testing.T) {
-	c := NewTestCluster()
-	enableTestWAL(t, c)
+	synctest.Test(t, func(t *testing.T) {
+		c := NewTestCluster()
+		defer c.pool.Release()
+		enableTestWAL(t, c)
 
-	_, err := c.wal.Log(eventCreateLambda, "workloadid")
-	require.NoError(t, err)
+		_, err := c.wal.Log(eventCreateLambda, "workloadid")
+		require.NoError(t, err)
 
-	store := c.store.(*storemocks.Store)
-	store.On("GetWorkload", mock.Anything, "workloadid").Return(nil, types.ErrMockError).Twice()
-	store.On("NotFound", types.ErrMockError).Return(false).Twice()
+		store := c.store.(*storemocks.Store)
+		store.On("GetWorkload", mock.Anything, "workloadid").Return(nil, types.ErrMockError).Twice()
+		store.On("NotFound", types.ErrMockError).Return(false).Twice()
 
-	c.wal.Recover(t.Context())
-	time.Sleep(500 * time.Millisecond)
-	c.wal.Recover(t.Context())
-	time.Sleep(500 * time.Millisecond)
-	store.AssertExpectations(t)
+		c.wal.Recover(t.Context())
+		synctest.Wait()
+		c.wal.Recover(t.Context())
+		synctest.Wait()
+		store.AssertExpectations(t)
+	})
 }
 
 func enableTestWAL(t *testing.T, c *Calcium) {


### PR DESCRIPTION
Eight real sleeps in TestRemoveWorkload, TestDissociateWorkload, TestSetNode, TestHandleCreateLambda and TestHandleCreateLambdaKeepsEntryUntilRemoved waited for pool goroutines to finish. The tests now run in synctest bubbles and wait on them. TestSetNode initializes the engine cache it removes from, outside the bubble so the cache's keepalive loop stays on the real clock; `go test -run 'TestSetNode$'` passes on its own (it panicked on a nil cache before). Package time 20.9s → 15.7s.