### PR TITLE
perf: give long-lived ssh sessions their own connections, and stop holding a control slot to wait on a process

### DIFF
--- a/engine/process/exec.go
+++ b/engine/process/exec.go
@@ -14,7 +14,7 @@ import (
 const chdirScript = `cd "$1" && shift && exec "$@"`
 
 func (e *Engine) Execute(ctx context.Context, ID string, config *enginetypes.ExecConfig) (execID string, stdout, stderr io.ReadCloser, stdin io.WriteCloser, err error) {
-	record, _, err := e.workloadMeta(ctx, ID)
+	record, err := e.record(ctx, ID)
 	if err != nil {
 		return "", nil, nil, nil, err
 	}

--- a/engine/process/lifecycle.go
+++ b/engine/process/lifecycle.go
@@ -104,6 +104,7 @@ func (e *Engine) VirtualizationRemove(ctx context.Context, ID string, _, force b
 	if err != nil {
 		return err
 	}
+	e.records.Delete(ID)
 	switch res.Code {
 	case workloadmeta.NotExistsCode:
 		return coretypes.ErrWorkloadNotExists
@@ -149,7 +150,7 @@ func (e *Engine) VirtualizationResize(context.Context, string, uint, uint) error
 }
 
 func (e *Engine) VirtualizationWait(ctx context.Context, ID, _ string) (*enginetypes.VirtualizationWaitResult, error) {
-	res, err := e.run(ctx, sshrunner.Shell(waitScript, unitName(ID))...)
+	res, err := sshrunner.Stream(ctx, e.runner, sshrunner.Shell(waitScript, unitName(ID))...)
 	if err != nil {
 		return &enginetypes.VirtualizationWaitResult{Message: err.Error(), Code: -1}, err
 	}

--- a/engine/process/lifecycle_test.go
+++ b/engine/process/lifecycle_test.go
@@ -239,7 +239,7 @@ func TestVirtualizationInspectReportsAMissingWorkload(t *testing.T) {
 }
 
 func TestVirtualizationWaitReturnsExecMainStatus(t *testing.T) {
-	runner := &sshrunnertest.Fake{Respond: func(string) *sshrunner.Result { return &sshrunner.Result{Stdout: "3\n"} }}
+	runner := &sshrunnertest.Fake{Started: []*sshrunnertest.Session{{Out: "3\n"}}}
 	e := testEngine(t, runner)
 
 	waited, err := e.VirtualizationWait(t.Context(), "w1", "")
@@ -249,10 +249,13 @@ func TestVirtualizationWaitReturnsExecMainStatus(t *testing.T) {
 	if waited.Code != 3 {
 		t.Errorf("got code %d, want 3", waited.Code)
 	}
+	if !runner.Started[0].Closed() {
+		t.Error("the wait must give its stream session back")
+	}
 }
 
 func TestVirtualizationWaitFailsOnAnUnreadableStatus(t *testing.T) {
-	runner := &sshrunnertest.Fake{Respond: func(string) *sshrunner.Result { return &sshrunner.Result{Stdout: "\n"} }}
+	runner := &sshrunnertest.Fake{Started: []*sshrunnertest.Session{{Out: "\n"}}}
 	e := testEngine(t, runner)
 
 	waited, err := e.VirtualizationWait(t.Context(), "w1", "")

--- a/engine/process/process.go
+++ b/engine/process/process.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -44,6 +45,7 @@ type Engine struct {
 	host        string
 	stopTimeout time.Duration
 	execs       *sshrunner.Execs
+	records     sync.Map
 }
 
 func MakeClient(_ context.Context, config coretypes.Config, nodename, endpoint string) (engine.API, error) {
@@ -104,6 +106,19 @@ func (e *Engine) call(ctx context.Context, argv ...string) (*sshrunner.Result, e
 
 func (e *Engine) run(ctx context.Context, argv ...string) (*sshrunner.Result, error) {
 	return sshrunner.Run(ctx, e.runner, argv...)
+}
+
+// record returns the workload's immutable record, read from the node once.
+func (e *Engine) record(ctx context.Context, ID string) (*meta, error) {
+	if cached, ok := e.records.Load(ID); ok {
+		return cached.(*meta), nil
+	}
+	record, _, err := e.workloadMeta(ctx, ID)
+	if err != nil {
+		return nil, err
+	}
+	e.records.Store(ID, record)
+	return record, nil
 }
 
 // workloadMeta reads the durable record and the overlay's mount state in one round trip.

--- a/engine/sshrunner/ssh.go
+++ b/engine/sshrunner/ssh.go
@@ -25,6 +25,9 @@ const (
 	ptyWidth  = 80
 	// sshd's default MaxSessions is 10; queue past that instead of being refused.
 	maxSessions = 8
+	// streams live on connections of their own, opened as they fill up and closed once idle (projecteru2/core#670)
+	maxStreamClients = 4
+	streamIdle       = 30 * time.Second
 
 	openRetries       = 4
 	openRetryInterval = 100 * time.Millisecond
@@ -41,6 +44,7 @@ type sshRunner struct {
 	addr     string
 	config   *ssh.ClientConfig
 	sessions *semaphore.Weighted
+	streams  *streamPool
 
 	mu     sync.Mutex
 	client *ssh.Client
@@ -52,7 +56,9 @@ func New(addr string, config *ssh.ClientConfig) Runner {
 }
 
 func newSSHRunner(addr string, config *ssh.ClientConfig) *sshRunner {
-	return &sshRunner{addr: addr, config: config, sessions: semaphore.NewWeighted(maxSessions)}
+	r := &sshRunner{addr: addr, config: config, sessions: semaphore.NewWeighted(maxSessions)}
+	r.streams = newStreamPool(func(ctx context.Context) (streamConn, error) { return r.dial(ctx) })
+	return r
 }
 
 func (r *sshRunner) Run(ctx context.Context, line string, stdin io.Reader) (*Result, error) {
@@ -81,17 +87,12 @@ func (r *sshRunner) Run(ctx context.Context, line string, stdin io.Reader) (*Res
 }
 
 func (r *sshRunner) Start(ctx context.Context, line string, opts *StartOptions) (_ Session, err error) {
-	if err = r.sessions.Acquire(ctx, 1); err != nil {
-		return nil, err
-	}
-	release := sync.OnceFunc(func() { r.sessions.Release(1) })
-
-	sess, err := r.newSession(ctx)
+	stream, sess, err := r.openStream(ctx)
 	if err != nil {
-		release()
 		return nil, err
 	}
-	running := &sshSession{sess: sess, stop: closeOnDone(ctx, sess), release: release}
+	running := &sshSession{sess: sess, release: sync.OnceFunc(func() { r.streams.release(stream) })}
+	running.stop = closeOnDone(ctx, running)
 	defer func() {
 		if err != nil {
 			_ = running.Close()
@@ -134,7 +135,9 @@ func (r *sshRunner) Files(ctx context.Context) (Files, error) {
 		release()
 		return nil, err
 	}
-	return &sftpFiles{client: remote, release: release}, nil
+	files := &sftpFiles{client: remote, release: release}
+	files.stop = closeOnDone(ctx, files)
+	return files, nil
 }
 
 func (r *sshRunner) Dial(ctx context.Context, network, addr string) (net.Conn, error) {
@@ -152,6 +155,7 @@ func (r *sshRunner) Ping(ctx context.Context) error {
 }
 
 func (r *sshRunner) Close() error {
+	r.streams.close()
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.client == nil {
@@ -177,6 +181,15 @@ func (r *sshRunner) connect(ctx context.Context, stale *ssh.Client) (*ssh.Client
 		_ = r.client.Close()
 		r.client = nil
 	}
+	client, err := r.dial(ctx)
+	if err != nil {
+		return nil, err
+	}
+	r.client = client
+	return r.client, nil
+}
+
+func (r *sshRunner) dial(ctx context.Context) (*ssh.Client, error) {
 	conn, err := (&net.Dialer{Timeout: r.config.Timeout}).DialContext(ctx, "tcp", r.addr)
 	if err != nil {
 		return nil, err
@@ -186,8 +199,26 @@ func (r *sshRunner) connect(ctx context.Context, stale *ssh.Client) (*ssh.Client
 		_ = conn.Close()
 		return nil, err
 	}
-	r.client = ssh.NewClient(handshaked, chans, reqs)
-	return r.client, nil
+	return ssh.NewClient(handshaked, chans, reqs), nil
+}
+
+// openStream takes a slot on a stream connection and opens the session there; a dead connection is dropped and the open retried once.
+func (r *sshRunner) openStream(ctx context.Context) (*streamClient, *ssh.Session, error) {
+	for attempt := 0; ; attempt++ {
+		stream, err := r.streams.acquire(ctx)
+		if err != nil {
+			return nil, nil, err
+		}
+		sess, err := bounded(ctx, stream.conn.NewSession)
+		if err == nil {
+			return stream, sess, nil
+		}
+		if ctx.Err() != nil || !isTransportError(err) || attempt == 1 {
+			r.streams.release(stream)
+			return nil, nil, err
+		}
+		r.streams.evict(stream)
+	}
 }
 
 type sshSession struct {
@@ -221,6 +252,7 @@ func (s *sshSession) Close() error {
 
 type sftpFiles struct {
 	client  *sftp.Client
+	stop    func()
 	release func()
 }
 
@@ -262,6 +294,7 @@ func (f *sftpFiles) Chmod(path string, mode os.FileMode) error {
 }
 
 func (f *sftpFiles) Close() error {
+	f.stop()
 	f.release()
 	return f.client.Close()
 }
@@ -290,8 +323,9 @@ func NewClientConfig(cfg coretypes.SSHConfig, user string, timeout time.Duration
 	}, nil
 }
 
-func closeOnDone(ctx context.Context, sess *ssh.Session) func() {
-	stop := context.AfterFunc(ctx, func() { _ = sess.Close() })
+// closeOnDone closes the wrapper when ctx ends, so the slot goes back with the transport.
+func closeOnDone(ctx context.Context, c io.Closer) func() {
+	stop := context.AfterFunc(ctx, func() { _ = c.Close() })
 	return func() { stop() }
 }
 
@@ -306,24 +340,24 @@ func openOnce[T any](ctx context.Context, r *sshRunner, f sshOp[T]) (T, error) {
 	if err != nil {
 		return zero, err
 	}
-	v, err := bounded(ctx, client, f)
+	v, err := bounded(ctx, func() (T, error) { return f(client) })
 	if err == nil || ctx.Err() != nil || !isTransportError(err) {
 		return v, err
 	}
 	if client, err = r.connect(ctx, client); err != nil {
 		return zero, err
 	}
-	return bounded(ctx, client, f)
+	return bounded(ctx, func() (T, error) { return f(client) })
 }
 
-func bounded[T any](ctx context.Context, client *ssh.Client, f sshOp[T]) (T, error) {
+func bounded[T any](ctx context.Context, open func() (T, error)) (T, error) {
 	type opened struct {
 		v   T
 		err error
 	}
 	done := make(chan opened, 1)
 	go func() {
-		v, err := f(client)
+		v, err := open()
 		done <- opened{v, err}
 	}()
 	select {

--- a/engine/sshrunner/ssh_test.go
+++ b/engine/sshrunner/ssh_test.go
@@ -7,6 +7,7 @@ import (
 	"syscall"
 	"testing"
 	"testing/synctest"
+	"time"
 
 	"github.com/cockroachdb/errors"
 	"golang.org/x/crypto/ssh"
@@ -93,7 +94,7 @@ func TestBoundedGivesUpOnADoneContextAndClosesTheLateResult(t *testing.T) {
 		late := &closeRecorder{}
 		result := make(chan error, 1)
 		go func() {
-			_, err := bounded(ctx, nil, func(*ssh.Client) (io.Closer, error) {
+			_, err := bounded(ctx, func() (io.Closer, error) {
 				<-release
 				return late, nil
 			})
@@ -120,7 +121,7 @@ func TestIsTransportErrorCountsAContextDeadline(t *testing.T) {
 
 func TestBoundedReturnsTheResultOfAnOpenThatFinishes(t *testing.T) {
 	want := &closeRecorder{}
-	got, err := bounded(t.Context(), nil, func(*ssh.Client) (io.Closer, error) { return want, nil })
+	got, err := bounded(t.Context(), func() (io.Closer, error) { return want, nil })
 	if err != nil || got != want {
 		t.Fatalf("got %v, %v; want the opened value", got, err)
 	}
@@ -153,6 +154,118 @@ func TestSSHRunnerBoundsConcurrentSessions(t *testing.T) {
 		t.Errorf("session %d must queue instead of opening", maxSessions+1)
 	}
 	runner.sessions.Release(maxSessions)
+}
+
+func TestStreamPoolOpensAConnectionPerEightSessions(t *testing.T) {
+	dials := 0
+	pool := newStreamPool(func(context.Context) (streamConn, error) { dials++; return &fakeConn{}, nil })
+	held := []*streamClient{}
+	for range maxSessions + 1 {
+		c, err := pool.acquire(t.Context())
+		if err != nil {
+			t.Fatalf("acquire: %v", err)
+		}
+		held = append(held, c)
+	}
+	if dials != 2 {
+		t.Fatalf("got %d dials, want 2 for %d sessions", dials, maxSessions+1)
+	}
+	if held[0] != held[maxSessions-1] || held[0] == held[maxSessions] {
+		t.Error("the first eight sessions share one connection and the ninth opens another")
+	}
+}
+
+func TestStreamPoolClosesAConnectionLeftIdle(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		conn := &fakeConn{}
+		pool := newStreamPool(func(context.Context) (streamConn, error) { return conn, nil })
+		c, err := pool.acquire(t.Context())
+		if err != nil {
+			t.Fatalf("acquire: %v", err)
+		}
+		pool.release(c)
+		time.Sleep(streamIdle / 2)
+		if _, err := pool.acquire(t.Context()); err != nil {
+			t.Fatalf("acquire: %v", err)
+		}
+		time.Sleep(streamIdle)
+		synctest.Wait()
+		if conn.closed {
+			t.Fatal("a connection taken again before its idle time must stay open")
+		}
+		pool.release(c)
+		time.Sleep(streamIdle + time.Second)
+		synctest.Wait()
+		if !conn.closed || len(pool.conns) != 0 {
+			t.Error("an idle connection must be closed and forgotten")
+		}
+	})
+}
+
+func TestStreamPoolWaitsWhenEveryConnectionIsFull(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		pool := newStreamPool(func(context.Context) (streamConn, error) { return &fakeConn{}, nil })
+		held := []*streamClient{}
+		for range maxStreamClients * maxSessions {
+			c, err := pool.acquire(t.Context())
+			if err != nil {
+				t.Fatalf("acquire: %v", err)
+			}
+			held = append(held, c)
+		}
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		if _, err := pool.acquire(ctx); !errors.Is(err, context.Canceled) {
+			t.Fatalf("got %v, want the caller to wait on its context once every connection is full", err)
+		}
+		pool.release(held[0])
+		if _, err := pool.acquire(t.Context()); err != nil {
+			t.Fatalf("a released slot must be handed out again: %v", err)
+		}
+	})
+}
+
+func TestOpenStreamDropsADeadConnection(t *testing.T) {
+	dead, live := &fakeConn{err: io.EOF}, &fakeConn{}
+	conns := []streamConn{dead, live}
+	r := newSSHRunner("127.0.0.1:22", &ssh.ClientConfig{})
+	r.streams = newStreamPool(func(context.Context) (streamConn, error) { c := conns[0]; conns = conns[1:]; return c, nil })
+
+	stream, _, err := r.openStream(t.Context())
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if stream.conn != live || !dead.closed {
+		t.Error("a connection whose session open fails on the transport must be closed and replaced")
+	}
+}
+
+func TestCloseOnDoneClosesWhenTheContextEnds(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		c := &closeRecorder{}
+		stop := closeOnDone(ctx, c)
+		cancel()
+		synctest.Wait()
+		if !c.closed {
+			t.Fatal("the closer must run when the context ends")
+		}
+		stop()
+	})
+}
+
+type fakeConn struct {
+	err    error
+	closed bool
+}
+
+func (c *fakeConn) NewSession() (*ssh.Session, error) {
+	return nil, c.err
+}
+
+func (c *fakeConn) Close() error {
+	c.closed = true
+	return nil
 }
 
 type closeRecorder struct{ closed bool }

--- a/engine/sshrunner/streams.go
+++ b/engine/sshrunner/streams.go
@@ -60,17 +60,26 @@ func (p *streamPool) release(c *streamClient) {
 	c.held--
 	p.total.Release(1)
 	if c.held == 0 {
-		c.idle = time.AfterFunc(streamIdle, func() { p.drop(c, false) })
+		c.idle = time.AfterFunc(streamIdle, func() { p.drop(c) })
 	}
 }
 
-func (p *streamPool) drop(c *streamClient, force bool) {
+func (p *streamPool) drop(c *streamClient) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	if c.held > 0 && !force {
+	if c.held > 0 {
 		return
 	}
 	p.forget(c)
+}
+
+// evict takes a dead connection out of the pool before its holder's slot goes back, so no one else can pick it up.
+func (p *streamPool) evict(c *streamClient) {
+	p.mu.Lock()
+	c.held--
+	p.forget(c)
+	p.mu.Unlock()
+	p.total.Release(1)
 }
 
 func (p *streamPool) close() {

--- a/engine/sshrunner/streams.go
+++ b/engine/sshrunner/streams.go
@@ -1,0 +1,104 @@
+package sshrunner
+
+import (
+	"context"
+	"slices"
+	"sync"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/sync/semaphore"
+)
+
+// streamConn is the part of an ssh client a long-lived session needs.
+type streamConn interface {
+	NewSession() (*ssh.Session, error)
+	Close() error
+}
+
+type streamDialer func(context.Context) (streamConn, error)
+
+// streamPool gives long-lived sessions their own connections, so followed logs never starve a node's control calls.
+type streamPool struct {
+	dial  streamDialer
+	total *semaphore.Weighted
+
+	mu    sync.Mutex
+	conns []*streamClient
+}
+
+func newStreamPool(dial streamDialer) *streamPool {
+	return &streamPool{dial: dial, total: semaphore.NewWeighted(maxStreamClients * maxSessions)}
+}
+
+func (p *streamPool) acquire(ctx context.Context) (*streamClient, error) {
+	if err := p.total.Acquire(ctx, 1); err != nil {
+		return nil, err
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, c := range p.conns {
+		if c.held < maxSessions {
+			c.hold()
+			return c, nil
+		}
+	}
+	conn, err := p.dial(ctx)
+	if err != nil {
+		p.total.Release(1)
+		return nil, err
+	}
+	c := &streamClient{conn: conn}
+	c.hold()
+	p.conns = append(p.conns, c)
+	return c, nil
+}
+
+func (p *streamPool) release(c *streamClient) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	c.held--
+	p.total.Release(1)
+	if c.held == 0 {
+		c.idle = time.AfterFunc(streamIdle, func() { p.drop(c, false) })
+	}
+}
+
+func (p *streamPool) drop(c *streamClient, force bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if c.held > 0 && !force {
+		return
+	}
+	p.forget(c)
+}
+
+func (p *streamPool) close() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, c := range slices.Clone(p.conns) {
+		p.forget(c)
+	}
+}
+
+func (p *streamPool) forget(c *streamClient) {
+	if c.idle != nil {
+		c.idle.Stop()
+	}
+	_ = c.conn.Close()
+	p.conns = slices.DeleteFunc(p.conns, func(x *streamClient) bool { return x == c })
+}
+
+type streamClient struct {
+	conn streamConn
+	held int
+	idle *time.Timer
+}
+
+func (c *streamClient) hold() {
+	c.held++
+	if c.idle != nil {
+		c.idle.Stop()
+		c.idle = nil
+	}
+}

--- a/engine/sshrunner/utils.go
+++ b/engine/sshrunner/utils.go
@@ -2,11 +2,13 @@ package sshrunner
 
 import (
 	"context"
+	"io"
 	"net"
 	"slices"
 	"strings"
 
 	"github.com/cockroachdb/errors"
+	"golang.org/x/sync/errgroup"
 
 	coretypes "github.com/projecteru2/core/types"
 )
@@ -70,5 +72,29 @@ func Run(ctx context.Context, runner Runner, argv ...string) (*Result, error) {
 	if err != nil {
 		return nil, err
 	}
+	return res, ExitError(argv, res)
+}
+
+// Stream runs argv on a stream connection and reports a non-zero exit as an error, for commands that outlive a control call.
+func Stream(ctx context.Context, runner Runner, argv ...string) (*Result, error) {
+	running, err := runner.Start(ctx, Quote(argv), &StartOptions{})
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = running.Close()
+	}()
+	var out, errOut []byte
+	var readers errgroup.Group
+	readers.Go(func() (err error) { out, err = io.ReadAll(running.Stdout()); return err })
+	readers.Go(func() (err error) { errOut, err = io.ReadAll(running.Stderr()); return err })
+	if readErr := readers.Wait(); readErr != nil {
+		return nil, readErr
+	}
+	code, waitErr := running.Wait()
+	if waitErr != nil {
+		return nil, waitErr
+	}
+	res := &Result{Stdout: string(out), Stderr: string(errOut), Code: code}
 	return res, ExitError(argv, res)
 }


### PR DESCRIPTION
Closes #670 and the audit items A-H1, A-M3 and A-L2. Stacked on #714 (the ssh context bound); merge that first.

Followed logs, attaches, execs and the process wait all took one of the eight session slots on a node's single ssh connection, so eight followed logs blocked every control call to that node until a deadline fired. Long-lived sessions (`Start`) now come from a pool of stream connections, opened as they fill up to four and closed after thirty idle seconds; the control connection keeps its eight slots for round trips (`Run`, `Files`). A session or sftp handle whose context ends gives its slot back together with the transport (A-L2). The process engine's wait runs over a stream connection instead of holding a control slot for the workload's whole life (A-H1), and an exec reads the workload's immutable record once instead of on every call (A-M3).

Tests: TestStreamPoolOpensAConnectionPerEightSessions, TestStreamPoolClosesAConnectionLeftIdle, TestStreamPoolWaitsWhenEveryConnectionIsFull, TestOpenStreamDropsADeadConnection, TestCloseOnDoneClosesWhenTheContextEnds, TestExecuteReadsTheRecordOnce, and the wait tests moved onto scripted stream sessions. Lane evidence to follow: nine followed logs on eru-n2 with a control call timed against the current build.