### PR TITLE
test: run the redis store against a real redis when one is named

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,3 +39,25 @@ jobs:
 
       - name: Build binary
         run: CGO_ENABLED=0 go build -o eru-core .
+
+  test-redis:
+    runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: --health-cmd "redis-cli ping" --health-interval 5s --health-timeout 3s --health-retries 10
+    env:
+      ERU_TEST_REDIS_ADDR: 127.0.0.1:6379
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Test the redis store against a real redis
+        run: go test -race -timeout 600s -count=1 ./store/redis/...

--- a/store/redis/ephemeral_test.go
+++ b/store/redis/ephemeral_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/alicebob/miniredis/v2"
-	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/projecteru2/core/types"
@@ -15,17 +13,7 @@ import (
 func TestEphemeralMustRevokeAfterKeepaliveFailed(t *testing.T) {
 	assert := assert.New(t)
 
-	s, err := miniredis.Run()
-	if err != nil {
-		t.Fail()
-	}
-	defer s.Close()
-
-	cli := redis.NewClient(&redis.Options{
-		Addr: s.Addr(),
-		DB:   0,
-	})
-	defer cli.Close()
+	cli, _ := testRedis(t)
 
 	pool, _ := utils.NewPool(10000)
 

--- a/store/redis/node_test.go
+++ b/store/redis/node_test.go
@@ -99,7 +99,7 @@ func (s *RediaronTestSuite) TestSetNodeStatus() {
 	_, err := s.rediaron.GetOne(s.T().Context(), key)
 	s.NoError(err)
 	time.Sleep(2 * time.Second)
-	s.rediserver.FastForward(2 * time.Second)
+	s.advance(2 * time.Second)
 	_, err = s.rediaron.GetOne(s.T().Context(), key)
 	s.Error(err)
 }
@@ -124,7 +124,7 @@ func (s *RediaronTestSuite) TestGetNodeStatus() {
 	s.Equal(ns.Nodename, node.Name)
 	s.True(ns.Alive)
 	time.Sleep(2 * time.Second)
-	s.rediserver.FastForward(2 * time.Second)
+	s.advance(2 * time.Second)
 	ns1, err := s.rediaron.GetNodeStatus(s.T().Context(), node.Name)
 	s.Error(err)
 	s.Nil(ns1)

--- a/store/redis/rediaron_test.go
+++ b/store/redis/rediaron_test.go
@@ -2,7 +2,9 @@ package redis
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -16,13 +18,11 @@ import (
 	"github.com/projecteru2/core/utils"
 )
 
-func TestRediaron(t *testing.T) {
-	s, err := miniredis.Run()
-	if err != nil {
-		t.Fail()
-	}
-	defer s.Close()
+// realRedisEnv names a running redis the tests use instead of miniredis; the CI redis job sets it.
+const realRedisEnv = "ERU_TEST_REDIS_ADDR"
 
+func TestRediaron(t *testing.T) {
+	cli, s := testRedis(t)
 	config := types.Config{}
 	config.LockTimeout = 10 * time.Second
 	config.GlobalTimeout = 30 * time.Second
@@ -32,14 +32,7 @@ func TestRediaron(t *testing.T) {
 	defer cancel()
 	factory.InitEngineCache(ctx, config, nil)
 
-	cli := redis.NewClient(&redis.Options{
-		Addr: s.Addr(),
-		DB:   0,
-	})
-
 	pool, _ := utils.NewPool(20)
-
-	defer cli.Close()
 	suite.Run(t, &RediaronTestSuite{
 		rediserver: s,
 		rediaron:   newRediaron(cli, config, pool),
@@ -141,25 +134,25 @@ func (s *RediaronTestSuite) TestCreateWritesNothingOnAConflict() {
 	s.NoError(s.rediaron.cli.Set(ctx, "b", "old", 0).Err())
 
 	s.ErrorIs(s.rediaron.Create(ctx, map[string]string{"a": "1", "b": "2"}), ErrAlreadyExists)
-	s.False(s.rediserver.Exists("a"))
-	value, _ := s.rediserver.Get("b")
+	s.False(s.exists("a"))
+	value := s.get("b")
 	s.Equal("old", value)
 }
 
 func (s *RediaronTestSuite) TestCreateAndDecrNeedsTheCounter() {
 	ctx := s.T().Context()
 	s.ErrorIs(s.rediaron.CreateAndDecr(ctx, map[string]string{"a": "1"}, "counter"), types.ErrKeyNotExists)
-	s.False(s.rediserver.Exists("a"))
+	s.False(s.exists("a"))
 
 	s.NoError(s.rediaron.cli.Set(ctx, "counter", "2", 0).Err())
 	s.NoError(s.rediaron.CreateAndDecr(ctx, map[string]string{"a": "1"}, "counter"))
-	counter, _ := s.rediserver.Get("counter")
+	counter := s.get("counter")
 	s.Equal("1", counter)
 
 	s.ErrorIs(s.rediaron.CreateAndDecr(ctx, map[string]string{"a": "1", "c": "3"}, "counter"), ErrAlreadyExists)
-	counter, _ = s.rediserver.Get("counter")
+	counter = s.get("counter")
 	s.Equal("1", counter)
-	s.False(s.rediserver.Exists("c"))
+	s.False(s.exists("c"))
 }
 
 func (s *RediaronTestSuite) TestBindStatusRefreshesAnUnchangedValueInPlace() {
@@ -167,27 +160,27 @@ func (s *RediaronTestSuite) TestBindStatusRefreshesAnUnchangedValueInPlace() {
 	s.NoError(s.rediaron.cli.Set(ctx, "entity", "1", 0).Err())
 
 	s.NoError(s.rediaron.BindStatus(ctx, "entity", "status", "v1", 10))
-	s.Equal(10*time.Second, s.rediserver.TTL("status"))
-	s.rediserver.FastForward(4 * time.Second)
+	s.InDelta(10, s.ttl("status").Seconds(), 1)
+	s.advance(4 * time.Second)
 	s.NoError(s.rediaron.BindStatus(ctx, "entity", "status", "v1", 10))
-	s.Equal(10*time.Second, s.rediserver.TTL("status"))
+	s.InDelta(10, s.ttl("status").Seconds(), 1)
 
 	s.NoError(s.rediaron.BindStatus(ctx, "entity", "status", "v2", 10))
-	value, _ := s.rediserver.Get("status")
+	value := s.get("status")
 	s.Equal("v2", value)
 
 	s.NoError(s.rediaron.BindStatus(ctx, "entity", "status", "v2", 0))
-	s.Zero(s.rediserver.TTL("status"))
+	s.Zero(s.ttl("status"))
 	s.ErrorIs(s.rediaron.BindStatus(ctx, "absent", "orphan", "v2", 10), types.ErrInvaildCount)
-	s.False(s.rediserver.Exists("orphan"))
+	s.False(s.exists("orphan"))
 	s.NoError(s.rediaron.BindStatus(ctx, "absent", "orphan", "v2", 0))
-	s.Equal(time.Hour, s.rediserver.TTL("orphan"))
+	s.InDelta(time.Hour.Seconds(), s.ttl("orphan").Seconds(), 1)
 
 	s.NoError(s.rediaron.BindStatus(ctx, "entity", "status", "v2", 10))
-	s.rediserver.FastForward(11 * time.Second)
-	s.False(s.rediserver.Exists("status"))
+	s.advance(11 * time.Second)
+	s.False(s.exists("status"))
 	s.NoError(s.rediaron.BindStatus(ctx, "entity", "status", "v2", 10))
-	s.Equal(10*time.Second, s.rediserver.TTL("status"))
+	s.InDelta(10, s.ttl("status").Seconds(), 1)
 }
 
 func (s *RediaronTestSuite) TestPrefixReadsTakeGlobMetacharactersLiterally() {
@@ -228,7 +221,49 @@ func (s *RediaronTestSuite) TestWatchSkipsTTLRefreshes() {
 	s.Equal([]common.Event{{Key: "aab", Type: common.EventPut}, {Key: "aaa", Type: common.EventExpire}}, events)
 }
 
+func (s *RediaronTestSuite) exists(key string) bool {
+	n, err := s.rediaron.cli.Exists(s.T().Context(), key).Result()
+	s.Require().NoError(err)
+	return n > 0
+}
+
+func (s *RediaronTestSuite) get(key string) string {
+	value, err := s.rediaron.cli.Get(s.T().Context(), key).Result()
+	if errors.Is(err, redis.Nil) {
+		return ""
+	}
+	s.Require().NoError(err)
+	return value
+}
+
+func (s *RediaronTestSuite) ttl(key string) time.Duration {
+	ttl, err := s.rediaron.cli.TTL(s.T().Context(), key).Result()
+	s.Require().NoError(err)
+	return max(ttl, 0)
+}
+
+func (s *RediaronTestSuite) advance(d time.Duration) {
+	if s.rediserver != nil {
+		s.rediserver.FastForward(d)
+		return
+	}
+	time.Sleep(d + 500*time.Millisecond)
+}
+
 func triggerMockedKeyspaceNotification(cli *redis.Client, key, action string) {
 	channel := fmt.Sprintf(keyNotifyPrefix, 0, key)
 	cli.Publish(context.Background(), channel, action).Result()
+}
+
+func testRedis(t testing.TB) (*redis.Client, *miniredis.Miniredis) {
+	t.Helper()
+	if addr := os.Getenv(realRedisEnv); addr != "" {
+		cli := redis.NewClient(&redis.Options{Addr: addr})
+		t.Cleanup(func() { _ = cli.Close() })
+		return cli, nil
+	}
+	s := miniredis.RunT(t)
+	cli := redis.NewClient(&redis.Options{Addr: s.Addr()})
+	t.Cleanup(func() { _ = cli.Close() })
+	return cli, s
 }

--- a/store/redis/service_test.go
+++ b/store/redis/service_test.go
@@ -57,15 +57,18 @@ func (s *RediaronTestSuite) TestServiceStatusStream() {
 	time.Sleep(500 * time.Millisecond)
 	triggerMockedKeyspaceNotification(s.rediaron.cli, fmt.Sprintf(common.ServiceStatusKey, "127.0.0.1:5001"), actionDel)
 
-	s.rediserver.FastForward(time.Second)
+	s.advance(time.Second)
 	s.Equal(<-ch, []string{"127.0.0.1:5002"})
 }
 
 func (s *RediaronTestSuite) TestServiceStatusStreamResnapshotsAfterReconnect() {
+	if s.rediserver == nil {
+		s.T().Skip("restarts the server, which only miniredis can do")
+	}
 	ctx, cancel := context.WithCancel(s.T().Context())
 	defer cancel()
 	key := fmt.Sprintf(common.ServiceStatusKey, "127.0.0.1:5001")
-	s.Require().NoError(s.rediserver.Set(key, "token"))
+	s.Require().NoError(s.rediaron.cli.Set(ctx, key, "token", 0).Err())
 
 	ch, err := s.rediaron.ServiceStatusStream(ctx)
 	s.Require().NoError(err)


### PR DESCRIPTION
The redis store tests only ever ran on miniredis. `testRedis` now hands out a client for the server named by `ERU_TEST_REDIS_ADDR` and falls back to miniredis; the suite reads keys back through the client instead of the miniredis handle, waits real time where it used to fast-forward, and skips the one test that restarts the server. A `test-redis` CI job runs the package against redis:7.

Local evidence: `go test ./store/redis/` 15.7s on miniredis; `ERU_TEST_REDIS_ADDR=127.0.0.1:6390 go test -race ./store/redis/` green against a brew redis.