### PR TITLE
docs: align the guides with the code

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -23,7 +23,7 @@ username and whose *value* is the password. The Go client does this for you — 
 | RPC | Request | Description |
 | --- | --- | --- |
 | `AddPod` | `name`, `desc` | Create a pod |
-| `RemovePod` | `name` | Remove a pod. Locks every node in it first |
+| `RemovePod` | `name` | Remove a pod. Takes the pod lock first |
 | `GetPod` | `name` | One pod |
 | `ListPods` | `Empty` | All pods |
 
@@ -31,12 +31,12 @@ username and whose *value* is the password. The Go client does this for you — 
 
 | RPC | Request | Description |
 | --- | --- | --- |
-| `AddNode` | `nodename`, `endpoint`, `podname`, `ca`/`cert`/`key`, `labels`, `resources`, `test` | Connect to the endpoint, read engine info, register the node with the resource plugins, then write its metadata |
+| `AddNode` | `nodename`, `endpoint`, `podname`, `labels`, `resources`, `test` | Connect to the endpoint, read engine info, register the node with the resource plugins, then write its metadata |
 | `RemoveNode` | `nodename` | Remove a node. Fails if it still hosts workloads |
 | `ListPodNodes` ⇊ | `podname`, `all`, `labels`, `timeout_in_second`, `skip_info` | Nodes of a pod. `all` includes nodes that are down; `skip_info` skips the engine round-trip; a `timeout_in_second` of 0 or less falls back to `connection_timeout` |
 | `GetNode` | `nodename`, `labels` | One node |
 | `GetNodeEngineInfo` | `nodename` | The node's engine type |
-| `SetNode` | `nodename`, `endpoint`, `ca`/`cert`/`key`, `labels`, `resources`, `delta`, `workloads_down`, `bypass` | Update a node. `delta` treats `resources` as a delta; `bypass` is a tri-state (`KEEP`/`TRUE`/`FALSE`) that takes the node out of scheduling; `workloads_down` marks its workloads dead |
+| `SetNode` | `nodename`, `endpoint`, `labels`, `resources`, `delta`, `workloads_down`, `bypass` | Update a node. `delta` treats `resources` as a delta; `bypass` is a tri-state (`KEEP`/`TRUE`/`FALSE`) that takes the node out of scheduling; `workloads_down` marks its workloads dead |
 
 `resources` on `AddNode`/`SetNode` is `map<string, bytes>` — one JSON document per resource
 plugin name. See [Resource plugins](resource-plugins.md).
@@ -87,7 +87,7 @@ plugin name. See [Resource plugins](resource-plugins.md).
 | `ExecuteWorkload` ⇅ | `workload_id`, `commands`, `envs`, `workdir`, `open_stdin` | Exec inside a workload. When `open_stdin` is set, further client messages carry stdin in `repl_cmd` |
 | `RunAndWait` ⇅ | `deploy_options`, `cmd`, `async`, `async_timeout` | Lambda: deploy, attach, wait for exit, then remove. The first messages carry the new workload IDs (`TYPEWORKLOADID`), the last output line is `[exitcode] <n>`. With `async`, core sends the IDs, detaches from the stream, forces `open_stdin` off, and logs the output itself under `async_timeout` seconds (default `global_timeout`) |
 | `LogStream` ⇊ | `id`, `tail`, `since`, `until`, `follow` | Engine logs for one workload |
-| `RawEngine` | `id`, `op`, `params`, `ignore_lock` | Pass an engine-specific operation through to the node's engine. No engine implements it today; every one returns `ErrEngineNotImplemented` |
+| `RawEngine` | `id`, `op`, `params`, `ignore_lock` | Pass an engine-specific operation through to the node's engine. No real engine implements it; containerd, cocoon and process all return `ErrEngineNotImplemented` (the `mock://` engine answers with a canned result) |
 
 ## Files
 
