### PR TITLE
fix: release containerd attach relays at task end

### DIFF
--- a/engine/containerd/attach_test.go
+++ b/engine/containerd/attach_test.go
@@ -6,8 +6,10 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/errors"
+	"github.com/containerd/containerd/v2/client"
 
 	"github.com/projecteru2/core/engine/sshrunner"
 	"github.com/projecteru2/core/engine/sshrunner/sshrunnertest"
@@ -205,18 +207,25 @@ func TestARelayDeathIsSurfacedWithTheReasonTheNodeGave(t *testing.T) {
 	default:
 		t.Fatal("a relay that dies under the workload must not die silently")
 	}
+	if !dying.Closed() {
+		t.Error("an ended relay must return its stream slot")
+	}
 }
 
 func TestARelayThatEndsCleanlyIsNotReported(t *testing.T) {
 	relay, closed := watchedAttach()
+	ended := &sshrunnertest.Session{}
 
-	relay.watch(t.Context(), "app_web_abc123", "stdout", &sshrunnertest.Session{})
+	relay.watch(t.Context(), "app_web_abc123", "stdout", ended)
 
 	if len(relay.died) != 0 {
 		t.Error("a relay ends with the task it serves, and that is not a failure")
 	}
 	if *closed {
 		t.Error("only the stdin relay ending is the end of the workload's input")
+	}
+	if !ended.Closed() {
+		t.Error("an ended relay must return its stream slot")
 	}
 }
 
@@ -277,6 +286,59 @@ func TestStartRefusesAWorkloadWhoseRelayAlreadyDied(t *testing.T) {
 	}
 }
 
+func TestTaskExitReleasesEveryRelay(t *testing.T) {
+	opened := []*sshrunnertest.Session{parked(), {}, {}}
+	relay := &attach{stdin: opened[0], stdout: opened[1], stderr: opened[2]}
+	e := newEngine(&Engine{})
+	e.attaches["app_web_abc123"] = relay
+	exited := make(chan client.ExitStatus, 1)
+	exited <- *client.NewExitStatus(0, time.Time{}, nil)
+
+	e.releaseAttachWhenTaskEnds(t.Context(), "app_web_abc123", relay, &waitingTask{exited: exited})
+
+	for i, sess := range opened {
+		if !sess.Closed() {
+			t.Errorf("relay %d outlived the task", i)
+		}
+	}
+	if _, ok := e.attaches["app_web_abc123"]; ok {
+		t.Error("a task exit leaves no attach behind")
+	}
+}
+
+func TestAnOldTaskExitKeepsTheReplacementAttach(t *testing.T) {
+	old := &attach{}
+	currentStdin := &sshrunnertest.Session{}
+	current := &attach{stdin: currentStdin}
+	e := newEngine(&Engine{})
+	e.attaches["app_web_abc123"] = current
+	exited := make(chan client.ExitStatus, 1)
+	exited <- *client.NewExitStatus(0, time.Time{}, nil)
+
+	e.releaseAttachWhenTaskEnds(t.Context(), "app_web_abc123", old, &waitingTask{exited: exited})
+
+	if e.attaches["app_web_abc123"] != current {
+		t.Error("an old task exit must not remove the restarted task's attach")
+	}
+	if currentStdin.Closed() {
+		t.Error("an old task exit must not close the restarted task's relay")
+	}
+}
+
+func TestTaskWaitFailureKeepsTheAttachForFinalCleanup(t *testing.T) {
+	relay := &attach{stdin: &sshrunnertest.Session{}}
+	e := newEngine(&Engine{})
+	e.attaches["app_web_abc123"] = relay
+	exited := make(chan client.ExitStatus, 1)
+	exited <- *client.NewExitStatus(255, time.Time{}, errors.New("wait failed"))
+
+	e.releaseAttachWhenTaskEnds(t.Context(), "app_web_abc123", relay, &waitingTask{exited: exited})
+
+	if e.attaches["app_web_abc123"] != relay {
+		t.Error("a failed wait must leave the attach for stop, remove, or restart to clean")
+	}
+}
+
 func TestVirtualizationResizeIsANoOpOnAPipe(t *testing.T) {
 	e := testEngine(t, &sshrunnertest.Fake{})
 
@@ -295,4 +357,13 @@ func watchedAttach() (*attach, *bool) {
 		died:       make(chan error, relayStreams),
 		closeStdin: func(context.Context) error { *closed = true; return nil },
 	}, closed
+}
+
+type waitingTask struct {
+	client.Task
+	exited <-chan client.ExitStatus
+}
+
+func (t *waitingTask) Wait(context.Context) (<-chan client.ExitStatus, error) {
+	return t.exited, nil
 }

