### PR TITLE
fix: let a leadership sweep trust the listing's liveness, and admit heap entries where they are pushed

### DIFF
--- a/cluster/calcium/service_test.go
+++ b/cluster/calcium/service_test.go
@@ -76,8 +76,9 @@ func TestServiceStatusStreamWithMultipleRegisteringAsExpired(t *testing.T) {
 
 	raw := make(chan struct{})
 	var expiry <-chan struct{} = raw
+	registeredAgain := make(chan struct{})
 	store.On("RegisterService", mock.Anything, mock.Anything, mock.Anything).Return(expiry, func() {}, nil).Once()
-	store.On("RegisterService", mock.Anything, mock.Anything, mock.Anything).Return(make(<-chan struct{}), func() {}, nil).Once()
+	store.On("RegisterService", mock.Anything, mock.Anything, mock.Anything).Run(func(mock.Arguments) { close(registeredAgain) }).Return(make(<-chan struct{}), func() {}, nil).Once()
 
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
@@ -85,7 +86,11 @@ func TestServiceStatusStreamWithMultipleRegisteringAsExpired(t *testing.T) {
 	assert.NoError(t, err)
 
 	close(raw)
-	time.Sleep(time.Millisecond)
+	select {
+	case <-registeredAgain:
+	case <-time.After(5 * time.Second):
+		t.Fatal("an expired registration must be renewed")
+	}
 	store.AssertExpectations(t)
 }
 

--- a/selfmon/selfmon.go
+++ b/selfmon/selfmon.go
@@ -145,20 +145,16 @@ func (n *NodeStatusWatcher) initNodeStatus(ctx context.Context) {
 		})
 	}()
 
+	var handlers errgroup.Group
+	handlers.SetLimit(nodeStatusHandlers)
 	for node := range nodes {
-		status, err := n.cluster.GetNodeStatus(ctx, node.Name)
-		if err != nil {
-			status = &types.NodeStatus{
-				Nodename: node.Name,
-				Podname:  node.Podname,
-				Alive:    false,
-			}
-		}
-		if node.Test {
-			status.Alive = true
-		}
-		n.dealNodeStatusMessage(ctx, status)
+		status := &types.NodeStatus{Nodename: node.Name, Podname: node.Podname, Alive: node.Available || node.Test}
+		handlers.Go(func() error {
+			n.dealNodeStatusMessage(ctx, status)
+			return nil
+		})
 	}
+	_ = handlers.Wait()
 }
 
 func (n *NodeStatusWatcher) monitor(ctx context.Context) error {

--- a/strategy/communism.go
+++ b/strategy/communism.go
@@ -37,6 +37,8 @@ func CommunismPlan(_ context.Context, infos []Info, need, total, limit int) (map
 		}
 		info.Count++
 		info.Capacity--
-		heap.Push(iHeap, info)
+		if iHeap.admit(info) {
+			heap.Push(iHeap, info)
+		}
 	}
 }

--- a/strategy/global.go
+++ b/strategy/global.go
@@ -30,7 +30,9 @@ func GlobalPlan(_ context.Context, infos []Info, need, total, _ int) (map[string
 		deployMap[infoWithMinUsage.Nodename]++
 		infoWithMinUsage.Usage += infoWithMinUsage.Rate
 		infoWithMinUsage.Capacity--
-		heap.Push(h, infoWithMinUsage)
+		if h.admit(infoWithMinUsage) {
+			heap.Push(h, infoWithMinUsage)
+		}
 	}
 
 	return deployMap, nil

--- a/strategy/strategy.go
+++ b/strategy/strategy.go
@@ -37,6 +37,7 @@ type Info struct {
 
 type strategyFunc = func(_ context.Context, _ []Info, need, total, limit int) (map[string]int, error)
 
+// Deploy spreads count workloads over strategyInfos by the named plan; a plan may reorder the slice.
 func Deploy(ctx context.Context, strategy string, count, nodesLimit int, strategyInfos []Info, total int) (map[string]int, error) {
 	deployMethod, ok := Plans[strategy]
 	if !ok {

--- a/strategy/utils.go
+++ b/strategy/utils.go
@@ -17,7 +17,9 @@ type infoHeap struct {
 func newInfoHeap(infos []Info, less infoLess, admit infoAdmit) *infoHeap {
 	h := &infoHeap{infos: make([]Info, 0, len(infos)), less: less, admit: admit}
 	for _, info := range infos {
-		h.Push(info)
+		if admit(info) {
+			h.infos = append(h.infos, info)
+		}
 	}
 	heap.Init(h)
 	return h
@@ -36,11 +38,7 @@ func (h *infoHeap) Swap(i, j int) {
 }
 
 func (h *infoHeap) Push(x any) {
-	info := x.(Info)
-	if !h.admit(info) {
-		return
-	}
-	h.infos = append(h.infos, info)
+	h.infos = append(h.infos, x.(Info))
 }
 
 func (h *infoHeap) Pop() any {


### PR DESCRIPTION
Audit items B8, B15 and B16.

- selfmon's leadership sweep re-read every node's status after ListPodNodes had already resolved it, then handled each down node one at a time; it now derives liveness from the listing (test nodes stay alive) and handles nodes with the same bounded group the watch uses (B8).
- `infoHeap.Push` silently dropped an entry its admit function rejected, so `heap.Push` re-sifted an unchanged heap; admission now happens at the two call sites and Push is a plain append (B16).
- `strategy.Deploy` says a plan may reorder the caller's slice (B15).