@@ -139,7 +139,7 @@ The message behind `CreateWorkload`, `CalculateCapacity`, `RunAndWait` and `Repl
 | `env`, `dns`, `extra_hosts`, `networks`, `user`, `labels`, `nodelabels` | Passed to the engine |
 | `data`, `modes`, `owners` | Files to place inside each workload at create time |
 | `after_create` | Commands to run once the workload exists |
-| `open_stdin`, `debug`, `ignore_hook`, `ignore_pull` | Behaviour switches |
+| `open_stdin`, `debug`, `ignore_hook`, `ignore_pull` | Behaviour switches. `debug` is accepted but no code in core reads it today |
 | `raw_args` | Engine-specific JSON blob merged into the create request |
 
 Core adds `APP_NAME`, `ERU_POD`, `ERU_NODE_NAME` and `ERU_WORKLOAD_SEQ` to every workload's

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,7 +55,8 @@ The package splits by concern — `create.go`, `realloc.go`, `remove.go`, `disso
   taken in sorted order and released in reverse, and lock keys are `clock_<id>` for a workload,
   `plock_<pod>` for a pod and `cnode_op_<pod>_<node>` for a node operation.
 - `utils.Txn` — the if/then/rollback shape used everywhere a resource change and a metadata
-  change must agree. If `then` fails, `rollback` runs; if `if` fails, it does not.
+  change must agree. `rollback` runs on either failure and is told which stage failed;
+  `utils.PCR` is the variant that skips it when the `if` failed.
 - `c.pool` — an ants pool sized by `max_concurrency`, so fan-out over nodes and workloads has a
   bounded goroutine count.
 
@@ -72,7 +73,7 @@ service registration, ephemeral keys and lock creation. Two implementations —
 
 `engine.API` is the runtime abstraction: virtualization lifecycle, exec, image, network and log
 operations. `engine/factory` picks the implementation from the node endpoint's scheme and caches
-the client, keyed by endpoint plus TLS material. Engines are horizontally decoupled — no engine
+the client, keyed by the node endpoint. Engines are horizontally decoupled — no engine
 imports another; what they share lives in its own package, `engine/sshrunner` for the SSH
 transport the containerd and process engines both run on, `engine/journal` for the journalctl
 arguments they both render. See [Engines](engines.md).