--- a/engine/containerd/lifecycle.go
+++ b/engine/containerd/lifecycle.go
@@ -40,10 +40,14 @@ func (e *Engine) VirtualizationStart(ctx context.Context, ID string) (err error)
 	}
 	// a task has fifos or a log uri, never both: an interactive workload takes the node fifos
 	creator := cio.LogURI(logShimURL)
+	var relay *attach
 	if _, stdin := info.Labels[stdinLabel]; stdin {
 		if creator, err = e.relayFifos(ctx, ID); err != nil {
 			return err
 		}
+		e.mu.Lock()
+		relay = e.attaches[ID]
+		e.mu.Unlock()
 		defer func() {
 			if err != nil {
 				e.releaseAttach(ID)
@@ -66,10 +70,21 @@ func (e *Engine) VirtualizationStart(ctx context.Context, ID string) (err error)
 	if err = e.relayFailure(ID); err != nil {
 		return err
 	}
-	return e.setDesiredStatus(ctx, found, info.Labels, client.Running)
+	if err = e.setDesiredStatus(ctx, found, info.Labels, client.Running); err != nil {
+		return err
+	}
+	if relay != nil {
+		go e.releaseAttachWhenTaskEnds(context.WithoutCancel(ctx), ID, relay, task)
+	}
+	return nil
 }
 
-func (e *Engine) VirtualizationStop(ctx context.Context, ID string, gracefulTimeout time.Duration) error {
+func (e *Engine) VirtualizationStop(ctx context.Context, ID string, gracefulTimeout time.Duration) (err error) {
+	defer func() {
+		if err == nil {
+			e.releaseAttach(ID)
+		}
+	}()
 	found, labels, err := e.markStopped(ctx, ID)
 	if err != nil {
 		return err
@@ -189,10 +204,10 @@ func (e *Engine) VirtualizationWait(ctx context.Context, ID, _ string) (*enginet
 	}
 	select {
 	case status := <-exited:
-		e.releaseAttach(ID)
 		if err = status.Error(); err != nil {
 			return &enginetypes.VirtualizationWaitResult{Message: err.Error(), Code: -1}, err
 		}
+		e.releaseAttach(ID)
 		return &enginetypes.VirtualizationWaitResult{Code: int64(status.ExitCode())}, nil
 	case <-ctx.Done():
 		return &enginetypes.VirtualizationWaitResult{Message: ctx.Err().Error(), Code: -1}, ctx.Err()

--- a/engine/containerd/lifecycle_test.go
+++ b/engine/containerd/lifecycle_test.go
@@ -19,6 +19,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/projecteru2/core/engine/sshrunner/sshrunnertest"
 	coretypes "github.com/projecteru2/core/types"
 )
 
@@ -62,6 +63,55 @@ func TestStopTreatsAVanishedTaskAsStopped(t *testing.T) {
 	}
 	if err := nilIfGone(coretypes.ErrMockError); !errors.Is(err, coretypes.ErrMockError) {
 		t.Errorf("got %v, want a real failure preserved", err)
+	}
+}
+
+func TestStopReleasesAttachWhenTaskIsAlreadyGone(t *testing.T) {
+	store := &trackingContainerStore{record: containers.Container{ID: "w1"}}
+	runtimeClient, err := client.New("", client.WithServices(
+		client.WithContainerStore(store),
+		client.WithTaskClient(&missingTaskClient{}),
+	))
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	opened := []*sshrunnertest.Session{{}, {}, {}}
+	e := newEngine(&Engine{client: runtimeClient})
+	e.attaches["w1"] = &attach{stdin: opened[0], stdout: opened[1], stderr: opened[2]}
+
+	if err = e.VirtualizationStop(t.Context(), "w1", 0); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+
+	for i, sess := range opened {
+		if !sess.Closed() {
+			t.Errorf("relay %d outlived the stopped task", i)
+		}
+	}
+	if _, ok := e.attaches["w1"]; ok {
+		t.Error("a stopped task leaves no attach behind")
+	}
+}
+
+func TestWaitFailureKeepsAttachForFinalCleanup(t *testing.T) {
+	store := &trackingContainerStore{record: containers.Container{ID: "w1"}}
+	runtimeClient, err := client.New("", client.WithServices(
+		client.WithContainerStore(store),
+		client.WithTaskClient(&waitFailureTaskClient{}),
+	))
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	relay := &attach{stdin: &sshrunnertest.Session{}}
+	e := newEngine(&Engine{client: runtimeClient})
+	e.attaches["w1"] = relay
+
+	if _, err = e.VirtualizationWait(t.Context(), "w1", ""); err == nil {
+		t.Fatal("a failed task wait must be reported")
+	}
+
+	if e.attaches["w1"] != relay {
+		t.Error("a failed wait must leave the attach for stop, remove, or restart to clean")
 	}
 }
 
@@ -130,4 +180,24 @@ type runningTaskClient struct {
 
 func (c *runningTaskClient) Get(context.Context, *tasks.GetRequest, ...grpc.CallOption) (*tasks.GetResponse, error) {
 	return &tasks.GetResponse{Process: &tasktypes.Process{ID: "w1", Status: tasktypes.Status_RUNNING}}, nil
+}
+
+type missingTaskClient struct {
+	tasks.TasksClient
+}
+
+func (c *missingTaskClient) Get(context.Context, *tasks.GetRequest, ...grpc.CallOption) (*tasks.GetResponse, error) {
+	return nil, status.Error(codes.NotFound, "task not found")
+}
+
+type waitFailureTaskClient struct {
+	tasks.TasksClient
+}
+
+func (c *waitFailureTaskClient) Get(context.Context, *tasks.GetRequest, ...grpc.CallOption) (*tasks.GetResponse, error) {
+	return &tasks.GetResponse{Process: &tasktypes.Process{ID: "w1", Status: tasktypes.Status_RUNNING}}, nil
+}
+
+func (c *waitFailureTaskClient) Wait(context.Context, *tasks.WaitRequest, ...grpc.CallOption) (*tasks.WaitResponse, error) {
+	return nil, status.Error(codes.Unavailable, "wait failed")
 }

--- a/engine/containerd/logs.go
+++ b/engine/containerd/logs.go
@@ -58,6 +58,7 @@ func (a *attach) close() {
 // watch reports a relay that ends on its own; its stderr is the only account of why it did.
 func (a *attach) watch(ctx context.Context, ID, stream string, sess sshrunner.Session) {
 	logger := log.WithFunc("engine.containerd.attach.watch").WithField("ID", ID)
+	defer func() { _ = sess.Close() }()
 	output, _ := io.ReadAll(sess.Stderr())
 	code, waitErr := sess.Wait()
 	reason := strings.TrimSpace(string(output))
@@ -185,11 +186,34 @@ func (e *Engine) relayFailure(ID string) error {
 func (e *Engine) releaseAttach(ID string) {
 	e.mu.Lock()
 	relay, ok := e.attaches[ID]
-	delete(e.attaches, ID)
 	e.mu.Unlock()
 	if ok {
-		relay.close()
+		e.releaseAttachIfCurrent(ID, relay)
 	}
+}
+
+func (e *Engine) releaseAttachIfCurrent(ID string, expected *attach) {
+	e.mu.Lock()
+	relay, ok := e.attaches[ID]
+	if !ok || relay != expected {
+		e.mu.Unlock()
+		return
+	}
+	delete(e.attaches, ID)
+	e.mu.Unlock()
+	relay.close()
+}
+
+func (e *Engine) releaseAttachWhenTaskEnds(ctx context.Context, ID string, relay *attach, task client.Task) {
+	exited, err := task.Wait(ctx)
+	if err != nil {
+		return
+	}
+	status, ok := <-exited
+	if !ok || status.Error() != nil {
+		return
+	}
+	e.releaseAttachIfCurrent(ID, relay)
 }
 
 func fifoSet(ID string) cio.Config {


### PR DESCRIPTION
## Summary

- close each FIFO relay session when its remote command ends so the SSH stream slot is returned
- release the current attach when the containerd task exits or `VirtualizationStop` succeeds
- preserve replacement attaches across restart races and keep attaches available for final cleanup when task waiting fails

## Why

An `OpenStdin` workload owns three long-lived SSH relay sessions. A normal stop or natural task exit could leave their wrappers registered and their bounded stream-pool slots held, so repeated interactive workloads could exhaust the pool. Cleanup now follows the task terminal state and remains idempotent.

## Verification

- `GOWORK=off go test -race -timeout 600s -count=1 ./...`
- `GOWORK=off make lint fmt-check`
- `GOWORK=off make vet`
- `GOOS=linux GOWORK=off asl ./...`
- `GOOS=darwin GOWORK=off asl ./...`
- `CGO_ENABLED=0 GOOS=linux GOWORK=off go build -o /dev/null .`
- `CGO_ENABLED=0 GOOS=darwin GOWORK=off go build -o /dev/null .`