### PR TITLE
fix: return the write error when a cpumem node repair cannot be stored

### DIFF
--- a/resource/plugins/cpumem/node.go
+++ b/resource/plugins/cpumem/node.go
@@ -269,7 +269,7 @@ func (p Plugin) FixNodeResource(ctx context.Context, nodename string, workloadsR
 		}
 		if err = p.doSetNodeResourceInfo(ctx, nodename, nodeResourceInfo); err != nil {
 			log.WithFunc("resource.cpumem.FixNodeResource").Error(ctx, err)
-			diffs = append(diffs, err.Error())
+			return nil, err
 		}
 	}
 

--- a/resource/plugins/cpumem/node_test.go
+++ b/resource/plugins/cpumem/node_test.go
@@ -1,6 +1,7 @@
 package cpumem
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"testing"
@@ -345,6 +346,16 @@ func TestGetAndFixNodeResourceInfo(t *testing.T) {
 	assert.Len(t, r.Usage["numa_memory"], 2)
 }
 
+func TestFixNodeResourceReturnsTheWriteError(t *testing.T) {
+	ctx := t.Context()
+	cm := initCPUMEM(t)
+	node := generateNodes(ctx, t, cm, 1, 2, 4*units.GB, 100, 0)[0]
+	cm.store = &putErrorStore{Store: cm.store}
+
+	_, err := cm.FixNodeResource(ctx, node, []plugintypes.WorkloadResource{{"cpu_request": 1.0, "memory_request": units.GB}})
+	assert.ErrorIs(t, err, coretypes.ErrMockError)
+}
+
 func TestSetNodeResourceInfo(t *testing.T) {
 	ctx := t.Context()
 	cm := initCPUMEM(t)
@@ -501,4 +512,12 @@ func BenchmarkGetNodesCapacityScaling(b *testing.B) {
 			}
 		})
 	}
+}
+
+type putErrorStore struct {
+	Store
+}
+
+func (putErrorStore) Put(context.Context, map[string]string) error {
+	return coretypes.ErrMockError
 }


### PR DESCRIPTION
Core commits the allocation-repair WAL entry when `NodeResource(fix=true)` returns no error. The built-in cpumem plugin appended a failed store write to the diffs and still returned success, so a repair whose write failed lost its retry while the stored usage stayed stale. `FixNodeResource` now returns the write error, as the gpu and storage plugins do after resource-extend #17. Successful fixes are unchanged and retries stay idempotent (the repair rewrites usage from the full workload set).

Test: `TestFixNodeResourceReturnsTheWriteError` with a store whose Put fails.

Gates: build, vet, full tests, lint and fmt-check on linux and darwin, asl on both: green.