@@ -90,8 +91,9 @@ bookkeeping; core owns node and workload metadata. See [Resource plugins](resour
 1. **rpc** converts the request, opens a task, and calls `Cluster.CreateWorkload`.
 2. **calcium** validates the options, stamps a random `ProcessIdent` on them and returns the
    channel; the rest happens on a pooled goroutine inside one `utils.Txn`.
-3. **Allocate** (`if`): lock every candidate node's pod, journal a
-   `allocate-workload` WAL entry naming the nodes, then
+3. **Allocate** (`if`): lock the candidate nodes (one candidate takes its node lock, several take
+   the pod lock and every node lock), journal a `allocate-workload` WAL entry naming the nodes,
+   then
    - ask the resource manager for each node's deploy capacity,
    - read the current deploy count per node from the store (deployed + in-flight),
    - hand both to `strategy.Deploy`, which returns `node -> count`,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -51,9 +51,10 @@ The package splits by concern — `create.go`, `realloc.go`, `remove.go`, `disso
 `lambda.go`, `log.go`, `network.go`, `node.go`, `pod.go`, `status.go`, `capacity.go`,
 `raw_engine.go`, `service.go`, `wal.go`, `remap.go` — over a small shared base:
 
-- `lock.go` — `withWorkloadLocked`, `withNodePodLocked`, `withNodeOperationLocked`. Locks are
-  taken in sorted order and released in reverse, and lock keys are `clock_<id>` for a workload,
-  `plock_<pod>` for a pod and `cnode_op_<pod>_<node>` for a node operation.
+- `lock.go` — `withWorkloadLocked`, `withNodesPlanLocked`, `withPodLocked`,
+  `withNodeOperationLocked`. Locks are taken in sorted order, pod locks before node locks, and
+  released in reverse; lock keys are `clock_<id>` for a workload, `plock_<pod>` for a pod and
+  `cnode_op_<pod>_<node>` for a node operation.
 - `utils.Txn` — the if/then/rollback shape used everywhere a resource change and a metadata
   change must agree. `rollback` runs on either failure and is told which stage failed;
   `utils.PCR` is the variant that skips it when the `if` failed.

--- a/docs/client.md
+++ b/docs/client.md
@@ -44,7 +44,9 @@ Importing `client` registers two gRPC resolvers, so `addr` may be:
 `eru://` is the interesting one: the client connects to the given address, subscribes to
 `WatchServiceStatus`, and rewrites the connection's address list every time core pushes a new set.
 Instances that come up join the round-robin pool, instances that go away leave it — no restart, no
-config change. A push with no addresses is ignored: a connection with none could never learn new ones. Credentials are passed as the `types.AuthConfig` argument to `NewClient`, not in the URL.
+config change. A push with no addresses is ignored: a connection with none could never learn new
+ones. The outer connection takes its credentials from the `types.AuthConfig` argument to
+`NewClient`; the `eru://` resolver takes the service-discovery credentials from the URL authority.
 
 ## Connection pool
 
@@ -82,9 +84,10 @@ for addresses := range ch {
 }
 ```
 
-`Watch` reconnects on its own: if the stream dies it retries after 10 seconds, and if no push
-arrives within the interval core advertised (twice `grpc.service_discovery_interval`) it cancels
-and re-establishes the watch rather than sitting on a silent connection.
+`Watch` reconnects on its own: a failed open is retried after 10 seconds, a broken stream is
+re-established at once, and if no push arrives within the interval core advertised (twice
+`grpc.service_discovery_interval`) it cancels and re-establishes the watch rather than sitting on
+a silent connection.
 
 ## Retries
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,8 +1,9 @@
 # Configuration
 
 Core reads one YAML file, given by `--config` or `ERU_CONFIG_PATH` (default `/etc/eru/core.yaml`).
-The file is loaded with [configor](https://github.com/jinzhu/configor): keys that are absent fall
-back to the `default` declared on the field in `types/config.go`, and unknown keys are ignored.
+The file is loaded with `gopkg.in/yaml.v3`; the `default` and `required` struct tags declared on
+the fields in `types/config.go` are applied by `utils/config.go`, so absent keys fall back to
+their default and unknown keys are ignored.
 
 [`core.yaml.sample`](https://github.com/projecteru2/core/blob/master/core.yaml.sample) in the repo
 root is a working starting point. Every key below is grouped the way that file groups them.
@@ -80,11 +81,12 @@ so the server must have them enabled.
 ## Git / SCM
 
 Only needed for `BuildImage` with the SCM build method. If `scm_type` is unset, core logs a
-warning at startup and the build API returns an error.
+warning at startup and an SCM build that names a repo fails with `ErrNoSCMSetting`; `RAW` and
+`EXIST` builds still work.
 
 | Key | Type | Default | Meaning |
 | --- | --- | --- | --- |
-| `git.scm_type` | string | — | `github` or `gitlab`; anything else disables the build API |
+| `git.scm_type` | string | — | `github` or `gitlab`; anything else leaves the SCM client unset, which only disables SCM builds |
 | `git.private_key` | string | — | Path to the SSH private key used to clone |
 | `git.token` | string | — | API token, sent as the `Authorization` header when fetching artifacts |
 | `git.clone_timeout` | duration | `300s` | Clone deadline |
@@ -183,9 +185,9 @@ See [Resource plugins](resource-plugins.md) for the contract these files must sa
 | `log.max_age` | int | `28` | Keep rotated files this many days |
 | `log.max_backups` | int | `3` | Keep at most this many rotated files |
 
-## Keys the sample still shows but core no longer reads
+## Keys core no longer reads
 
-`core.yaml.sample` predates two renames. Both are silently ignored if you copy them verbatim:
+`core.yaml.sample` still shows the first; older configs may carry all three. Each is silently ignored:
 
 - top-level `log_level` — use the `log:` section above (`log.level`)
 - the whole `docker:` section — the engine it configured is gone; `hub` and `namespace` moved to

--- a/docs/engines.md
+++ b/docs/engines.md
@@ -26,10 +26,11 @@ An endpoint with any other prefix is rejected with `ErrInvaildNodeEndpoint`.
 on TCP — `plugins/server/grpc` registers on the TCP listener just the plugins implementing
 `RegisterTCP`, and CRI is the only one — so the native API (containers, tasks, images, content,
 diff, events) is reachable on the unix socket alone. Core therefore dials it the way it dials a
-process node: one SSH connection per node, with containerd's gRPC client running over an OpenSSH
-socket forward (`direct-streamlocal`, on by default in sshd) of `containerd.socket`. The same
-connection carries `journalctl`, `ctr` and the CNI conf listing. `types.Node.{ca,cert,key}` are
-unused by this engine.
+process node: one control connection per node, plus up to four more for long-lived streams, with
+containerd's gRPC client running over an OpenSSH socket forward (`direct-streamlocal`, on by
+default in sshd) of `containerd.socket`. The control connection carries the non-follow
+`journalctl` and the CNI conf listing; `ctr tasks exec` and a followed `journalctl` take stream
+connections of their own. `types.Node.{ca,cert,key}` are unused by this engine.
 
 Everything containerd's API cannot answer from core is asked of the node over that connection: a
 task's stdio lives in node-local FIFOs, so `Execute` and the copy verbs run `ctr tasks exec` on
@@ -124,8 +125,8 @@ leaves nothing on the node and hangs the workload forever, which is precisely th
 must not be silent.
 
 The relays are closed once that exit is consumed, or when the workload is removed, and the fifo
-directory goes with the workload directory. Until then they hold three of the eight SSH sessions a
-node allows ([core#670](https://github.com/projecteru2/core/issues/670)). Such a workload has no
+directory goes with the workload directory. Until then they hold three slots on the node's stream
+connections ([core#670](https://github.com/projecteru2/core/issues/670)). Such a workload has no
 log shim and nothing in journald: its output travels the stream, exactly as it did with docker.
 Everything else keeps `NewTask` + `LogURI`.
 
@@ -263,7 +264,7 @@ the cocoon daemon's events on it. The eru name stays in the meta file and in cor
 | `VirtualizationLogs` | `journalctl SYSLOG_IDENTIFIER=eru ERU_ID=<id>` with `-n`, `--since` and `--until` — eru-agent copies the guest console into journald; a followed stream ends when the guest stops, and both `journalctl` and the status watcher are killed by pid rather than through a pipeline, since the watcher only notices a closed pipe at its next event |
 | `VirtualizationAttach` | without stdin, the journald follow; with stdin, `ErrEngineNotImplemented` — the console needs a pty (core#660) |
 | `Execute` / `ExecExitCode` | `vm exec [-i] [-e K=V …] <id> -- <cmd>` through cocoon-agent in pipe mode, stdio on the SSH session, the exit code the guest command's. `ExecResize` is `ErrEngineNotImplemented` (core#660). A `user` and a `working_dir` are applied inside a Linux guest by wrapping the command — `runuser -u U -- env --chdir=D <cmd>` for a bare user name, `setpriv --reuid=U --regid=G --clear-groups -- env --chdir=D <cmd>` when the id is numeric or a group is named — so the directory is entered as the target user; on a Windows guest both are `ErrEngineNotImplemented` |
-| `VirtualizationCopyTo` / `CopyFrom` | a one-entry tar through `vm exec … tar -x -P -f -` / `tar -c -P -f -`: the absolute entry name makes tar create the parents, and `tar.exe` ships with Windows 10+. A copy into a guest that is not running is `ErrEngineNotImplemented` — the state is checked first, one round trip per file |
+| `VirtualizationCopyTo` / `CopyFrom` | a one-entry tar through `vm exec … tar -x -P -f -` / `tar -c -P -f -`: the absolute entry name makes tar create the parents, and `tar.exe` ships with Windows 10+. A copy into a guest that is not running is `ErrInvaildWorkloadOps` — the state is checked first, one round trip per file |
 | `VirtualizationUpdateResource` | a remap (the cpumem binding refresh core runs after every deploy) is a no-op without a round trip; a realloc is `ErrEngineNotImplemented`, CPU and memory hot-plug wait on cocoon (core#661) |
 | `ImagePull` | `image pull <ref>` for OCI VM images and cloud-image URLs, registry auth left to cocoon's own config; a split-qcow2 artifact (the Windows images) is `oras pull`ed and `image import`ed under the same ref, once |
 | `ImageList` / `ImageRemove` | `image list --format json` filtered by name prefix / `image rm`. An empty store answers `No images found.` in prose rather than `[]`, and reads as an empty list, not a failed node |
@@ -302,7 +303,7 @@ hook carries survives both wrappers, which is why neither is a login shell.
 
 A VM has no way to take a file before it boots: the copy verbs go through cocoon-agent inside the
 guest, and core sends a deploy's `--file` set between the create and the start. Such a deploy fails
-with `ErrEngineNotImplemented` and "send them after the vm boots" rather than a tar error from a
+with `ErrInvaildWorkloadOps` and "send them after the vm boots" rather than a tar error from a
 guest that does not exist yet; the same holds for `replace --copy`. Files reach a VM through
 `eru-cli send` once it is running, or through the image.
 
@@ -386,8 +387,8 @@ artifacts can be pulled.
 pair in the `ssh` config block — the endpoint's user overrides `ssh.user` — and drives `systemd`,
 `journalctl`, `oras` and sftp. No eru daemon runs on the node. Every remote command is built as an
 argv and single-quoted before it is sent, so workload names, paths and environment values are
-never interpolated into a shell line. Sessions are bounded at eight per node, so a wide deploy
-queues instead of exhausting sshd's `MaxSessions`.
+never interpolated into a shell line. Control calls are bounded at eight sessions per node, so a
+wide deploy queues instead of exhausting sshd's `MaxSessions`.
 
 One transient service per workload (`eru-<id>.service`), one slice per pod (`eru-<pod>.slice`):
 
@@ -437,8 +438,8 @@ minimal bundle carries `sh` and often not `env`, which is why the shell enters t
 `ImagePush` has nothing left to do — `ImageBuildFromExist` pushes the artifact as it builds it.
 
 Resources land on cgroup v2 unit properties: `AllowedCPUs`, `AllowedMemoryNodes` and `CPUWeight`
-for bound CPUs, `CPUQuota` whenever a quota is set, then `MemoryMax`, `MemoryLow` (half the
-reservation), `MemorySwapMax=0`, `TasksMax` and the four `IO*Max` knobs per device. Volume
+for bound CPUs, `CPUQuota` whenever a quota is set, then `MemoryMax`, `MemoryLow` (half the limit,
+never under 4 MiB), `MemorySwapMax=0`, `TasksMax` and the four `IO*Max` knobs per device. Volume
 bindings become `BindPaths=` — `BindReadOnlyPaths=` for an `ro` mode — with the source expanded
 against the workload's environment and created before the unit starts; a bind needs no
 `RootDirectory=`, so raw workloads get them too. The resource knobs live in `<id>/props`, one
@@ -494,16 +495,15 @@ Two different things share the name:
 
 ## The engine cache
 
-`engine/factory` keeps one client per `(endpoint, ca, cert, key)` tuple, so repeated calls to the
-same node reuse one connection. Two background loops keep it honest:
+`engine/factory` keeps one client per node endpoint, so repeated calls to the same node reuse one
+connection. Two background loops keep it honest:
 
 - **Liveness sweep** — every `connection_timeout`, `Ping` every cached engine: `IsServing` over the
   forward for containerd, an SSH keepalive request on the connection for process and cocoon. Neither
   takes a session, so a node whose eight sessions are all held still answers, and the binary each
   engine needs is checked once at `AddNode` instead. A failing engine is
   replaced by `EngineWithErr` holding the error; a cached `EngineWithErr` is retried, and if it
-  connects, the real client takes its place. If the retry fails and the node's status key is gone,
-  the entry is dropped.
+  connects, the real client takes its place.
 - **Node status subscriber** — reads the store's node status stream. When a node goes down, every
   cached engine belonging to it is evicted; when a node's metadata turns out to be invalid, its
   metrics labels are removed too.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -18,6 +18,7 @@ zero-padded, so replaying the keys in order replays the entries in order.
 | `create-workload` | the engine is asked to create a workload, and before one is removed | removes the workload — from the store if it is there, otherwise off the engine, found by name when the entry has no ID yet |
 | `replace-workload` | the old workload of a replace is removed | removes the old workload if the new one reached the store, releasing nothing, because the new one inherited its resources |
 | `realloc-workload` | a realloc mutates plugin usage, metadata and engine limits | re-applies the stored engine params under the node-operation lock — the same step a failed realloc runs inline as its repair, committing the entry only when the reapply holds |
+| `remap-node` | a node's engine params are reapplied to its workloads | recomputes the remap and reapplies it under the node-operation lock |
 | `create-processing` | an in-flight deploy counter is written | deletes the stale counter, so it stops inflating deploy counts forever |
 | `create-lambda` | a `RunAndWait` workload starts | waits for it to exit, then removes it |
 
@@ -25,9 +26,9 @@ Each replayed handler gets a 32-second deadline. Entries whose handler is unknow
 skipped; entries that fail are logged and left in place for the next start.
 
 Because the journal is in the store, **any instance can finish another's work**. The active node
-status watcher keeps the live service addresses from the store's service stream and, every
-`grpc.service_heartbeat_interval`, replays the journal of every `/wal/` prefix whose address is no
-longer registered. It holds `/wal-replay/{address}` while it does, so two instances that disagree
+status watcher re-reads the live service addresses from the store every
+`grpc.service_heartbeat_interval` and replays the journal of every `/wal/` prefix whose address is
+no longer registered. It holds `/wal-replay/{address}` while it does, so two instances that disagree
 about who is dead still cannot replay one journal twice; the handlers are idempotent, so a second
 pass is harmless anyway.
 
@@ -44,8 +45,8 @@ workloads, ask the plugins for capacity and usage, inspect each workload on the 
 
 Every core instance starts a node status watcher, but only one is active at a time. They compete
 for an ephemeral key at `/selfmon/active` with a `ha_keepalive_interval` TTL; the winner runs, the
-losers retry every second and log once a minute. If the winner dies, its key expires and another
-takes over.
+losers retry every `ha_keepalive_interval`/4 (at least a second) and log once a minute. If the
+winner dies, its key expires and another takes over.
 
 The active watcher:
 
@@ -129,7 +130,8 @@ seconds.
 
 ## Instance identity
 
-Each instance's identifier is the SHA-256 of its marshalled config, and every workload it creates
-is labelled `eru.coreid` with that value. Instances sharing a config share an identity by design —
-it identifies the *cluster configuration* a workload belongs to, not the process that created it.
+Each instance's identifier is the SHA-256 of its store settings (`store`, `etcd.machines`,
+`etcd.prefix`, `redis.addr`, `redis.db`), and every workload it creates is labelled `eru.coreid`
+with that value. Instances sharing a store share an identity by design — it identifies the *store*
+a workload belongs to, not the process that created it.
 `Info` returns it.

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -41,8 +41,9 @@ ephemeral keys.
 - **TLS** — enabled only when `etcd.ca`, `etcd.cert` and `etcd.key` are all set.
 - **Auth** — `etcd.auth.username` / `password`.
 - **Watch streams** — `ServiceStatusStream`, `NodeStatusStream` and `WorkloadStatusStream` are
-  etcd watches on a prefix. Each opens the watch *before* the initial `Get`, so nothing is missed
-  between the snapshot and the stream.
+  etcd watches on a prefix. `ServiceStatusStream` opens its watch *before* its initial `Get`, so
+  nothing is missed between the snapshot and the stream; the node and workload streams carry no
+  snapshot and report changes only.
 
 ## redis
 
@@ -78,12 +79,12 @@ Core takes three kinds of lock, always in sorted order and always released in re
 
 | Key | Taken by |
 | --- | --- |
-| `plock_{podname}` | anything that reads or changes node resources: deploy, realloc, remove, dissociate, node resource inspection |
+| `plock_{podname}` | `RemovePod`, and a deploy whose plan spans more than one node |
 | `clock_{workloadID}` | anything that touches one workload |
 | `cnode_op_{podname}_{nodename}` | node operations that must not interleave, notably remap |
 
-A deploy holds the *pod* lock for the whole allocation phase, which is what serializes capacity
-decisions across instances.
+A deploy that plans on more than one node holds the *pod* lock for the whole allocation phase; a
+single-candidate deploy holds only that node's operation lock.
 
 ## Embedded etcd
 


### PR DESCRIPTION
Docs pass against the current code: every statement the 2026-09-03 docs audit found stale, wrong or missing, corrected in place.

Covers the pod-lock scope and the deploy lock steps, the removed TLS request fields, the engine cache key, the transaction rollback rule, the client credential and reconnect behaviour, the config loader, the SCM build failure mode, the removed sample sections, the SSH session model and the stream connections, the cocoon copy error, `MemoryLow`, the liveness sweep, the `remap-node` WAL event, the active watcher, the election retry interval, the instance identifier, the stream snapshot rule, the `RawEngine` mock answer and the unread `debug` option.

Evidence: every relative link in README.md and docs/ resolves; no Go change.
