### PR TITLE
perf: find the best cpu plan split by binary search and plan node capacities in parallel

### DIFF
--- a/resource/plugins/cpumem/node.go
+++ b/resource/plugins/cpumem/node.go
@@ -6,12 +6,17 @@ import (
 	"fmt"
 	"maps"
 	"math"
+	"runtime"
 	"slices"
 	"strconv"
+	"sync"
 
 	"github.com/sanity-io/litter"
 
+	"golang.org/x/sync/errgroup"
+
 	enginetypes "github.com/projecteru2/core/engine/types"
+
 	"github.com/projecteru2/core/log"
 	"github.com/projecteru2/core/resource/plugins/cpumem/schedule"
 	cpumemtypes "github.com/projecteru2/core/resource/plugins/cpumem/types"
@@ -120,23 +125,33 @@ func (p Plugin) GetNodesDeployCapacity(ctx context.Context, nodenames []string, 
 		return nil, err
 	}
 
-	nodesDeployCapacityMap := make(map[string]*plugintypes.NodeDeployCapacity, len(nodenames))
-	total := 0
-
 	nodesResourceInfos, err := p.doGetNodesResourceInfo(ctx, nodenames)
 	if err != nil {
 		return nil, err
 	}
 
+	var mu sync.Mutex
+	nodesDeployCapacityMap := make(map[string]*plugintypes.NodeDeployCapacity, len(nodenames))
+	var planners errgroup.Group
+	planners.SetLimit(runtime.GOMAXPROCS(0))
 	for nodename, nodeResourceInfo := range nodesResourceInfos {
-		nodeDeployCapacity := p.doGetNodeDeployCapacity(nodeResourceInfo, req)
-		if nodeDeployCapacity.Capacity > 0 {
-			nodesDeployCapacityMap[nodename] = nodeDeployCapacity
-			if total == math.MaxInt || nodeDeployCapacity.Capacity == math.MaxInt {
-				total = math.MaxInt
-			} else {
-				total += nodeDeployCapacity.Capacity
+		planners.Go(func() error {
+			if nodeDeployCapacity := p.doGetNodeDeployCapacity(nodeResourceInfo, req); nodeDeployCapacity.Capacity > 0 {
+				mu.Lock()
+				nodesDeployCapacityMap[nodename] = nodeDeployCapacity
+				mu.Unlock()
 			}
+			return nil
+		})
+	}
+	_ = planners.Wait()
+
+	total := 0
+	for _, nodeDeployCapacity := range nodesDeployCapacityMap {
+		if total == math.MaxInt || nodeDeployCapacity.Capacity == math.MaxInt {
+			total = math.MaxInt
+		} else {
+			total += nodeDeployCapacity.Capacity
 		}
 	}
 

--- a/resource/plugins/cpumem/node_test.go
+++ b/resource/plugins/cpumem/node_test.go
@@ -468,3 +468,20 @@ func TestAddNodeSplitsMemoryPerNUMANode(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, map[string]any{"0": float64(4 * units.GB), "1": float64(4 * units.GB)}, numaMemory)
 }
+
+func BenchmarkGetNodesCapacityScaling(b *testing.B) {
+	for _, tc := range []struct{ nodes, cores int }{{100, 24}, {1000, 24}, {100, 64}, {100, 128}, {100, 256}, {1000, 128}} {
+		b.Run(fmt.Sprintf("nodes=%d/cores=%d", tc.nodes, tc.cores), func(b *testing.B) {
+			ctx := b.Context()
+			cm := initCPUMEM(b)
+			nodes := generateNodes(ctx, b, cm, tc.nodes, tc.cores, 128*units.GB, 100, 0)
+			req := plugintypes.WorkloadResourceRequest{"cpu-bind": true, "cpu-request": 1.3, "memory-request": "1"}
+			b.ResetTimer()
+			for b.Loop() {
+				if _, err := cm.GetNodesDeployCapacity(ctx, nodes, req); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/resource/plugins/cpumem/schedule/schedule.go
+++ b/resource/plugins/cpumem/schedule/schedule.go
@@ -4,13 +4,16 @@ import (
 	"cmp"
 	"container/heap"
 	"slices"
+	"sort"
 
 	"github.com/projecteru2/core/resource/plugins/cpumem/types"
+	"github.com/projecteru2/core/utils"
 )
 
 type cpuCore struct {
 	ID     string
 	pieces int
+	index  int
 }
 
 type cpuCoreHeap []*cpuCore
@@ -94,121 +97,120 @@ func (h *host) getCPUPlans(cpuRequest float64) []types.CPUMap {
 		return h.getFragmentCPUPlans(h.fragmentCores, fragment)
 	}
 
-	fragmentCapacityMap := map[string]int{}
-	totalFragmentCapacity := 0
-	bestCPUPlans := [2][]types.CPUMap{h.getFullCPUPlans(h.fullCores, full), h.getFragmentCPUPlans(h.fragmentCores, fragment)}
-	bestCapacity := min(len(bestCPUPlans[0]), len(bestCPUPlans[1]))
-
-	for _, core := range h.fullCores {
-		fragmentCapacityMap[core.ID] = core.pieces / fragment
-	}
-
-	for _, core := range h.fragmentCores {
-		fragmentCapacityMap[core.ID] = core.pieces / fragment
-		totalFragmentCapacity += fragmentCapacityMap[core.ID]
-	}
-
-	for len(h.fragmentCores) < maxFragmentCores {
-		newFragmentCore := h.fullCores[0]
-		h.fragmentCores = append(h.fragmentCores, newFragmentCore)
-		h.fullCores = h.fullCores[1:]
-		totalFragmentCapacity += fragmentCapacityMap[newFragmentCore.ID]
-
-		fullCPUPlans := h.getFullCPUPlans(h.fullCores, full)
-		capacity := min(len(fullCPUPlans), totalFragmentCapacity)
-		if capacity > bestCapacity {
-			bestCPUPlans[0] = fullCPUPlans
-			bestCPUPlans[1] = h.getFragmentCPUPlans(h.fragmentCores, fragment)
-			bestCapacity = capacity
-		}
-	}
-
-	cpuPlans := []types.CPUMap{}
+	bestMoved, bestCapacity := h.bestSplit(full, fragment, max(min(maxFragmentCores-len(h.fragmentCores), len(h.fullCores)), 0))
+	fullCPUPlans := h.getFullCPUPlans(h.fullCores[bestMoved:], full)
+	fragmentCPUPlans := h.getFragmentCPUPlans(append(slices.Clone(h.fragmentCores), h.fullCores[:bestMoved]...), fragment)
+	cpuPlans := make([]types.CPUMap, 0, bestCapacity)
 	for i := range bestCapacity {
-		fullCPUPlans := bestCPUPlans[0]
-		fragmentCPUPlans := bestCPUPlans[1]
-
 		cpuMap := types.CPUMap{}
 		cpuMap.Add(fullCPUPlans[i])
 		cpuMap.Add(fragmentCPUPlans[i])
-
 		cpuPlans = append(cpuPlans, cpuMap)
 	}
-
 	return cpuPlans
 }
 
-func (h *host) getFullCPUPlans(cores []*cpuCore, full int) []types.CPUMap {
-	if h.affinity {
-		return h.getFullCPUPlansWithAffinity(cores, full)
+// bestSplit finds the first split with the largest capacity where the falling full-plan count meets the rising fragment count.
+func (h *host) bestSplit(full, fragment, maxMoved int) (int, int) {
+	fragmentCapacity := make([]int, maxMoved+1)
+	for _, core := range h.fragmentCores {
+		fragmentCapacity[0] += core.pieces / fragment
+	}
+	for moved := 1; moved <= maxMoved; moved++ {
+		fragmentCapacity[moved] = fragmentCapacity[moved-1] + h.fullCores[moved-1].pieces/fragment
+	}
+	fullCapacity := func(moved int) int { return h.countFullCPUPlans(h.fullCores[moved:], full) }
+	firstReaching := func(capacity int) int {
+		return sort.SearchInts(fragmentCapacity, capacity)
 	}
 
-	result := []types.CPUMap{}
-	cpuHeap := &cpuCoreHeap{}
-	indexMap := map[string]int{}
+	crossing := sort.Search(maxMoved+1, func(moved int) bool { return fragmentCapacity[moved] >= fullCapacity(moved) })
+	if crossing > maxMoved {
+		return firstReaching(fragmentCapacity[maxMoved]), fragmentCapacity[maxMoved]
+	}
+	capacity := fullCapacity(crossing)
+	if crossing > 0 && fragmentCapacity[crossing-1] >= capacity {
+		return firstReaching(fragmentCapacity[crossing-1]), fragmentCapacity[crossing-1]
+	}
+	return crossing, capacity
+}
+
+func (h *host) countFullCPUPlans(cores []*cpuCore, full int) int {
+	count := 0
+	h.eachFullCPUPlan(cores, full, func([]int) { count++ })
+	return count
+}
+
+func (h *host) getFullCPUPlans(cores []*cpuCore, full int) []types.CPUMap {
+	type ranked struct {
+		plan types.CPUMap
+		rank int
+	}
+	plans := []ranked{}
+	h.eachFullCPUPlan(cores, full, func(picked []int) {
+		plan, rank := types.CPUMap{}, 0
+		for _, i := range picked {
+			plan[cores[i].ID] = h.shareBase
+			rank += i
+		}
+		plans = append(plans, ranked{plan, rank})
+	})
+	if !h.affinity {
+		// restore the pre-heap core priority across the produced plans
+		slices.SortFunc(plans, func(a, b ranked) int { return cmp.Compare(a.rank, b.rank) })
+	}
+	return utils.Map(plans, func(r ranked) types.CPUMap { return r.plan })
+}
+
+// eachFullCPUPlan visits every whole-core plan as the indexes of its cores; with affinity the cores go in order, otherwise the busiest first.
+func (h *host) eachFullCPUPlan(cores []*cpuCore, full int, visit func(picked []int)) {
+	pieces := make([]int, len(cores))
 	for i, core := range cores {
-		indexMap[core.ID] = i
-		cpuHeap.Push(&cpuCore{ID: core.ID, pieces: core.pieces})
+		pieces[i] = core.pieces
+	}
+	if h.affinity {
+		order := make([]int, len(cores))
+		for i := range order {
+			order[i] = i
+		}
+		for len(order) >= full {
+			count := len(order) / full
+			kept := []int{}
+			for i := range count {
+				picked := order[i*full : i*full+full]
+				visit(picked)
+				for _, j := range picked {
+					if pieces[j] -= h.shareBase; pieces[j] > 0 {
+						kept = append(kept, j)
+					}
+				}
+			}
+			order = append(kept, order[count*full:]...)
+		}
+		return
+	}
+
+	cpuHeap := &cpuCoreHeap{}
+	for i, core := range cores {
+		cpuHeap.Push(&cpuCore{ID: core.ID, pieces: core.pieces, index: i})
 	}
 	heap.Init(cpuHeap)
-
+	picked := make([]int, full)
 	for cpuHeap.Len() >= full {
-		plan := types.CPUMap{}
 		resourcesToPush := []*cpuCore{}
-
-		for range full {
+		for n := range full {
 			core := heap.Pop(cpuHeap).(*cpuCore)
-			plan[core.ID] = h.shareBase
-
+			picked[n] = core.index
 			core.pieces -= h.shareBase
 			if core.pieces > 0 {
 				resourcesToPush = append(resourcesToPush, core)
 			}
 		}
-
-		result = append(result, plan)
+		visit(picked)
 		for _, core := range resourcesToPush {
 			heap.Push(cpuHeap, core)
 		}
 	}
-
-	// restore the pre-heap core priority across the produced plans
-	sumOfIDs := func(c types.CPUMap) int {
-		sum := 0
-		for ID := range c {
-			sum += indexMap[ID]
-		}
-		return sum
-	}
-
-	slices.SortFunc(result, func(a, b types.CPUMap) int { return cmp.Compare(sumOfIDs(a), sumOfIDs(b)) })
-
-	return result
-}
-
-func (h *host) getFullCPUPlansWithAffinity(cores []*cpuCore, full int) []types.CPUMap {
-	result := []types.CPUMap{}
-
-	for len(cores) >= full {
-		count := len(cores) / full
-		tempCores := []*cpuCore{}
-		for i := range count {
-			cpuMap := types.CPUMap{}
-			for j := i * full; j < i*full+full; j++ {
-				cpuMap[cores[j].ID] = h.shareBase
-
-				remainingPieces := cores[j].pieces - h.shareBase
-				if remainingPieces > 0 {
-					tempCores = append(tempCores, &cpuCore{ID: cores[j].ID, pieces: remainingPieces})
-				}
-			}
-			result = append(result, cpuMap)
-		}
-
-		cores = append(tempCores, cores[len(cores)/full*full:]...)
-	}
-
-	return result
 }
 
 func (h *host) getFragmentCPUPlans(cores []*cpuCore, fragment int) []types.CPUMap {

--- a/resource/plugins/cpumem/schedule/schedule_test.go
+++ b/resource/plugins/cpumem/schedule/schedule_test.go
@@ -1,6 +1,8 @@
 package schedule
 
 import (
+	"math/rand/v2"
+	"reflect"
 	"strconv"
 	"testing"
 
@@ -398,6 +400,26 @@ func TestFragmentCoresAboveMaxShare(t *testing.T) {
 	assert.ElementsMatch(t, cpuPlans, []*types.CPUPlan{{CPUMap: types.CPUMap{"4": 50}}})
 }
 
+func TestGetCPUPlansMatchTheLinearSplitScan(t *testing.T) {
+	rng := rand.New(rand.NewPCG(7, 11))
+	for range 300 {
+		cores := 1 + rng.IntN(40)
+		cpuMap := types.CPUMap{}
+		for i := range cores {
+			cpuMap[strconv.Itoa(i)] = rng.IntN(4) * 25
+		}
+		shareBase, maxFragment := 100, -1+rng.IntN(cores+2)
+		full, fragment := 1+rng.IntN(3), 25*(1+rng.IntN(3))
+		request := float64(full) + float64(fragment)/float64(shareBase)
+
+		got := newHost(cpuMap, shareBase, maxFragment).getCPUPlans(request)
+		want := linearSplitCPUPlans(newHost(cpuMap, shareBase, maxFragment), request)
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("cores=%v maxFragment=%d request=%v: got %v, want %v", cpuMap, maxFragment, request, got, want)
+		}
+	}
+}
+
 func BenchmarkGetCPUPlans(b *testing.B) {
 	resourceInfo := &types.NodeResourceInfo{
 		Capacity: &types.NodeResource{
@@ -424,4 +446,43 @@ func applyCPUPlans(t *testing.T, resourceInfo *types.NodeResourceInfo, cpuPlans 
 		resourceInfo.Usage.CPUMap.Add(cpuPlan.CPUMap)
 	}
 	assert.Nil(t, resourceInfo.Validate())
+}
+
+// linearSplitCPUPlans is the pre-bestSplit planner: every split built and compared in order.
+func linearSplitCPUPlans(h *host, cpuRequest float64) []types.CPUMap {
+	piecesRequest := int(cpuRequest * float64(h.shareBase))
+	full, fragment := piecesRequest/h.shareBase, piecesRequest%h.shareBase
+	maxFragmentCores := len(h.fullCores) + len(h.fragmentCores) - full
+	if h.maxFragmentCores != -1 && h.maxFragmentCores < maxFragmentCores {
+		maxFragmentCores = h.maxFragmentCores
+	}
+	if fragment == 0 || full == 0 {
+		return h.getCPUPlans(cpuRequest)
+	}
+	totalFragmentCapacity := 0
+	bestCPUPlans := [2][]types.CPUMap{h.getFullCPUPlans(h.fullCores, full), h.getFragmentCPUPlans(h.fragmentCores, fragment)}
+	bestCapacity := min(len(bestCPUPlans[0]), len(bestCPUPlans[1]))
+	for _, core := range h.fragmentCores {
+		totalFragmentCapacity += core.pieces / fragment
+	}
+	for len(h.fragmentCores) < maxFragmentCores {
+		newFragmentCore := h.fullCores[0]
+		h.fragmentCores = append(h.fragmentCores, newFragmentCore)
+		h.fullCores = h.fullCores[1:]
+		totalFragmentCapacity += newFragmentCore.pieces / fragment
+		fullCPUPlans := h.getFullCPUPlans(h.fullCores, full)
+		if capacity := min(len(fullCPUPlans), totalFragmentCapacity); capacity > bestCapacity {
+			bestCPUPlans[0] = fullCPUPlans
+			bestCPUPlans[1] = h.getFragmentCPUPlans(h.fragmentCores, fragment)
+			bestCapacity = capacity
+		}
+	}
+	cpuPlans := []types.CPUMap{}
+	for i := range bestCapacity {
+		cpuMap := types.CPUMap{}
+		cpuMap.Add(bestCPUPlans[0][i])
+		cpuMap.Add(bestCPUPlans[1][i])
+		cpuPlans = append(cpuPlans, cpuMap)
+	}
+	return cpuPlans
 }


### PR DESCRIPTION
cpumem's mixed full+fragment planner built every plan set for every candidate split, so the cost of one node grew with the square of its cores: 100 nodes of 256 cores took 1.3s per GetNodesDeployCapacity call, under the pod lock on every create.

Candidate splits are now only counted; the crossing of the falling full-plan count and the rising fragment count is found by binary search; the plans are built once, for the winning split. Nodes are planned in parallel up to GOMAXPROCS. The plans are unchanged: TestGetCPUPlansMatchTheLinearSplitScan checks 300 random hosts against the old linear scan.

BenchmarkGetNodesCapacityScaling (cpu-bind 1.3, per call):

| nodes x cores | before | after |
|---|---|---|
| 100 x 24 | 23ms | 5ms |
| 1000 x 24 | 179ms | 18ms |
| 100 x 64 | 112ms | 6ms |
| 100 x 128 | 370ms | 12ms |
| 100 x 256 | 1305ms | 21ms |
| 1000 x 128 | 3.29s | 82ms |