### PR TITLE
perf: lock a node for the resource write, the pod only for a multi-node plan

### DIFF
--- a/cluster/calcium/capacity.go
+++ b/cluster/calcium/capacity.go
@@ -23,7 +23,7 @@ func (c *Calcium) CalculateCapacity(ctx context.Context, opts *types.DeployOptio
 		NodeCapacities: map[string]int{},
 	}
 
-	return msg, c.withNodesPodLocked(ctx, opts.NodeFilter, func(ctx context.Context, nodeMap map[string]*types.Node) error {
+	return msg, c.withNodes(ctx, opts.NodeFilter, func(ctx context.Context, nodeMap map[string]*types.Node) error {
 		nodenames := slices.Collect(maps.Keys(nodeMap))
 
 		if opts.DeployStrategy != strategy.Dummy {

--- a/cluster/calcium/capacity_test.go
+++ b/cluster/calcium/capacity_test.go
@@ -1,6 +1,7 @@
 package calcium
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,7 +23,7 @@ func TestCalculateCapacity(t *testing.T) {
 	store := c.store.(*storemocks.Store)
 
 	lock := &lockmocks.DistributedLock{}
-	lock.On("Lock", mock.Anything).Return(ctx, nil)
+	lock.On("Lock", mock.Anything).Return(context.Background(), nil)
 	lock.On("Unlock", mock.Anything).Return(nil)
 	store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
 

--- a/cluster/calcium/control_test.go
+++ b/cluster/calcium/control_test.go
@@ -209,7 +209,7 @@ func newControlTestCluster(t *testing.T) (*Calcium, context.Context, *storemocks
 	ctx := t.Context()
 	store := c.store.(*storemocks.Store)
 	lock := &lockmocks.DistributedLock{}
-	lock.On("Lock", mock.Anything).Return(ctx, nil)
+	lock.On("Lock", mock.Anything).Return(context.Background(), nil)
 	lock.On("Unlock", mock.Anything).Return(nil)
 	store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
 	return c, ctx, store

--- a/cluster/calcium/copy_test.go
+++ b/cluster/calcium/copy_test.go
@@ -1,6 +1,7 @@
 package calcium
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,7 +32,7 @@ func TestCopy(t *testing.T) {
 	}
 	store := c.store.(*storemocks.Store)
 	lock := &lockmocks.DistributedLock{}
-	lock.On("Lock", mock.Anything).Return(ctx, nil)
+	lock.On("Lock", mock.Anything).Return(context.Background(), nil)
 	lock.On("Unlock", mock.Anything).Return(nil)
 	store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
 	store.On("GetWorkload", mock.Anything, mock.Anything).Return(nil, types.ErrMockError).Once()

--- a/cluster/calcium/create.go
+++ b/cluster/calcium/create.go
@@ -80,7 +80,7 @@ func (c *Calcium) doCreateWorkloads(ctx context.Context, opts *types.DeployOptio
 						_ = send(caller, ch, &types.CreateWorkloadMessage{Error: err})
 					}
 				}()
-				return c.withNodesPodLocked(ctx, opts.NodeFilter, func(ctx context.Context, nodeMap map[string]*types.Node) (err error) {
+				return c.withNodesPlanLocked(ctx, opts.NodeFilter, func(ctx context.Context, nodeMap map[string]*types.Node) (err error) {
 					if len(nodeMap) == 0 {
 						return types.ErrEmptyNodeMap
 					}
@@ -133,7 +133,7 @@ func (c *Calcium) doCreateWorkloads(ctx context.Context, opts *types.DeployOptio
 					}
 				}
 				for nodename, rollbackResources := range resourcesToRollback {
-					if e := c.withNodePodLocked(ctx, nodename, func(ctx context.Context, _ *types.Node) error {
+					if e := c.withNodeOperationLocked(ctx, nodename, func(ctx context.Context, _ *types.Node) error {
 						return c.rmgr.RollbackAlloc(ctx, nodename, rollbackResources)
 					}); e != nil {
 						logger.Error(ctx, e)

--- a/cluster/calcium/create_test.go
+++ b/cluster/calcium/create_test.go
@@ -337,7 +337,7 @@ func TestDoDeployWorkloadsOnNodeErrorPerWorkload(t *testing.T) {
 	store.On("GetNode", mock.Anything, mock.Anything).Return(node, nil)
 	store.On("ListNodeWorkloads", mock.Anything, mock.Anything, mock.Anything).Return(nil, types.ErrMockError)
 	lock := &lockmocks.DistributedLock{}
-	lock.On("Lock", mock.Anything).Return(ctx, nil)
+	lock.On("Lock", mock.Anything).Return(context.Background(), nil)
 	lock.On("Unlock", mock.Anything).Return(nil)
 	store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
 	engine.On("VirtualizationCreate", mock.Anything, mock.Anything).Return(nil, types.ErrMockError)
@@ -495,7 +495,7 @@ func newCreateWorkloadCluster(t *testing.T, createProcessingErr, deleteProcessin
 	store.On("DeleteProcessing", mock.Anything, mock.Anything, mock.Anything).Return(deleteProcessingErr)
 
 	lock := &lockmocks.DistributedLock{}
-	lock.On("Lock", mock.Anything).Return(t.Context(), nil)
+	lock.On("Lock", mock.Anything).Return(context.Background(), nil)
 	lock.On("Unlock", mock.Anything).Return(nil)
 	store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
 

--- a/cluster/calcium/dissociate.go
+++ b/cluster/calcium/dissociate.go
@@ -23,26 +23,26 @@ func (c *Calcium) DissociateWorkload(ctx context.Context, IDs []string) (chan *t
 		defer close(ch)
 
 		for nodename, workloadIDs := range nodeWorkloadGroup {
-			if nodeErr := c.withNodePodLocked(ctx, nodename, func(ctx context.Context, node *types.Node) error {
-				for _, workloadID := range workloadIDs {
-					msg := &types.DissociateWorkloadMessage{WorkloadID: workloadID}
-					if workloadErr := c.withWorkloadLocked(ctx, workloadID, false, func(ctx context.Context, workload *types.Workload) error {
-						return c.withResourceReleased(ctx, node, workload, func(ctx context.Context) error {
-							return c.store.RemoveWorkload(ctx, workload)
-						})
-					}); workloadErr != nil {
-						logger.WithField("id", workloadID).Error(ctx, workloadErr, "failed to dissociate workload")
-						msg.Error = workloadErr
-					}
-					if err := send(caller, ch, msg); err != nil {
-						return err
-					}
-				}
-				c.invokePoolAsync(func() { c.RemapResourceAndLog(ctx, logger, node) })
-				return nil
-			}); nodeErr != nil {
-				logger.WithField("node", nodename).Error(ctx, nodeErr, "failed to lock node")
+			node, err := c.store.GetNode(ctx, nodename)
+			if err != nil {
+				logger.WithField("node", nodename).Error(ctx, err, "failed to get node")
+				continue
 			}
+			for _, workloadID := range workloadIDs {
+				msg := &types.DissociateWorkloadMessage{WorkloadID: workloadID}
+				if workloadErr := c.withWorkloadLocked(ctx, workloadID, false, func(ctx context.Context, workload *types.Workload) error {
+					return c.withResourceReleased(ctx, node, workload, func(ctx context.Context) error {
+						return c.store.RemoveWorkload(ctx, workload)
+					})
+				}); workloadErr != nil {
+					logger.WithField("id", workloadID).Error(ctx, workloadErr, "failed to dissociate workload")
+					msg.Error = workloadErr
+				}
+				if err := send(caller, ch, msg); err != nil {
+					return
+				}
+			}
+			c.invokePoolAsync(func() { c.RemapResourceAndLog(ctx, logger, node) })
 		}
 	})
 	return ch, nil

--- a/cluster/calcium/dissociate.go
+++ b/cluster/calcium/dissociate.go
@@ -31,7 +31,7 @@ func (c *Calcium) DissociateWorkload(ctx context.Context, IDs []string) (chan *t
 			for _, workloadID := range workloadIDs {
 				msg := &types.DissociateWorkloadMessage{WorkloadID: workloadID}
 				if workloadErr := c.withWorkloadLocked(ctx, workloadID, false, func(ctx context.Context, workload *types.Workload) error {
-					return c.withResourceReleased(ctx, node, workload, func(ctx context.Context) error {
+					return c.withResourceReleased(ctx, logger, node, workload, func(ctx context.Context) error {
 						return c.store.RemoveWorkload(ctx, workload)
 					})
 				}); workloadErr != nil {

--- a/cluster/calcium/dissociate_test.go
+++ b/cluster/calcium/dissociate_test.go
@@ -1,6 +1,7 @@
 package calcium
 
 import (
+	"context"
 	"testing"
 	"testing/synctest"
 
@@ -23,7 +24,7 @@ func TestDissociateWorkload(t *testing.T) {
 		rmgr := c.rmgr.(*resourcemocks.Manager)
 
 		lock := &lockmocks.DistributedLock{}
-		lock.On("Lock", mock.Anything).Return(ctx, nil)
+		lock.On("Lock", mock.Anything).Return(context.Background(), nil)
 		lock.On("Unlock", mock.Anything).Return(nil)
 
 		c1 := &types.Workload{

--- a/cluster/calcium/lambda_test.go
+++ b/cluster/calcium/lambda_test.go
@@ -250,6 +250,9 @@ func newLambdaCluster(t *testing.T) (*Calcium, []*types.Node) {
 
 	store := c.store.(*storemocks.Store)
 	rmgr := c.rmgr.(*resourcemocks.Manager)
+	rmgr.On("SetNodeResourceUsage", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+		resourcetypes.Resources{}, resourcetypes.Resources{}, nil,
+	)
 	rmgr.On("GetNodeResourceInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 		resourcetypes.Resources{},
 		resourcetypes.Resources{},
@@ -287,7 +290,7 @@ func newLambdaCluster(t *testing.T) (*Calcium, []*types.Node) {
 	store.On("DeleteProcessing", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	lock := &lockmocks.DistributedLock{}
-	lock.On("Lock", mock.Anything).Return(t.Context(), nil)
+	lock.On("Lock", mock.Anything).Return(context.Background(), nil)
 	lock.On("Unlock", mock.Anything).Return(nil)
 	store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
 	store.On("GetNodesByPod", mock.Anything, mock.Anything, mock.Anything).Return(nodes, nil)

--- a/cluster/calcium/lock.go
+++ b/cluster/calcium/lock.go
@@ -10,6 +10,7 @@ import (
 	"github.com/projecteru2/core/lock"
 	"github.com/projecteru2/core/log"
 	"github.com/projecteru2/core/types"
+	"github.com/projecteru2/core/utils"
 )
 
 type (
@@ -17,7 +18,7 @@ type (
 	nodesHandler     func(context.Context, map[string]*types.Node) error
 	workloadHandler  func(context.Context, *types.Workload) error
 	workloadsHandler func(context.Context, map[string]*types.Workload) error
-	nodeLockKey      func(*types.Node) string
+	nodeLockKeys     func([]*types.Node) []string
 )
 
 func (c *Calcium) doLock(ctx context.Context, name string, timeout time.Duration) (lock lock.DistributedLock, rCtx context.Context, err error) {
@@ -94,29 +95,29 @@ func (c *Calcium) withWorkloadsLocked(ctx context.Context, ignoreLock bool, IDs 
 	return f(ctx, workloads)
 }
 
-func (c *Calcium) withNodePodLocked(ctx context.Context, nodename string, f nodeHandler) error {
-	return withNodeLocked(ctx, nodename, c.withNodesPodLocked, f)
-}
-
 func (c *Calcium) withNodeOperationLocked(ctx context.Context, nodename string, f nodeHandler) error {
 	return withNodeLocked(ctx, nodename, c.withNodesOperationLocked, f)
 }
 
 func (c *Calcium) withNodesOperationLocked(ctx context.Context, nodeFilter *types.NodeFilter, f nodesHandler) error {
-	genKey := func(node *types.Node) string {
-		return fmt.Sprintf(cluster.NodeOperationLock, node.Podname, node.Name)
-	}
-	return c.withNodesLocked(ctx, nodeFilter, genKey, f)
+	return c.withNodesLocked(ctx, nodeFilter, nodeOperationKeys, f)
 }
 
-func (c *Calcium) withNodesPodLocked(ctx context.Context, nodeFilter *types.NodeFilter, f nodesHandler) error {
-	genKey := func(node *types.Node) string {
-		return fmt.Sprintf(cluster.PodLock, node.Podname)
-	}
-	return c.withNodesLocked(ctx, nodeFilter, genKey, f)
+// withNodesPlanLocked serializes a deploy plan: one candidate takes its node lock, several take the pod lock and every node lock.
+func (c *Calcium) withNodesPlanLocked(ctx context.Context, nodeFilter *types.NodeFilter, f nodesHandler) error {
+	return c.withNodesLocked(ctx, nodeFilter, func(nodes []*types.Node) []string {
+		if len(nodes) == 1 {
+			return nodeOperationKeys(nodes)
+		}
+		return append(podKeys(nodes), nodeOperationKeys(nodes)...)
+	}, f)
 }
 
-func (c *Calcium) withNodesLocked(ctx context.Context, nodeFilter *types.NodeFilter, genKey nodeLockKey, f nodesHandler) error {
+func (c *Calcium) withPodLocked(ctx context.Context, podname string, f nodesHandler) error {
+	return c.withNodesLocked(ctx, &types.NodeFilter{Podname: podname, All: true}, podKeys, f)
+}
+
+func (c *Calcium) withNodesLocked(ctx context.Context, nodeFilter *types.NodeFilter, keysOf nodeLockKeys, f nodesHandler) error {
 	nodes := map[string]*types.Node{}
 	locks := map[string]lock.DistributedLock{}
 	lockKeys := []string{}
@@ -132,12 +133,11 @@ func (c *Calcium) withNodesLocked(ctx context.Context, nodeFilter *types.NodeFil
 	if err != nil {
 		return err
 	}
-
-	keys := make([]string, 0, len(ns))
 	for _, n := range ns {
 		nodes[n.Name] = n
-		keys = append(keys, genKey(n))
 	}
+
+	keys := keysOf(ns)
 	slices.Sort(keys)
 	var lock lock.DistributedLock
 	for _, key := range slices.Compact(keys) {
@@ -150,6 +150,49 @@ func (c *Calcium) withNodesLocked(ctx context.Context, nodeFilter *types.NodeFil
 		lockKeys = append(lockKeys, key)
 	}
 	return f(ctx, nodes)
+}
+
+// withNodeKeyLocked takes one node's operation lock around f; the caller already holds the node.
+func (c *Calcium) withNodeKeyLocked(ctx context.Context, node *types.Node, f func(context.Context) error) error {
+	lock, ctx, err := c.doLock(ctx, nodeOperationKey(node), c.config.LockTimeout)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := c.doUnlock(context.WithoutCancel(ctx), lock, nodeOperationKey(node)); err != nil {
+			log.WithFunc("calcium.withNodeKeyLocked").Errorf(ctx, err, "failed to unlock %s", nodeOperationKey(node))
+		}
+	}()
+	return f(ctx)
+}
+
+// withNodes resolves the filter without taking any lock, for paths that only read.
+func (c *Calcium) withNodes(ctx context.Context, nodeFilter *types.NodeFilter, f nodesHandler) error {
+	ns, err := c.filterNodes(ctx, nodeFilter)
+	if err != nil {
+		return err
+	}
+	nodes := make(map[string]*types.Node, len(ns))
+	for _, n := range ns {
+		nodes[n.Name] = n
+	}
+	return f(ctx, nodes)
+}
+
+func (c *Calcium) withNode(ctx context.Context, nodename string, f nodeHandler) error {
+	return withNodeLocked(ctx, nodename, c.withNodes, f)
+}
+
+func nodeOperationKey(node *types.Node) string {
+	return fmt.Sprintf(cluster.NodeOperationLock, node.Podname, node.Name)
+}
+
+func nodeOperationKeys(nodes []*types.Node) []string {
+	return utils.Map(nodes, nodeOperationKey)
+}
+
+func podKeys(nodes []*types.Node) []string {
+	return utils.Map(nodes, func(node *types.Node) string { return fmt.Sprintf(cluster.PodLock, node.Podname) })
 }
 
 func withNodeLocked(ctx context.Context, nodename string, withNodes func(context.Context, *types.NodeFilter, nodesHandler) error, f nodeHandler) error {

--- a/cluster/calcium/lock.go
+++ b/cluster/calcium/lock.go
@@ -1,9 +1,11 @@
 package calcium
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/projecteru2/core/cluster"
@@ -138,7 +140,7 @@ func (c *Calcium) withNodesLocked(ctx context.Context, nodeFilter *types.NodeFil
 	}
 
 	keys := keysOf(ns)
-	slices.Sort(keys)
+	slices.SortFunc(keys, byLockOrder)
 	var lock lock.DistributedLock
 	for _, key := range slices.Compact(keys) {
 		lock, ctx, err = c.doLock(ctx, key, c.config.LockTimeout)
@@ -206,4 +208,15 @@ func withNodeLocked(ctx context.Context, nodename string, withNodes func(context
 		}
 		return types.ErrNodeNotExists
 	})
+}
+
+// byLockOrder puts pod locks before node locks, so a plan blocks a node only for as long as it plans on it.
+func byLockOrder(a, b string) int {
+	rank := func(key string) int {
+		if strings.HasPrefix(key, "plock_") {
+			return 0
+		}
+		return 1
+	}
+	return cmp.Or(cmp.Compare(rank(a), rank(b)), strings.Compare(a, b))
 }

--- a/cluster/calcium/lock_test.go
+++ b/cluster/calcium/lock_test.go
@@ -30,7 +30,7 @@ func TestDoLock(t *testing.T) {
 	lock.On("Unlock", mock.Anything).Return(nil).Once()
 	_, _, err = c.doLock(ctx, "somename", 1)
 	assert.Error(t, err)
-	lock.On("Lock", mock.Anything).Return(ctx, nil)
+	lock.On("Lock", mock.Anything).Return(context.Background(), nil)
 	_, _, err = c.doLock(ctx, "somename", 1)
 	assert.NoError(t, err)
 }
@@ -77,7 +77,7 @@ func TestWithWorkloadsLocked(t *testing.T) {
 	store.On("GetWorkloads", mock.Anything, mock.Anything).Return([]*types.Workload{{}}, nil).Once()
 	err := c.withWorkloadsLocked(ctx, false, []string{"c1", "c2"}, func(ctx context.Context, workloads map[string]*types.Workload) error { return nil })
 	assert.Error(t, err)
-	lock.On("Lock", mock.Anything).Return(ctx, nil)
+	lock.On("Lock", mock.Anything).Return(context.Background(), nil)
 	store.On("GetWorkloads", mock.Anything, mock.Anything).Return(nil, types.ErrMockError).Once()
 	err = c.withWorkloadsLocked(ctx, false, []string{"c1", "c2"}, func(ctx context.Context, workloads map[string]*types.Workload) error { return nil })
 	assert.Error(t, err)
@@ -106,7 +106,7 @@ func TestWithWorkloadLocked(t *testing.T) {
 	store.On("GetWorkloads", mock.Anything, mock.Anything).Return([]*types.Workload{{}}, nil).Once()
 	err := c.withWorkloadLocked(ctx, "c1", false, func(ctx context.Context, workload *types.Workload) error { return nil })
 	assert.Error(t, err)
-	lock.On("Lock", mock.Anything).Return(ctx, nil)
+	lock.On("Lock", mock.Anything).Return(context.Background(), nil)
 	store.On("GetWorkloads", mock.Anything, mock.Anything).Return(nil, types.ErrMockError).Once()
 	err = c.withWorkloadLocked(ctx, "c1", false, func(ctx context.Context, workload *types.Workload) error { return nil })
 	assert.Error(t, err)
@@ -162,7 +162,7 @@ func TestWithNodesPlanLocked(t *testing.T) {
 	lock.On("Lock", mock.Anything).Return(t.Context(), types.ErrMockError).Once()
 	err = c.withNodesPlanLocked(ctx, &types.NodeFilter{Podname: "test", Includes: []string{"test"}, All: false}, func(ctx context.Context, nodes map[string]*types.Node) error { return nil })
 	assert.Error(t, err)
-	lock.On("Lock", mock.Anything).Return(ctx, nil)
+	lock.On("Lock", mock.Anything).Return(context.Background(), nil)
 	store.On("GetNode", mock.Anything, mock.Anything).Return(nil, types.ErrMockError).Once()
 	err = c.withNodesPlanLocked(ctx, &types.NodeFilter{Podname: "test", Includes: []string{"test"}, All: false}, func(ctx context.Context, nodes map[string]*types.Node) error { return nil })
 	assert.Error(t, err)
@@ -184,7 +184,7 @@ func TestWithNodesPlanLockedTakesPodAndNodeLocksInKeyOrder(t *testing.T) {
 	}
 	store.On("GetNodes", mock.Anything, mock.Anything).Return(nodes, nil)
 	lock := &lockmocks.DistributedLock{}
-	lock.On("Lock", mock.Anything).Return(t.Context(), nil)
+	lock.On("Lock", mock.Anything).Return(context.Background(), nil)
 	lock.On("Unlock", mock.Anything).Return(nil)
 	keys := []string{}
 	store.On("CreateLock", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
@@ -204,7 +204,7 @@ func TestWithNodesPlanLockedTakesOnlyTheNodeLockForOneCandidate(t *testing.T) {
 	store := c.store.(*storemocks.Store)
 	store.On("GetNode", mock.Anything, "a1").Return(&types.Node{NodeMeta: types.NodeMeta{Name: "a1", Podname: "poda"}, Available: true}, nil)
 	lock := &lockmocks.DistributedLock{}
-	lock.On("Lock", mock.Anything).Return(t.Context(), nil)
+	lock.On("Lock", mock.Anything).Return(context.Background(), nil)
 	lock.On("Unlock", mock.Anything).Return(nil)
 	keys := []string{}
 	store.On("CreateLock", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
@@ -257,7 +257,7 @@ func TestWithNodesOperationLocked(t *testing.T) {
 	lock.On("Lock", mock.Anything).Return(t.Context(), types.ErrMockError).Once()
 	err = c.withNodesOperationLocked(ctx, &types.NodeFilter{Podname: "test", Includes: []string{"test"}, All: false}, func(ctx context.Context, nodes map[string]*types.Node) error { return nil })
 	assert.Error(t, err)
-	lock.On("Lock", mock.Anything).Return(ctx, nil)
+	lock.On("Lock", mock.Anything).Return(context.Background(), nil)
 	store.On("GetNode", mock.Anything, mock.Anything).Return(nil, types.ErrMockError).Once()
 	err = c.withNodesOperationLocked(ctx, &types.NodeFilter{Podname: "test", Includes: []string{"test"}, All: false}, func(ctx context.Context, nodes map[string]*types.Node) error { return nil })
 	assert.Error(t, err)
@@ -288,7 +288,7 @@ func TestWithNodeOperationLocked(t *testing.T) {
 	lock := &lockmocks.DistributedLock{}
 	store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
 	lock.On("Unlock", mock.Anything).Return(nil)
-	lock.On("Lock", mock.Anything).Return(ctx, nil)
+	lock.On("Lock", mock.Anything).Return(context.Background(), nil)
 	store.On("GetNode", mock.Anything, mock.Anything).Return(nil, types.ErrMockError).Once()
 	err := c.withNodeOperationLocked(ctx, "test", func(ctx context.Context, node *types.Node) error { return nil })
 	assert.Error(t, err)

--- a/cluster/calcium/lock_test.go
+++ b/cluster/calcium/lock_test.go
@@ -196,7 +196,7 @@ func TestWithNodesPlanLockedTakesPodAndNodeLocksInKeyOrder(t *testing.T) {
 		return nil
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, []string{"cnode_op_poda_b1", "cnode_op_podb_a1", "cnode_op_podb_c1", "plock_poda", "plock_podb"}, keys)
+	assert.Equal(t, []string{"plock_poda", "plock_podb", "cnode_op_poda_b1", "cnode_op_podb_a1", "cnode_op_podb_c1"}, keys)
 }
 
 func TestWithNodesPlanLockedTakesOnlyTheNodeLockForOneCandidate(t *testing.T) {

--- a/cluster/calcium/lock_test.go
+++ b/cluster/calcium/lock_test.go
@@ -123,7 +123,7 @@ func TestWithWorkloadLocked(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestWithNodesPodLocked(t *testing.T) {
+func TestWithNodesPlanLocked(t *testing.T) {
 	c := NewTestCluster()
 	ctx := t.Context()
 	store := c.store.(*storemocks.Store)
@@ -141,11 +141,11 @@ func TestWithNodesPodLocked(t *testing.T) {
 		Available: true,
 	}
 	store.On("GetNodesByPod", mock.Anything, mock.Anything, mock.Anything).Return([]*types.Node{}, types.ErrMockError).Once()
-	err := c.withNodesPodLocked(ctx, &types.NodeFilter{Podname: "test", All: false}, func(ctx context.Context, nodes map[string]*types.Node) error { return nil })
+	err := c.withNodesPlanLocked(ctx, &types.NodeFilter{Podname: "test", All: false}, func(ctx context.Context, nodes map[string]*types.Node) error { return nil })
 	assert.Error(t, err)
 	store.On("GetNodesByPod", mock.Anything, mock.Anything, mock.Anything).Return([]*types.Node{}, nil).Once()
 	var ns map[string]*types.Node
-	err = c.withNodesPodLocked(ctx, &types.NodeFilter{Podname: "test", Labels: map[string]string{"eru": "2"}, All: false}, func(ctx context.Context, nodes map[string]*types.Node) error {
+	err = c.withNodesPlanLocked(ctx, &types.NodeFilter{Podname: "test", Labels: map[string]string{"eru": "2"}, All: false}, func(ctx context.Context, nodes map[string]*types.Node) error {
 		ns = nodes
 		return nil
 	})
@@ -153,28 +153,28 @@ func TestWithNodesPodLocked(t *testing.T) {
 	assert.Empty(t, ns)
 	store.On("GetNodesByPod", mock.Anything, mock.Anything, mock.Anything).Return([]*types.Node{}, nil)
 	store.On("GetNode", mock.Anything, mock.Anything).Return(nil, types.ErrMockError).Once()
-	err = c.withNodesPodLocked(ctx, &types.NodeFilter{Podname: "test", Includes: []string{"test"}, All: false}, func(ctx context.Context, nodes map[string]*types.Node) error { return nil })
+	err = c.withNodesPlanLocked(ctx, &types.NodeFilter{Podname: "test", Includes: []string{"test"}, All: false}, func(ctx context.Context, nodes map[string]*types.Node) error { return nil })
 	assert.Error(t, err)
 	store.On("GetNode", mock.Anything, mock.Anything).Return(node1, nil).Once()
 	lock := &lockmocks.DistributedLock{}
 	store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
 	lock.On("Unlock", mock.Anything).Return(nil)
 	lock.On("Lock", mock.Anything).Return(t.Context(), types.ErrMockError).Once()
-	err = c.withNodesPodLocked(ctx, &types.NodeFilter{Podname: "test", Includes: []string{"test"}, All: false}, func(ctx context.Context, nodes map[string]*types.Node) error { return nil })
+	err = c.withNodesPlanLocked(ctx, &types.NodeFilter{Podname: "test", Includes: []string{"test"}, All: false}, func(ctx context.Context, nodes map[string]*types.Node) error { return nil })
 	assert.Error(t, err)
 	lock.On("Lock", mock.Anything).Return(ctx, nil)
 	store.On("GetNode", mock.Anything, mock.Anything).Return(nil, types.ErrMockError).Once()
-	err = c.withNodesPodLocked(ctx, &types.NodeFilter{Podname: "test", Includes: []string{"test"}, All: false}, func(ctx context.Context, nodes map[string]*types.Node) error { return nil })
+	err = c.withNodesPlanLocked(ctx, &types.NodeFilter{Podname: "test", Includes: []string{"test"}, All: false}, func(ctx context.Context, nodes map[string]*types.Node) error { return nil })
 	assert.Error(t, err)
 	store.On("GetNode", mock.Anything, mock.Anything).Return(node1, nil)
-	err = c.withNodesPodLocked(ctx, &types.NodeFilter{Podname: "test", Includes: []string{"test"}, All: false}, func(ctx context.Context, nodes map[string]*types.Node) error {
+	err = c.withNodesPlanLocked(ctx, &types.NodeFilter{Podname: "test", Includes: []string{"test"}, All: false}, func(ctx context.Context, nodes map[string]*types.Node) error {
 		assert.Len(t, nodes, 1)
 		return nil
 	})
 	assert.NoError(t, err)
 }
 
-func TestWithNodesPodLockedTakesPodLocksInKeyOrder(t *testing.T) {
+func TestWithNodesPlanLockedTakesPodAndNodeLocksInKeyOrder(t *testing.T) {
 	c := NewTestCluster()
 	store := c.store.(*storemocks.Store)
 	nodes := []*types.Node{
@@ -191,44 +191,32 @@ func TestWithNodesPodLockedTakesPodLocksInKeyOrder(t *testing.T) {
 		keys = append(keys, args.String(0))
 	}).Return(lock, nil)
 
-	err := c.withNodesPodLocked(t.Context(), &types.NodeFilter{Includes: []string{"a1", "b1", "c1"}}, func(_ context.Context, locked map[string]*types.Node) error {
+	err := c.withNodesPlanLocked(t.Context(), &types.NodeFilter{Includes: []string{"a1", "b1", "c1"}}, func(_ context.Context, locked map[string]*types.Node) error {
 		assert.Len(t, locked, 3)
 		return nil
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, []string{"plock_poda", "plock_podb"}, keys)
+	assert.Equal(t, []string{"cnode_op_poda_b1", "cnode_op_podb_a1", "cnode_op_podb_c1", "plock_poda", "plock_podb"}, keys)
 }
 
-func TestWithNodePodLocked(t *testing.T) {
+func TestWithNodesPlanLockedTakesOnlyTheNodeLockForOneCandidate(t *testing.T) {
 	c := NewTestCluster()
-	ctx := t.Context()
 	store := c.store.(*storemocks.Store)
-	rmgr := c.rmgr.(*resourcemocks.Manager)
-	rmgr.On("GetNodeResourceInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil, nil, nil)
-
-	node1 := &types.Node{
-		NodeMeta: types.NodeMeta{
-			Name: "test",
-			Labels: map[string]string{
-				"eru": "1",
-			},
-			Podname: "test",
-		},
-		Available: true,
-	}
+	store.On("GetNode", mock.Anything, "a1").Return(&types.Node{NodeMeta: types.NodeMeta{Name: "a1", Podname: "poda"}, Available: true}, nil)
 	lock := &lockmocks.DistributedLock{}
-	store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
+	lock.On("Lock", mock.Anything).Return(t.Context(), nil)
 	lock.On("Unlock", mock.Anything).Return(nil)
-	lock.On("Lock", mock.Anything).Return(ctx, nil)
-	store.On("GetNode", mock.Anything, mock.Anything).Return(nil, types.ErrMockError).Once()
-	err := c.withNodePodLocked(ctx, "test", func(ctx context.Context, node *types.Node) error { return nil })
-	assert.Error(t, err)
-	store.On("GetNode", mock.Anything, mock.Anything).Return(node1, nil)
-	err = c.withNodePodLocked(ctx, "test", func(ctx context.Context, node *types.Node) error {
-		assert.Equal(t, node.Name, node1.Name)
+	keys := []string{}
+	store.On("CreateLock", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		keys = append(keys, args.String(0))
+	}).Return(lock, nil)
+
+	err := c.withNodesPlanLocked(t.Context(), &types.NodeFilter{Includes: []string{"a1"}}, func(_ context.Context, locked map[string]*types.Node) error {
+		assert.Len(t, locked, 1)
 		return nil
 	})
 	assert.NoError(t, err)
+	assert.Equal(t, []string{"cnode_op_poda_a1"}, keys)
 }
 
 func TestWithNodesOperationLocked(t *testing.T) {
@@ -311,7 +299,7 @@ func TestWithNodeOperationLocked(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	err = c.withNodePodLocked(ctx, "test", func(ctx context.Context, node *types.Node) error {
+	err = c.withNodeOperationLocked(ctx, "test", func(ctx context.Context, node *types.Node) error {
 		return c.withNodeOperationLocked(ctx, node.Name, func(ctx context.Context, node *types.Node) error {
 			assert.Equal(t, node.Name, node1.Name)
 			return nil

--- a/cluster/calcium/node.go
+++ b/cluster/calcium/node.go
@@ -93,7 +93,7 @@ func (c *Calcium) RemoveNode(ctx context.Context, nodename string) error {
 		logger.Error(ctx, types.ErrEmptyNodeName)
 		return types.ErrEmptyNodeName
 	}
-	return c.withNodePodLocked(ctx, nodename, func(ctx context.Context, node *types.Node) error {
+	return c.withNodeOperationLocked(ctx, nodename, func(ctx context.Context, node *types.Node) error {
 		workloads, err := c.ListNodeWorkloads(ctx, node.Name, nil)
 		if err != nil {
 			logger.Error(ctx, err)
@@ -195,7 +195,7 @@ func (c *Calcium) SetNode(ctx context.Context, opts *types.SetNodeOptions) (*typ
 		return nil, err
 	}
 	var n *types.Node
-	err := c.withNodePodLocked(ctx, opts.Nodename, func(ctx context.Context, node *types.Node) error {
+	err := c.withNodeOperationLocked(ctx, opts.Nodename, func(ctx context.Context, node *types.Node) error {
 		logger.Info(ctx, "set node")
 		var err error
 		if err = c.refreshResourceInfo(ctx, node); err != nil {

--- a/cluster/calcium/node_test.go
+++ b/cluster/calcium/node_test.go
@@ -99,7 +99,7 @@ func TestRemoveNode(t *testing.T) {
 	store := c.store.(*storemocks.Store)
 
 	lock := &lockmocks.DistributedLock{}
-	lock.On("Lock", mock.Anything).Return(ctx, nil)
+	lock.On("Lock", mock.Anything).Return(context.Background(), nil)
 	lock.On("Unlock", mock.Anything).Return(nil)
 	store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
 	name := "test"
@@ -242,7 +242,7 @@ func TestSetNode(t *testing.T) {
 
 		store := c.store.(*storemocks.Store)
 		lock := &lockmocks.DistributedLock{}
-		lock.On("Lock", mock.Anything).Return(ctx, nil)
+		lock.On("Lock", mock.Anything).Return(context.Background(), nil)
 		lock.On("Unlock", mock.Anything).Return(nil)
 		store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
 		name := "test"

--- a/cluster/calcium/pod.go
+++ b/cluster/calcium/pod.go
@@ -25,11 +25,7 @@ func (c *Calcium) RemovePod(ctx context.Context, podname string) error {
 		return types.ErrEmptyPodName
 	}
 
-	nodeFilter := &types.NodeFilter{
-		Podname: podname,
-		All:     true,
-	}
-	return c.withNodesPodLocked(ctx, nodeFilter, func(ctx context.Context, _ map[string]*types.Node) error {
+	return c.withPodLocked(ctx, podname, func(ctx context.Context, _ map[string]*types.Node) error {
 		err := c.store.RemovePod(ctx, podname)
 		logger.Error(ctx, err)
 		return err

--- a/cluster/calcium/pod_test.go
+++ b/cluster/calcium/pod_test.go
@@ -1,6 +1,7 @@
 package calcium
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -39,7 +40,7 @@ func TestRemovePod(t *testing.T) {
 
 	store := c.store.(*storemocks.Store)
 	lock := &lockmocks.DistributedLock{}
-	lock.On("Lock", mock.Anything).Return(ctx, nil)
+	lock.On("Lock", mock.Anything).Return(context.Background(), nil)
 	lock.On("Unlock", mock.Anything).Return(nil)
 	store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
 	store.On("RemovePod", mock.Anything, mock.Anything).Return(nil)

--- a/cluster/calcium/raw_engine_test.go
+++ b/cluster/calcium/raw_engine_test.go
@@ -1,6 +1,7 @@
 package calcium
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,7 +19,7 @@ func TestRawEngine(t *testing.T) {
 	ctx := t.Context()
 	store := c.store.(*storemocks.Store)
 	lock := &lockmocks.DistributedLock{}
-	lock.On("Lock", mock.Anything).Return(ctx, nil)
+	lock.On("Lock", mock.Anything).Return(context.Background(), nil)
 	lock.On("Unlock", mock.Anything).Return(nil)
 	store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
 	workload := &types.Workload{

--- a/cluster/calcium/realloc.go
+++ b/cluster/calcium/realloc.go
@@ -21,15 +21,15 @@ func (c *Calcium) ReallocResource(ctx context.Context, opts *types.ReallocOption
 	if err != nil {
 		return err
 	}
+	node, err := c.store.GetNode(ctx, workload.Nodename)
+	if err != nil {
+		return err
+	}
 	var repair reallocRepair
-	err = c.withNodePodLocked(ctx, workload.Nodename, func(ctx context.Context, node *types.Node) error {
-		return c.withNodeOperationLocked(ctx, node.Name, func(ctx context.Context, node *types.Node) error {
-			return c.withWorkloadLocked(ctx, opts.ID, false, func(ctx context.Context, workload *types.Workload) error {
-				repair, err = c.doReallocOnNode(ctx, node, workload, opts)
-				logger.Error(ctx, err)
-				return err
-			})
-		})
+	err = c.withWorkloadLocked(ctx, opts.ID, false, func(ctx context.Context, workload *types.Workload) error {
+		repair, err = c.doReallocOnNode(ctx, node, workload, opts)
+		logger.Error(ctx, err)
+		return err
 	})
 	if repair != nil {
 		repair()
@@ -60,9 +60,10 @@ func (c *Calcium) doReallocOnNode(ctx context.Context, node *types.Node, workloa
 	settled, err := utils.Txn(
 		ctx,
 		func(ctx context.Context) error {
-			// Realloc mutates node resource meta in the resource plugin
-			engineParams, deltaResources, resources, err = c.rmgr.Realloc(ctx, workload.Nodename, workload.Resources, opts.Resources)
-			if err != nil {
+			if err = c.withNodeKeyLocked(ctx, node, func(ctx context.Context) (err error) {
+				engineParams, deltaResources, resources, err = c.rmgr.Realloc(ctx, workload.Nodename, workload.Resources, opts.Resources)
+				return err
+			}); err != nil {
 				return err
 			}
 			reallocated = true
@@ -81,7 +82,9 @@ func (c *Calcium) doReallocOnNode(ctx context.Context, node *types.Node, workloa
 			}
 			c.remapped.Delete(workload.Nodename)
 			var rollbackErr error
-			if resourceErr := c.rmgr.RollbackRealloc(ctx, workload.Nodename, deltaResources); resourceErr != nil {
+			if resourceErr := c.withNodeKeyLocked(ctx, node, func(ctx context.Context) error {
+				return c.rmgr.RollbackRealloc(ctx, workload.Nodename, deltaResources)
+			}); resourceErr != nil {
 				rollbackErr = errors.Join(rollbackErr, resourceErr)
 				logger.Errorf(ctx, rollbackErr, "failed to rollback workload %+v, resource args %+v, engine args %+v", workload.ID, litter.Sdump(resources), litter.Sdump(engineParams))
 			}

--- a/cluster/calcium/realloc_test.go
+++ b/cluster/calcium/realloc_test.go
@@ -28,7 +28,7 @@ func TestRealloc(t *testing.T) {
 	c.config.Scheduler.ShareBase = 100
 
 	lock := &lockmocks.DistributedLock{}
-	lock.On("Lock", mock.Anything).Return(ctx, nil)
+	lock.On("Lock", mock.Anything).Return(context.Background(), nil)
 	lock.On("Unlock", mock.Anything).Return(nil)
 
 	engine := &enginemocks.API{}
@@ -121,7 +121,7 @@ func TestReallocJournalsRepairEntries(t *testing.T) {
 	c.wal = mwal
 
 	lock := &lockmocks.DistributedLock{}
-	lock.On("Lock", mock.Anything).Return(ctx, nil)
+	lock.On("Lock", mock.Anything).Return(context.Background(), nil)
 	lock.On("Unlock", mock.Anything).Return(nil)
 	engine := &enginemocks.API{}
 	engine.On("VirtualizationUpdateResource", mock.Anything, mock.Anything, mock.Anything).Return(nil)
@@ -164,7 +164,7 @@ func TestReallocRepairsRuntimeBeforeCommittingItsJournal(t *testing.T) {
 	workload := &types.Workload{ID: "c1", Nodename: node.Name, Engine: engine, EngineParams: oldParams}
 
 	lock := &lockmocks.DistributedLock{}
-	lock.On("Lock", mock.Anything).Return(ctx, nil)
+	lock.On("Lock", mock.Anything).Return(context.Background(), nil)
 	lock.On("Unlock", mock.Anything).Return(nil)
 	store := c.store.(*storemocks.Store)
 	store.On("UpdateWorkload", mock.Anything, mock.Anything).Return(nil)
@@ -221,7 +221,7 @@ func TestReallocKeepsRepairEntriesUntilRollbackCompletes(t *testing.T) {
 
 			store := c.store.(*storemocks.Store)
 			lock := &lockmocks.DistributedLock{}
-			lock.On("Lock", mock.Anything).Return(ctx, nil)
+			lock.On("Lock", mock.Anything).Return(context.Background(), nil)
 			lock.On("Unlock", mock.Anything).Return(nil)
 			store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
 			store.On("UpdateWorkload", mock.Anything, workload).Return(types.ErrMockError).Once()

--- a/cluster/calcium/realloc_test.go
+++ b/cluster/calcium/realloc_test.go
@@ -66,12 +66,12 @@ func TestRealloc(t *testing.T) {
 	store.AssertExpectations(t)
 	store.On("GetNode", mock.Anything, "node1").Return(node1, nil)
 
+	store.On("GetWorkloads", mock.Anything, []string{"c1"}).Return(newC1, nil)
 	store.On("CreateLock", mock.Anything, mock.Anything).Return(nil, types.ErrMockError).Once()
 	err = c.ReallocResource(ctx, opts)
 	assert.True(t, errors.Is(err, types.ErrMockError))
 	store.AssertExpectations(t)
 	store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
-	store.On("GetWorkloads", mock.Anything, []string{"c1"}).Return(newC1, nil)
 
 	rmgr.On("Realloc", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 		resourcetypes.Resources{}, nil, nil, types.ErrMockError,
@@ -220,6 +220,10 @@ func TestReallocKeepsRepairEntriesUntilRollbackCompletes(t *testing.T) {
 			workload := &types.Workload{ID: "c1", Nodename: node.Name, Engine: engine, Resources: resourcetypes.Resources{}}
 
 			store := c.store.(*storemocks.Store)
+			lock := &lockmocks.DistributedLock{}
+			lock.On("Lock", mock.Anything).Return(ctx, nil)
+			lock.On("Unlock", mock.Anything).Return(nil)
+			store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
 			store.On("UpdateWorkload", mock.Anything, workload).Return(types.ErrMockError).Once()
 			store.On("UpdateWorkload", mock.Anything, mock.Anything).Return(nil).Once()
 			rmgr := c.rmgr.(*resourcemocks.Manager)

--- a/cluster/calcium/remap_test.go
+++ b/cluster/calcium/remap_test.go
@@ -1,6 +1,7 @@
 package calcium
 
 import (
+	"context"
 	"strconv"
 	"sync/atomic"
 	"testing"
@@ -45,7 +46,7 @@ func TestRemapResource(t *testing.T) {
 
 	store.On("GetNode", mock.Anything, mock.Anything).Return(node, nil)
 	lock := &lockmocks.DistributedLock{}
-	lock.On("Lock", mock.Anything).Return(t.Context(), nil)
+	lock.On("Lock", mock.Anything).Return(context.Background(), nil)
 	lock.On("Unlock", mock.Anything).Return(nil)
 	store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
 	c.RemapResourceAndLog(t.Context(), log.WithField("test", "zc"), node)
@@ -131,7 +132,7 @@ func TestRemapReplayRecomputesFromLiveState(t *testing.T) {
 
 	store := c.store.(*storemocks.Store)
 	lock := &lockmocks.DistributedLock{}
-	lock.On("Lock", mock.Anything).Return(t.Context(), nil)
+	lock.On("Lock", mock.Anything).Return(context.Background(), nil)
 	lock.On("Unlock", mock.Anything).Return(nil)
 	store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
 	store.On("GetNode", mock.Anything, node.Name).Return(node, nil)

--- a/cluster/calcium/remove.go
+++ b/cluster/calcium/remove.go
@@ -72,25 +72,14 @@ func (c *Calcium) RemoveWorkload(ctx context.Context, IDs []string, force bool) 
 
 func (c *Calcium) doRemoveOneWorkload(ctx context.Context, node *types.Node, workload *types.Workload, force bool) error {
 	logger := log.WithFunc("calcium.doRemoveOneWorkload").WithField("id", workload.ID)
-
-	nodeCommit, err := c.journal(ctx, logger, eventWorkloadResourceAllocated, []*types.Node{node})
-	if err != nil {
-		return err
-	}
-	workloadCommit, err := c.journal(ctx, logger, eventWorkloadCreated, &types.Workload{ID: workload.ID, Name: workload.Name, Nodename: workload.Nodename})
-	if err != nil {
-		nodeCommit()
-		return err
-	}
-	defer workloadCommit()
-
-	err = c.withResourceReleased(ctx, node, workload, func(ctx context.Context) error {
+	return c.withResourceReleased(ctx, logger, node, workload, func(ctx context.Context) error {
+		workloadCommit, err := c.journal(ctx, logger, eventWorkloadCreated, &types.Workload{ID: workload.ID, Name: workload.Name, Nodename: workload.Nodename})
+		if err != nil {
+			return err
+		}
+		defer workloadCommit()
 		return c.doRemoveWorkload(ctx, workload, force)
 	})
-	if err == nil {
-		nodeCommit()
-	}
-	return err
 }
 
 func (c *Calcium) doRemoveWorkload(ctx context.Context, workload *types.Workload, force bool) error {

--- a/cluster/calcium/remove.go
+++ b/cluster/calcium/remove.go
@@ -6,11 +6,15 @@ import (
 	"sync"
 
 	"github.com/cockroachdb/errors"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/projecteru2/core/log"
 	"github.com/projecteru2/core/types"
 	"github.com/projecteru2/core/utils"
 )
+
+// removeWorkers bounds the engine removes in flight on one node.
+const removeWorkers = 16
 
 func (c *Calcium) RemoveWorkload(ctx context.Context, IDs []string, force bool) (chan *types.RemoveWorkloadMessage, error) {
 	logger := log.WithFunc("calcium.RemoveWorkload").WithField("IDs", IDs).WithField("force", force)
@@ -37,11 +41,11 @@ func (c *Calcium) RemoveWorkload(ctx context.Context, IDs []string, force bool) 
 					_ = send(caller, ch, &types.RemoveWorkloadMessage{Success: false})
 					return
 				}
-				var removes sync.WaitGroup
+				var removes errgroup.Group
+				removes.SetLimit(removeWorkers)
 				for _, workloadID := range workloadIDs {
-					removes.Add(1)
-					_ = c.pool.Invoke(func() {
-						defer removes.Done()
+					removes.Go(func() error {
+						defer log.SentryDefer()
 						ret := &types.RemoveWorkloadMessage{WorkloadID: workloadID, Success: true, Hook: []*bytes.Buffer{}}
 						if workloadErr := c.withWorkloadLocked(ctx, workloadID, false, func(ctx context.Context, workload *types.Workload) error {
 							if err := c.doRemoveOneWorkload(ctx, node, workload, force); err != nil {
@@ -55,9 +59,10 @@ func (c *Calcium) RemoveWorkload(ctx context.Context, IDs []string, force bool) 
 							ret.Success = false
 						}
 						_ = send(caller, ch, ret)
+						return nil
 					})
 				}
-				removes.Wait()
+				_ = removes.Wait()
 				c.invokePoolAsync(func() { c.RemapResourceAndLog(ctx, logger, node) })
 			})
 		}

--- a/cluster/calcium/remove.go
+++ b/cluster/calcium/remove.go
@@ -77,17 +77,20 @@ func (c *Calcium) doRemoveOneWorkload(ctx context.Context, node *types.Node, wor
 	if err != nil {
 		return err
 	}
-	defer nodeCommit()
-
 	workloadCommit, err := c.journal(ctx, logger, eventWorkloadCreated, &types.Workload{ID: workload.ID, Name: workload.Name, Nodename: workload.Nodename})
 	if err != nil {
+		nodeCommit()
 		return err
 	}
 	defer workloadCommit()
 
-	return c.withResourceReleased(ctx, node, workload, func(ctx context.Context) error {
+	err = c.withResourceReleased(ctx, node, workload, func(ctx context.Context) error {
 		return c.doRemoveWorkload(ctx, workload, force)
 	})
+	if err == nil {
+		nodeCommit()
+	}
+	return err
 }
 
 func (c *Calcium) doRemoveWorkload(ctx context.Context, workload *types.Workload, force bool) error {

--- a/cluster/calcium/remove.go
+++ b/cluster/calcium/remove.go
@@ -31,8 +31,17 @@ func (c *Calcium) RemoveWorkload(ctx context.Context, IDs []string, force bool) 
 			wg.Add(1)
 			_ = c.pool.Invoke(func() {
 				defer wg.Done()
-				if nodeErr := c.withNodePodLocked(ctx, nodename, func(ctx context.Context, node *types.Node) error {
-					for _, workloadID := range workloadIDs {
+				node, err := c.store.GetNode(ctx, nodename)
+				if err != nil {
+					logger.WithField("node", nodename).Error(ctx, err, "failed to get node")
+					_ = send(caller, ch, &types.RemoveWorkloadMessage{Success: false})
+					return
+				}
+				var removes sync.WaitGroup
+				for _, workloadID := range workloadIDs {
+					removes.Add(1)
+					_ = c.pool.Invoke(func() {
+						defer removes.Done()
 						ret := &types.RemoveWorkloadMessage{WorkloadID: workloadID, Success: true, Hook: []*bytes.Buffer{}}
 						if workloadErr := c.withWorkloadLocked(ctx, workloadID, false, func(ctx context.Context, workload *types.Workload) error {
 							if err := c.doRemoveOneWorkload(ctx, node, workload, force); err != nil {
@@ -45,16 +54,11 @@ func (c *Calcium) RemoveWorkload(ctx context.Context, IDs []string, force bool) 
 							ret.Hook = append(ret.Hook, bytes.NewBufferString(workloadErr.Error()))
 							ret.Success = false
 						}
-						if err := send(caller, ch, ret); err != nil {
-							return err
-						}
-					}
-					c.invokePoolAsync(func() { c.RemapResourceAndLog(ctx, logger, node) })
-					return nil
-				}); nodeErr != nil {
-					logger.WithField("node", nodename).Error(ctx, nodeErr, "failed to lock node")
-					_ = send(caller, ch, &types.RemoveWorkloadMessage{Success: false})
+						_ = send(caller, ch, ret)
+					})
 				}
+				removes.Wait()
+				c.invokePoolAsync(func() { c.RemapResourceAndLog(ctx, logger, node) })
 			})
 		}
 	})

--- a/cluster/calcium/remove_test.go
+++ b/cluster/calcium/remove_test.go
@@ -26,7 +26,7 @@ func TestRemoveWorkload(t *testing.T) {
 		defer c.pool.Release()
 		ctx := t.Context()
 		lock := &lockmocks.DistributedLock{}
-		lock.On("Lock", mock.Anything).Return(ctx, nil)
+		lock.On("Lock", mock.Anything).Return(context.Background(), nil)
 		lock.On("Unlock", mock.Anything).Return(nil)
 		store := c.store.(*storemocks.Store)
 		rmgr := c.rmgr.(*resourcemocks.Manager)
@@ -135,7 +135,7 @@ func TestRemoveWorkloadJournalsRepairEntries(t *testing.T) {
 	c.wal = mwal
 
 	lock := &lockmocks.DistributedLock{}
-	lock.On("Lock", mock.Anything).Return(ctx, nil)
+	lock.On("Lock", mock.Anything).Return(context.Background(), nil)
 	lock.On("Unlock", mock.Anything).Return(nil)
 	engine := &enginemocks.API{}
 	engine.On("VirtualizationRemove", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
@@ -161,6 +161,44 @@ func TestRemoveWorkloadJournalsRepairEntries(t *testing.T) {
 	assert.Equal(t, 2, committed)
 }
 
+func TestRemoveWorkloadKeepsTheNodeEntryWhenTheReleaseFails(t *testing.T) {
+	c := NewTestCluster()
+	ctx := t.Context()
+
+	committed := []string{}
+	mwal := &walmocks.WAL{}
+	mwal.On("Log", mock.Anything, mock.Anything).Return(func(eventyp string, _ any) (wal.Commit, error) {
+		return func() error { committed = append(committed, eventyp); return nil }, nil
+	})
+	c.wal = mwal
+
+	lock := &lockmocks.DistributedLock{}
+	lock.On("Lock", mock.Anything).Return(context.Background(), nil)
+	lock.On("Unlock", mock.Anything).Return(nil)
+	engine := &enginemocks.API{}
+	engine.On("VirtualizationRemove", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	workload := &types.Workload{ID: "xx", Name: "test", Nodename: "test", Engine: engine}
+
+	store := c.store.(*storemocks.Store)
+	store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
+	store.On("GetWorkloads", mock.Anything, mock.Anything).Return([]*types.Workload{workload}, nil)
+	store.On("GetNode", mock.Anything, mock.Anything).Return(&types.Node{NodeMeta: types.NodeMeta{Name: "test"}}, nil)
+	store.On("RemoveWorkload", mock.Anything, mock.Anything).Return(nil)
+	store.On("ListNodeWorkloads", mock.Anything, mock.Anything, mock.Anything).Return(nil, types.ErrMockError)
+	rmgr := c.rmgr.(*resourcemocks.Manager)
+	rmgr.On("SetNodeResourceUsage", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+		nil, nil, types.ErrMockError,
+	)
+
+	ch, err := c.RemoveWorkload(ctx, []string{"xx"}, true)
+	assert.NoError(t, err)
+	for r := range ch {
+		assert.True(t, r.Success)
+	}
+	engine.AssertExpectations(t)
+	assert.Equal(t, []string{eventWorkloadCreated}, committed)
+}
+
 func TestRemoveWorkloadLocksTheWorkloadThenItsNode(t *testing.T) {
 	c := NewTestCluster()
 	defer c.pool.Release()
@@ -178,7 +216,7 @@ func TestRemoveWorkloadLocksTheWorkloadThenItsNode(t *testing.T) {
 	rmgr.On("SetNodeResourceUsage", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(resourcetypes.Resources{}, resourcetypes.Resources{}, nil)
 	rmgr.On("Remap", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
 	lock := &lockmocks.DistributedLock{}
-	lock.On("Lock", mock.Anything).Return(ctx, nil)
+	lock.On("Lock", mock.Anything).Return(context.Background(), nil)
 	lock.On("Unlock", mock.Anything).Return(nil)
 	var mu sync.Mutex
 	keys := []string{}

--- a/cluster/calcium/remove_test.go
+++ b/cluster/calcium/remove_test.go
@@ -199,6 +199,45 @@ func TestRemoveWorkloadKeepsTheNodeEntryWhenTheReleaseFails(t *testing.T) {
 	assert.Equal(t, []string{eventWorkloadCreated}, committed)
 }
 
+func TestRemoveWorkloadKeepsTheNodeEntryWhenTheRemovalFails(t *testing.T) {
+	c := NewTestCluster()
+	ctx := t.Context()
+
+	committed := []string{}
+	mwal := &walmocks.WAL{}
+	mwal.On("Log", mock.Anything, mock.Anything).Return(func(eventyp string, _ any) (wal.Commit, error) {
+		return func() error { committed = append(committed, eventyp); return nil }, nil
+	})
+	c.wal = mwal
+
+	lock := &lockmocks.DistributedLock{}
+	lock.On("Lock", mock.Anything).Return(context.Background(), nil)
+	lock.On("Unlock", mock.Anything).Return(nil)
+	engine := &enginemocks.API{}
+	engine.On("VirtualizationRemove", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(types.ErrMockError)
+	workload := &types.Workload{ID: "xx", Name: "test", Nodename: "test", Engine: engine}
+
+	store := c.store.(*storemocks.Store)
+	store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
+	store.On("GetWorkloads", mock.Anything, mock.Anything).Return([]*types.Workload{workload}, nil)
+	store.On("GetNode", mock.Anything, mock.Anything).Return(&types.Node{NodeMeta: types.NodeMeta{Name: "test"}}, nil)
+	store.On("RemoveWorkload", mock.Anything, mock.Anything).Return(nil)
+	store.On("AddWorkload", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	store.On("ListNodeWorkloads", mock.Anything, mock.Anything, mock.Anything).Return(nil, types.ErrMockError)
+	rmgr := c.rmgr.(*resourcemocks.Manager)
+	rmgr.On("SetNodeResourceUsage", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+		resourcetypes.Resources{}, resourcetypes.Resources{}, nil,
+	)
+
+	ch, err := c.RemoveWorkload(ctx, []string{"xx"}, true)
+	assert.NoError(t, err)
+	for r := range ch {
+		assert.False(t, r.Success)
+	}
+	engine.AssertExpectations(t)
+	assert.Equal(t, []string{eventWorkloadCreated}, committed)
+}
+
 func TestRemoveWorkloadLocksTheWorkloadThenItsNode(t *testing.T) {
 	c := NewTestCluster()
 	defer c.pool.Release()

--- a/cluster/calcium/remove_test.go
+++ b/cluster/calcium/remove_test.go
@@ -2,6 +2,7 @@ package calcium
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"testing/synctest"
 
@@ -158,4 +159,42 @@ func TestRemoveWorkloadJournalsRepairEntries(t *testing.T) {
 	}
 	assert.Equal(t, []string{eventWorkloadResourceAllocated, eventWorkloadCreated}, logged)
 	assert.Equal(t, 2, committed)
+}
+
+func TestRemoveWorkloadLocksTheWorkloadThenItsNode(t *testing.T) {
+	c := NewTestCluster()
+	defer c.pool.Release()
+	ctx := t.Context()
+	store := c.store.(*storemocks.Store)
+	rmgr := c.rmgr.(*resourcemocks.Manager)
+	engine := &enginemocks.API{}
+	engine.On("VirtualizationRemove", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	workload := &types.Workload{ID: "w1", Name: "app_entry_x", Nodename: "n1", Engine: engine}
+	node := &types.Node{NodeMeta: types.NodeMeta{Name: "n1", Podname: "p1"}}
+	store.On("GetWorkloads", mock.Anything, mock.Anything).Return([]*types.Workload{workload}, nil)
+	store.On("GetNode", mock.Anything, "n1").Return(node, nil)
+	store.On("RemoveWorkload", mock.Anything, mock.Anything).Return(nil)
+	store.On("ListNodeWorkloads", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
+	rmgr.On("SetNodeResourceUsage", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(resourcetypes.Resources{}, resourcetypes.Resources{}, nil)
+	rmgr.On("Remap", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
+	lock := &lockmocks.DistributedLock{}
+	lock.On("Lock", mock.Anything).Return(ctx, nil)
+	lock.On("Unlock", mock.Anything).Return(nil)
+	var mu sync.Mutex
+	keys := []string{}
+	store.On("CreateLock", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		mu.Lock()
+		defer mu.Unlock()
+		keys = append(keys, args.String(0))
+	}).Return(lock, nil)
+
+	ch, err := c.RemoveWorkload(ctx, []string{"w1"}, true)
+	assert.NoError(t, err)
+	for m := range ch {
+		assert.True(t, m.Success)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, []string{"clock_w1", "cnode_op_p1_n1"}, keys[:2], "the workload lock first, then the node lock around the release, never the pod lock")
+	assert.NotContains(t, keys, "plock_p1")
 }

--- a/cluster/calcium/replace_test.go
+++ b/cluster/calcium/replace_test.go
@@ -1,6 +1,7 @@
 package calcium
 
 import (
+	"context"
 	"sync/atomic"
 	"testing"
 
@@ -21,7 +22,7 @@ func TestReplaceWorkload(t *testing.T) {
 	c := NewTestCluster()
 	ctx := t.Context()
 	lock := &lockmocks.DistributedLock{}
-	lock.On("Lock", mock.Anything).Return(ctx, nil)
+	lock.On("Lock", mock.Anything).Return(context.Background(), nil)
 	lock.On("Unlock", mock.Anything).Return(nil)
 	store := c.store.(*storemocks.Store)
 	rmgr := c.rmgr.(*resourcemocks.Manager)

--- a/cluster/calcium/resource.go
+++ b/cluster/calcium/resource.go
@@ -13,7 +13,7 @@ import (
 func (c *Calcium) PodResource(ctx context.Context, podname string) (chan *types.NodeResourceInfo, error) {
 	logger := log.WithFunc("calcium.PodResource").WithField("podname", podname)
 	var ch chan *types.NodeResourceInfo
-	err := c.withNodesPodLocked(ctx, &types.NodeFilter{Podname: podname}, func(ctx context.Context, nodes map[string]*types.Node) error {
+	err := c.withNodes(ctx, &types.NodeFilter{Podname: podname}, func(ctx context.Context, nodes map[string]*types.Node) error {
 		ch = make(chan *types.NodeResourceInfo, len(nodes))
 		defer close(ch)
 		wg := &sync.WaitGroup{}
@@ -55,10 +55,15 @@ func (c *Calcium) doGetNodeResource(ctx context.Context, nodename string, inspec
 		return nil, types.ErrEmptyNodeName
 	}
 	var nr *types.NodeResourceInfo
-	if err := c.withNodePodLocked(ctx, nodename, func(ctx context.Context, node *types.Node) (err error) {
+	compute := func(ctx context.Context, node *types.Node) (err error) {
 		nr, err = c.doComputeNodeResource(ctx, node.Name, fix)
 		return err
-	}); err != nil {
+	}
+	withNode := c.withNode
+	if fix {
+		withNode = c.withNodeOperationLocked
+	}
+	if err := withNode(ctx, nodename, compute); err != nil {
 		return nil, err
 	}
 

--- a/cluster/calcium/resource_test.go
+++ b/cluster/calcium/resource_test.go
@@ -1,6 +1,7 @@
 package calcium
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -76,7 +77,7 @@ func TestNodeResource(t *testing.T) {
 	rmgr := c.rmgr.(*resourcemocks.Manager)
 	lock := &lockmocks.DistributedLock{}
 	store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
-	lock.On("Lock", mock.Anything).Return(ctx, nil)
+	lock.On("Lock", mock.Anything).Return(context.Background(), nil)
 	lock.On("Unlock", mock.Anything).Return(nil)
 
 	node := &types.Node{

--- a/cluster/calcium/resource_test.go
+++ b/cluster/calcium/resource_test.go
@@ -21,10 +21,6 @@ func TestPodResource(t *testing.T) {
 	nodename := "testnode"
 	store := c.store.(*storemocks.Store)
 	rmgr := c.rmgr.(*resourcemocks.Manager)
-	lock := &lockmocks.DistributedLock{}
-	lock.On("Lock", mock.Anything).Return(ctx, nil)
-	lock.On("Unlock", mock.Anything).Return(nil)
-
 	store.On("GetNodesByPod", mock.Anything, mock.Anything, mock.Anything).Return(nil, types.ErrMockError).Once()
 	ch, err := c.PodResource(ctx, podname)
 	assert.Error(t, err)
@@ -35,8 +31,6 @@ func TestPodResource(t *testing.T) {
 		},
 	}
 	store.On("GetNodesByPod", mock.Anything, mock.Anything, mock.Anything).Return([]*types.Node{node}, nil)
-	store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
-
 	store.On("ListNodeWorkloads", mock.Anything, mock.Anything, mock.Anything).Return(nil, types.ErrMockError).Once()
 	ch, err = c.PodResource(ctx, podname)
 	assert.NoError(t, err)

--- a/cluster/calcium/send_test.go
+++ b/cluster/calcium/send_test.go
@@ -1,6 +1,7 @@
 package calcium
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -32,7 +33,7 @@ func TestSend(t *testing.T) {
 	}
 	store := c.store.(*storemocks.Store)
 	lock := &lockmocks.DistributedLock{}
-	lock.On("Lock", mock.Anything).Return(ctx, nil)
+	lock.On("Lock", mock.Anything).Return(context.Background(), nil)
 	lock.On("Unlock", mock.Anything).Return(nil)
 	store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
 	store.On("GetWorkloads", mock.Anything, mock.Anything).Return(nil, types.ErrMockError).Once()

--- a/cluster/calcium/sendlarge_test.go
+++ b/cluster/calcium/sendlarge_test.go
@@ -28,7 +28,7 @@ func TestSendLarge(t *testing.T) {
 	store := &storemocks.Store{}
 	c.store = store
 	lock := &lockmocks.DistributedLock{}
-	lock.On("Lock", mock.Anything).Return(t.Context(), nil)
+	lock.On("Lock", mock.Anything).Return(context.Background(), nil)
 	lock.On("Unlock", mock.Anything).Return(nil)
 	store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
 	store.On("GetWorkloads", mock.Anything, mock.Anything).Return(nil, types.ErrMockError).Once()

--- a/cluster/calcium/utils.go
+++ b/cluster/calcium/utils.go
@@ -14,14 +14,13 @@ import (
 	"github.com/projecteru2/core/utils"
 )
 
-// withResourceReleased journals the node, runs the removal, then gives the workload's usage back under the node lock; the usage stays charged until the workload is gone, and a failed release stays in the journal for repair.
+// withResourceReleased journals the node, runs the removal, then gives the workload's usage back under the node lock; the usage stays charged until the workload is gone, and a failed removal or release stays in the journal for repair.
 func (c *Calcium) withResourceReleased(ctx context.Context, logger *log.Fields, node *types.Node, workload *types.Workload, remove func(context.Context) error) error {
 	nodeCommit, err := c.journal(ctx, logger, eventWorkloadResourceAllocated, []*types.Node{node})
 	if err != nil {
 		return err
 	}
 	if err = remove(ctx); err != nil {
-		nodeCommit()
 		return err
 	}
 	err = c.withNodeKeyLocked(ctx, node, func(ctx context.Context) (err error) {

--- a/cluster/calcium/utils.go
+++ b/cluster/calcium/utils.go
@@ -14,15 +14,26 @@ import (
 	"github.com/projecteru2/core/utils"
 )
 
-// withResourceReleased runs the removal, then gives the workload's usage back under the node lock; the usage stays charged until the workload is gone, so a deploy in between cannot take it.
-func (c *Calcium) withResourceReleased(ctx context.Context, node *types.Node, workload *types.Workload, remove func(context.Context) error) error {
-	if err := remove(ctx); err != nil {
+// withResourceReleased journals the node, runs the removal, then gives the workload's usage back under the node lock; the usage stays charged until the workload is gone, and a failed release stays in the journal for repair.
+func (c *Calcium) withResourceReleased(ctx context.Context, logger *log.Fields, node *types.Node, workload *types.Workload, remove func(context.Context) error) error {
+	nodeCommit, err := c.journal(ctx, logger, eventWorkloadResourceAllocated, []*types.Node{node})
+	if err != nil {
 		return err
 	}
-	return c.withNodeKeyLocked(ctx, node, func(ctx context.Context) (err error) {
+	if err = remove(ctx); err != nil {
+		nodeCommit()
+		return err
+	}
+	err = c.withNodeKeyLocked(ctx, node, func(ctx context.Context) (err error) {
 		_, _, err = c.rmgr.SetNodeResourceUsage(ctx, node.Name, nil, nil, []resourcetypes.Resources{workload.Resources}, true, plugins.Decr)
 		return err
 	})
+	if err != nil {
+		logger.WithField("id", workload.ID).Error(ctx, err, "usage release left to the journal")
+		return nil
+	}
+	nodeCommit()
+	return nil
 }
 
 func (c *Calcium) invokePoolAsync(f func()) {

--- a/cluster/calcium/utils.go
+++ b/cluster/calcium/utils.go
@@ -17,17 +17,21 @@ import (
 func (c *Calcium) withResourceReleased(ctx context.Context, node *types.Node, workload *types.Workload, then func(context.Context) error) error {
 	_, err := utils.Txn(
 		ctx,
-		func(ctx context.Context) (err error) {
-			_, _, err = c.rmgr.SetNodeResourceUsage(ctx, node.Name, nil, nil, []resourcetypes.Resources{workload.Resources}, true, plugins.Decr)
-			return err
+		func(ctx context.Context) error {
+			return c.withNodeKeyLocked(ctx, node, func(ctx context.Context) (err error) {
+				_, _, err = c.rmgr.SetNodeResourceUsage(ctx, node.Name, nil, nil, []resourcetypes.Resources{workload.Resources}, true, plugins.Decr)
+				return err
+			})
 		},
 		then,
-		func(ctx context.Context, failedByCond bool) (err error) {
+		func(ctx context.Context, failedByCond bool) error {
 			if failedByCond {
 				return nil
 			}
-			_, _, err = c.rmgr.SetNodeResourceUsage(ctx, node.Name, nil, nil, []resourcetypes.Resources{workload.Resources}, true, plugins.Incr)
-			return err
+			return c.withNodeKeyLocked(ctx, node, func(ctx context.Context) (err error) {
+				_, _, err = c.rmgr.SetNodeResourceUsage(ctx, node.Name, nil, nil, []resourcetypes.Resources{workload.Resources}, true, plugins.Incr)
+				return err
+			})
 		},
 		c.config.GlobalTimeout,
 	)

--- a/cluster/calcium/utils.go
+++ b/cluster/calcium/utils.go
@@ -14,28 +14,15 @@ import (
 	"github.com/projecteru2/core/utils"
 )
 
-func (c *Calcium) withResourceReleased(ctx context.Context, node *types.Node, workload *types.Workload, then func(context.Context) error) error {
-	_, err := utils.Txn(
-		ctx,
-		func(ctx context.Context) error {
-			return c.withNodeKeyLocked(ctx, node, func(ctx context.Context) (err error) {
-				_, _, err = c.rmgr.SetNodeResourceUsage(ctx, node.Name, nil, nil, []resourcetypes.Resources{workload.Resources}, true, plugins.Decr)
-				return err
-			})
-		},
-		then,
-		func(ctx context.Context, failedByCond bool) error {
-			if failedByCond {
-				return nil
-			}
-			return c.withNodeKeyLocked(ctx, node, func(ctx context.Context) (err error) {
-				_, _, err = c.rmgr.SetNodeResourceUsage(ctx, node.Name, nil, nil, []resourcetypes.Resources{workload.Resources}, true, plugins.Incr)
-				return err
-			})
-		},
-		c.config.GlobalTimeout,
-	)
-	return err
+// withResourceReleased runs the removal, then gives the workload's usage back under the node lock; the usage stays charged until the workload is gone, so a deploy in between cannot take it.
+func (c *Calcium) withResourceReleased(ctx context.Context, node *types.Node, workload *types.Workload, remove func(context.Context) error) error {
+	if err := remove(ctx); err != nil {
+		return err
+	}
+	return c.withNodeKeyLocked(ctx, node, func(ctx context.Context) (err error) {
+		_, _, err = c.rmgr.SetNodeResourceUsage(ctx, node.Name, nil, nil, []resourcetypes.Resources{workload.Resources}, true, plugins.Decr)
+		return err
+	})
 }
 
 func (c *Calcium) invokePoolAsync(f func()) {

--- a/cluster/calcium/wal_test.go
+++ b/cluster/calcium/wal_test.go
@@ -26,7 +26,7 @@ func TestHandleWorkloadResourceAllocatedMultipleNodes(t *testing.T) {
 	store := c.store.(*storemocks.Store)
 	rmgr := c.rmgr.(*resourcemocks.Manager)
 	lock := &lockmocks.DistributedLock{}
-	lock.On("Lock", mock.Anything).Return(t.Context(), nil)
+	lock.On("Lock", mock.Anything).Return(context.Background(), nil)
 	lock.On("Unlock", mock.Anything).Return(nil)
 	store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
 	store.On("ListNodeWorkloads", mock.Anything, mock.Anything, mock.Anything).Return(nil, types.ErrMockError)
@@ -54,7 +54,7 @@ func TestHandleWorkloadResourceAllocatedKeepsEntryUntilEveryNodeIsFixed(t *testi
 	enableTestWAL(t, c)
 	store := c.store.(*storemocks.Store)
 	lock := &lockmocks.DistributedLock{}
-	lock.On("Lock", mock.Anything).Return(t.Context(), nil)
+	lock.On("Lock", mock.Anything).Return(context.Background(), nil)
 	lock.On("Unlock", mock.Anything).Return(nil)
 	store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
 	store.On("GetNode", mock.Anything, "n1").Return(&types.Node{NodeMeta: types.NodeMeta{Name: "n1"}}, nil)
@@ -281,7 +281,7 @@ func TestHandleReallocWorkload(t *testing.T) {
 	engineParams := resourcetypes.Resources{"cpumem": {"cpu": 2}}
 	store := c.store.(*storemocks.Store)
 	lock := &lockmocks.DistributedLock{}
-	lock.On("Lock", mock.Anything).Return(t.Context(), nil)
+	lock.On("Lock", mock.Anything).Return(context.Background(), nil)
 	lock.On("Unlock", mock.Anything).Return(nil)
 	store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
 	store.On("GetNode", mock.Anything, "n1").Return(&types.Node{NodeMeta: types.NodeMeta{Name: "n1"}}, nil)
@@ -308,7 +308,7 @@ func TestHandleReallocWorkloadOnAnEngineThatCannotReplayIt(t *testing.T) {
 	engineParams := resourcetypes.Resources{"cpumem": {"cpu": 2}}
 	store := c.store.(*storemocks.Store)
 	lock := &lockmocks.DistributedLock{}
-	lock.On("Lock", mock.Anything).Return(t.Context(), nil)
+	lock.On("Lock", mock.Anything).Return(context.Background(), nil)
 	lock.On("Unlock", mock.Anything).Return(nil)
 	store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
 	store.On("GetNode", mock.Anything, "n1").Return(&types.Node{NodeMeta: types.NodeMeta{Name: "n1"}}, nil)
@@ -379,7 +379,7 @@ func TestHandleCreateLambda(t *testing.T) {
 			Once()
 		store.On("ListNodeWorkloads", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil).Once()
 		lock := &lockmocks.DistributedLock{}
-		lock.On("Lock", mock.Anything).Return(t.Context(), nil)
+		lock.On("Lock", mock.Anything).Return(context.Background(), nil)
 		lock.On("Unlock", mock.Anything).Return(nil)
 		store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
 


### PR DESCRIPTION
The C-4 decision from the audit: layer the pod lock instead of removing it.

Every remove, dissociate, realloc, node change and single-node deploy took the pod lock, so a pod's churn was one serialized queue: a hundred removes on one node ran their engine deletes one after another under it (22s on the lane).

- The pod lock now guards only a multi-node deploy plan, which also takes every candidate node's operation lock (`cnode_op_<pod>_<node>`) before it reads capacity, so a plugin's read-modify-write of a node's usage always runs under that node's lock, whichever path writes it.
- A single-node deploy takes the node lock alone.
- Remove and dissociate take the workload lock and hold the node lock only around the usage release (and its rollback), so engine removes on one node run in parallel and different nodes never wait on each other.
- Realloc holds the node lock only around the plugin writes.
- Read-only paths (PodResource, CalculateCapacity, NodeResource without --fix) take no lock (B12); --fix takes the node lock. RemovePod keeps the pod lock.
- Lock order: every path acquires its keys sorted, so `clock_` < `cnode_op_` < `plock_`, and no path takes a workload lock after a node lock (realloc and remove used to nest the other way).

Tests: TestWithNodesPlanLockedTakesPodAndNodeLocksInKeyOrder, TestWithNodesPlanLockedTakesOnlyTheNodeLockForOneCandidate, TestRemoveWorkloadLocksTheWorkloadThenItsNode, plus the existing suites. Lane A/B (remove@N on eru-n2, deploy/remove across two mock nodes, e2e-a/b1) follows in a comment.