### PR TITLE
fix: hand a new service watcher the latest addresses at once

### DIFF
--- a/discovery/helium/helium.go
+++ b/discovery/helium/helium.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math/rand/v2"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/projecteru2/core/log"
@@ -16,6 +17,7 @@ const interval = 15 * time.Second
 type Helium struct {
 	store     store.Store
 	subs      sync.Map
+	latest    atomic.Pointer[types.ServiceStatus]
 	interval  time.Duration
 	unsubChan chan uint32
 	done      chan struct{}
@@ -37,6 +39,9 @@ func New(ctx context.Context, config types.GRPCConfig, store store.Store) *Heliu
 
 func (h *Helium) Subscribe() (uint32, <-chan types.ServiceStatus) {
 	ch := make(chan types.ServiceStatus, 1)
+	if latest := h.latest.Load(); latest != nil {
+		ch <- *latest
+	}
 	for {
 		ID := rand.Uint32() //nolint:gosec
 		if _, taken := h.subs.LoadOrStore(ID, ch); !taken {
@@ -80,6 +85,7 @@ func (h *Helium) start(ctx context.Context) {
 					Addresses: addresses,
 					Interval:  h.interval * 2,
 				}
+				h.latest.Store(&latestStatus)
 
 			case ID := <-h.unsubChan:
 				if v, ok := h.subs.LoadAndDelete(ID); ok {

--- a/discovery/helium/helium.go
+++ b/discovery/helium/helium.go
@@ -39,14 +39,18 @@ func New(ctx context.Context, config types.GRPCConfig, store store.Store) *Heliu
 
 func (h *Helium) Subscribe() (uint32, <-chan types.ServiceStatus) {
 	ch := make(chan types.ServiceStatus, 1)
-	if latest := h.latest.Load(); latest != nil {
-		ch <- *latest
-	}
 	for {
 		ID := rand.Uint32() //nolint:gosec
-		if _, taken := h.subs.LoadOrStore(ID, ch); !taken {
-			return ID, ch
+		if _, taken := h.subs.LoadOrStore(ID, ch); taken {
+			continue
 		}
+		if latest := h.latest.Load(); latest != nil {
+			select {
+			case ch <- *latest:
+			default:
+			}
+		}
+		return ID, ch
 	}
 }
 
@@ -85,7 +89,8 @@ func (h *Helium) start(ctx context.Context) {
 					Addresses: addresses,
 					Interval:  h.interval * 2,
 				}
-				h.latest.Store(&latestStatus)
+				published := latestStatus
+				h.latest.Store(&published)
 
 			case ID := <-h.unsubChan:
 				if v, ok := h.subs.LoadAndDelete(ID); ok {

--- a/discovery/helium/helium_test.go
+++ b/discovery/helium/helium_test.go
@@ -44,6 +44,28 @@ func TestHelium(t *testing.T) {
 	close(chAddr)
 }
 
+func TestSubscribeGetsTheLatestStatusAtOnce(t *testing.T) {
+	chAddr := make(chan []string)
+	store := &storemocks.Store{}
+	store.On("ServiceStatusStream", mock.Anything).Return(chAddr, nil)
+	service := New(t.Context(), types.GRPCConfig{ServiceDiscoveryPushInterval: time.Hour}, store)
+
+	chAddr <- []string{"10.0.0.1"}
+	first, chFirst := service.Subscribe()
+	<-chFirst
+	service.Unsubscribe(first)
+
+	ID, chStatus := service.Subscribe()
+	select {
+	case status := <-chStatus:
+		assert.Equal(t, []string{"10.0.0.1"}, status.Addresses)
+	case <-time.After(time.Second):
+		t.Fatal("a new subscriber must be handed the latest status without waiting for the next push")
+	}
+	service.Unsubscribe(ID)
+	close(chAddr)
+}
+
 func TestDispatchDoesNotWaitForAStuckSubscriber(t *testing.T) {
 	chAddr := make(chan []string)
 	store := &storemocks.Store{}


### PR DESCRIPTION
A new WatchServiceStatus subscriber waited for the next store event or push tick, up to `service_discovery_interval`, before it saw any core address (the lane's 6s watch window tripped on it under the redis store). helium keeps the latest status and primes a new subscriber's channel with it. Test: TestSubscribeGetsTheLatestStatusAtOnce.