### PR TITLE
fix: build the registry resolver per image call again

### DIFF
--- a/engine/containerd/containerd.go
+++ b/engine/containerd/containerd.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/containerd/containerd/v2/client"
-	"github.com/containerd/containerd/v2/core/remotes"
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/platforms"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -57,7 +56,6 @@ type Engine struct {
 	socket    string
 	host      string
 	platform  ocispec.Platform
-	resolver  remotes.Resolver
 
 	execs *sshrunner.Execs
 
@@ -115,7 +113,6 @@ func MakeClient(ctx context.Context, config coretypes.Config, nodename, endpoint
 func newEngine(e *Engine) *Engine {
 	e.execs = sshrunner.NewExecs()
 	e.attaches = map[string]*attach{}
-	e.resolver = newResolver(e.config.Registry)
 	return e
 }
 

--- a/engine/containerd/image.go
+++ b/engine/containerd/image.go
@@ -90,7 +90,7 @@ func (e *Engine) ImagesPrune(ctx context.Context) error {
 }
 
 func (e *Engine) ImagePull(ctx context.Context, ref string, _ bool) (io.ReadCloser, error) {
-	if _, err := e.client.Pull(ctx, normalizeRef(ref), client.WithPullUnpack, client.WithResolver(e.resolver)); err != nil {
+	if _, err := e.client.Pull(ctx, normalizeRef(ref), client.WithPullUnpack, client.WithResolver(e.resolver())); err != nil {
 		return nil, err
 	}
 	return io.NopCloser(strings.NewReader("")), nil
@@ -106,7 +106,7 @@ func (e *Engine) ImagePush(ctx context.Context, ref string) (io.ReadCloser, erro
 		}
 		return nil, err
 	}
-	if err = e.client.Push(ctx, ref, image.Target(), client.WithResolver(e.resolver)); err != nil {
+	if err = e.client.Push(ctx, ref, image.Target(), client.WithResolver(e.resolver())); err != nil {
 		return nil, err
 	}
 	return io.NopCloser(strings.NewReader("")), nil
@@ -127,7 +127,7 @@ func (e *Engine) ImageLocalDigests(ctx context.Context, image string) ([]string,
 
 func (e *Engine) ImageRemoteDigest(ctx context.Context, image string) (string, error) {
 	image = normalizeRef(image)
-	_, desc, err := e.resolver.Resolve(ctx, image)
+	_, desc, err := e.resolver().Resolve(ctx, image)
 	if err != nil {
 		return "", err
 	}
@@ -234,10 +234,10 @@ func (e *Engine) imageConfig(ctx context.Context, image client.Image) (*ocispec.
 	return &config.Config, nil
 }
 
-// newResolver authenticates every registry request against the configured credentials.
-func newResolver(registry coretypes.RegistryConfig) remotes.Resolver {
-	auths := registry.Auths
-	plainHTTP := registry.PlainHTTP
+// resolver authenticates every registry request against the configured credentials; its push tracker remembers blobs per digest, not per repository, so it must not outlive one call.
+func (e *Engine) resolver() remotes.Resolver {
+	auths := e.config.Registry.Auths
+	plainHTTP := e.config.Registry.PlainHTTP
 	return docker.NewResolver(docker.ResolverOptions{
 		Hosts: docker.ConfigureDefaultRegistries(
 			docker.WithAuthorizer(docker.NewDockerAuthorizer(docker.WithAuthCreds(func(host string) (string, string, error) {


### PR DESCRIPTION
The containerd docker pusher tracks pushed blobs by digest in the resolver's status tracker, so a resolver shared across calls (#729) skipped uploading a layer already pushed for one repository when the next push targeted another; the registry answered the manifest with `blob unknown to registry`. Seen on the lane's final E2E: an `image build --exist` push after a raw build of the same base image failed while every other build passed. The resolver is built per call again (its cost is one struct and an authorizer); the WHY line on `resolver` records the tracker's scope.

Gates: build, vet, full tests, lint and fmt-check on linux and darwin, asl on both: green. Lane: to be re-run on the merged build.