### PR TITLE
fix: collapse concurrent oras probes, tell a vm that has not booted from a verb it lacks, and move the cfs period next to its users

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -8,9 +8,8 @@ import (
 )
 
 const (
-	Gitlab        = "gitlab"
-	Github        = "github"
-	CPUPeriodBase = 100000
+	Gitlab = "gitlab"
+	Github = "github"
 	// ERUMark labels a workload as controlled by eru.
 	ERUMark = "ERU"
 	// LabelMeta holds the encoded publish and healthcheck metadata.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,7 +21,7 @@ core.go            flags, config, logging, gRPC server, signal handling
 ```
 
 The dependency direction is one-way: `rpc` knows `cluster`, `cluster` knows `store`, `resource`,
-`engine`, `strategy` and `wal`, and none of those know `cluster`.
+`engine`, `strategy` and `wal`; of those only `engine` looks back at `cluster`, for the label names it writes.
 
 ## Startup
 

--- a/engine/cocoon/cocoon.go
+++ b/engine/cocoon/cocoon.go
@@ -4,9 +4,11 @@ import (
 	"cmp"
 	"context"
 	"slices"
-	"sync"
+	"sync/atomic"
 
 	"github.com/cockroachdb/errors"
+
+	"golang.org/x/sync/singleflight"
 
 	"github.com/projecteru2/core/engine"
 	"github.com/projecteru2/core/engine/sshrunner"
@@ -36,8 +38,8 @@ type Engine struct {
 
 	execs *sshrunner.Execs
 
-	probe   sync.Mutex
-	hasOras bool
+	probe   singleflight.Group
+	hasOras atomic.Bool
 }
 
 func MakeClient(_ context.Context, config coretypes.Config, nodename, endpoint string) (engine.API, error) {

--- a/engine/cocoon/copy.go
+++ b/engine/cocoon/copy.go
@@ -25,7 +25,7 @@ func (e *Engine) VirtualizationCopyChunkTo(ctx context.Context, ID, target strin
 		return err
 	}
 	if !info.Running {
-		return errors.Wrap(coretypes.ErrEngineNotImplemented, "a vm takes files through its guest agent, send them after the vm boots")
+		return errors.Wrap(coretypes.ErrInvaildWorkloadOps, "a vm takes files through its guest agent, send them after the vm boots")
 	}
 	argv := e.vm("exec", "-i", ID, "--", "tar", "-x", "-P", "-f", "-")
 	running, err := e.runner.Start(ctx, sshrunner.Quote(argv), &sshrunner.StartOptions{Stdin: true})

--- a/engine/cocoon/copy_test.go
+++ b/engine/cocoon/copy_test.go
@@ -60,8 +60,8 @@ func TestVirtualizationCopyToRefusesAGuestThatHasNotBooted(t *testing.T) {
 	e := testEngine(t, runner)
 
 	err := e.VirtualizationCopyTo(t.Context(), "w1", "/etc/app.conf", []byte("x"), 0, 0, 0o644)
-	if !errors.Is(err, coretypes.ErrEngineNotImplemented) {
-		t.Errorf("got %v, want ErrEngineNotImplemented", err)
+	if !errors.Is(err, coretypes.ErrInvaildWorkloadOps) {
+		t.Errorf("got %v, want ErrInvaildWorkloadOps", err)
 	}
 	if len(runner.Lines()) != 1 {
 		t.Errorf("got %q, want the state check and no exec", runner.Lines())

--- a/engine/cocoon/image.go
+++ b/engine/cocoon/image.go
@@ -1,11 +1,13 @@
 package cocoon
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"io"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/cockroachdb/errors"
 
@@ -172,13 +174,20 @@ func (e *Engine) orasPresent(ctx context.Context) bool {
 	if e.hasOras.Load() {
 		return true
 	}
-	present, _, _ := e.probe.Do("oras", func() (any, error) {
-		res, err := e.call(ctx, sshrunner.Shell(orasProbe)...)
+	probed := e.probe.DoChan("oras", func() (any, error) {
+		probeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cmp.Or(e.config.ConnectionTimeout, time.Minute))
+		defer cancel()
+		res, err := e.call(probeCtx, sshrunner.Shell(orasProbe)...)
 		found := err == nil && res.Code == 0
 		if found {
 			e.hasOras.Store(true)
 		}
 		return found, nil
 	})
-	return present.(bool)
+	select {
+	case result := <-probed:
+		return result.Val.(bool)
+	case <-ctx.Done():
+		return false
+	}
 }

--- a/engine/cocoon/image.go
+++ b/engine/cocoon/image.go
@@ -169,12 +169,16 @@ func (e *Engine) partsArtifact(ctx context.Context, ref string) bool {
 }
 
 func (e *Engine) orasPresent(ctx context.Context) bool {
-	e.probe.Lock()
-	defer e.probe.Unlock()
-	if e.hasOras {
+	if e.hasOras.Load() {
 		return true
 	}
-	res, err := e.call(ctx, sshrunner.Shell(orasProbe)...)
-	e.hasOras = err == nil && res.Code == 0
-	return e.hasOras
+	present, _, _ := e.probe.Do("oras", func() (any, error) {
+		res, err := e.call(ctx, sshrunner.Shell(orasProbe)...)
+		found := err == nil && res.Code == 0
+		if found {
+			e.hasOras.Store(true)
+		}
+		return found, nil
+	})
+	return present.(bool)
 }

--- a/engine/containerd/spec.go
+++ b/engine/containerd/spec.go
@@ -18,7 +18,6 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 
-	corecluster "github.com/projecteru2/core/cluster"
 	"github.com/projecteru2/core/engine"
 	enginetypes "github.com/projecteru2/core/engine/types"
 	coretypes "github.com/projecteru2/core/types"
@@ -256,11 +255,11 @@ func withDevices(devices []nodeDevice) oci.SpecOpts {
 func resourceSpec(resource *engine.VirtualizationResource, rArgs *RawArgs, devices []blockDevice) *specs.LinuxResources {
 	limits := &specs.LinuxResources{CPU: &specs.LinuxCPU{}}
 	shares := uint64(defaultCPUShare)
-	period := uint64(corecluster.CPUPeriodBase)
+	period := uint64(enginetypes.CPUPeriodBase)
 	limits.CPU.Period = &period
 
 	if resource.Quota > 0 {
-		quota := int64(resource.Quota * float64(corecluster.CPUPeriodBase))
+		quota := int64(resource.Quota * float64(enginetypes.CPUPeriodBase))
 		limits.CPU.Quota = &quota
 	}
 	if len(resource.CPU) > 0 {

--- a/engine/types/virtualization.go
+++ b/engine/types/virtualization.go
@@ -4,6 +4,9 @@ import (
 	resourcetypes "github.com/projecteru2/core/resource/types"
 )
 
+// CPUPeriodBase is the cfs period a workload's cpu quota is expressed against.
+const CPUPeriodBase = 100000
+
 // VirtualizationCreateOptions describes a workload to create.
 type VirtualizationCreateOptions struct {
 	EngineParams resourcetypes.Resources


### PR DESCRIPTION
Three engine-layer audit items (A-M2, A-M6, A-M7).

- cocoon's oras probe held a mutex across the SSH round trip, so a wide deploy on a node without oras paid one probe per workload in series. Concurrent probes now share one call through singleflight and only a positive answer is kept, as before.
- A copy into a vm that has not booted yet returned `ErrEngineNotImplemented`, the sentinel for verbs the engine never has; it returns `ErrInvaildWorkloadOps`, the sentinel for the wrong state, so a caller can tell retry-later from never.
- `CPUPeriodBase` lived in `cluster` with both users in `engine/containerd`; it moves to `engine/types`, and architecture.md now says what `engine` still reads from `cluster` (the label names).