### PR TITLE
perf: bound the creates in flight on one node

### DIFF
--- a/cluster/calcium/create.go
+++ b/cluster/calcium/create.go
@@ -231,8 +231,8 @@ func (c *Calcium) doDeployWorkloadsOnNode(ctx context.Context, emit createEmit, 
 	}
 
 	appendLock := sync.Mutex{}
-	wg := &sync.WaitGroup{}
-	wg.Add(nd.deploy)
+	var creates errgroup.Group
+	creates.SetLimit(nodeWorkers)
 	for idx := range nd.deploy {
 		createMsg := &types.CreateWorkloadMessage{
 			Podname:  opts.Podname,
@@ -240,8 +240,8 @@ func (c *Calcium) doDeployWorkloadsOnNode(ctx context.Context, emit createEmit, 
 			Publish:  map[string][]string{},
 		}
 
-		_ = c.pool.Invoke(func() {
-			defer wg.Done()
+		creates.Go(func() error {
+			defer log.SentryDefer()
 			var e error
 			defer func() {
 				if e != nil {
@@ -260,9 +260,10 @@ func (c *Calcium) doDeployWorkloadsOnNode(ctx context.Context, emit createEmit, 
 
 			createOpts := c.doMakeWorkloadOptions(ctx, nd.seq+idx, createMsg, opts, node)
 			e = c.doDeployOneWorkload(ctx, node, opts, createMsg, createOpts, true)
+			return nil
 		})
 	}
-	wg.Wait()
+	_ = creates.Wait()
 
 	c.invokePoolAsync(func() { c.RemapResourceAndLog(ctx, logger, node.Name) })
 

--- a/cluster/calcium/utils.go
+++ b/cluster/calcium/utils.go
@@ -16,8 +16,8 @@ import (
 	"github.com/projecteru2/core/utils"
 )
 
-// releaseWorkers bounds the engine removes in flight on one node.
-const releaseWorkers = 16
+// nodeWorkers bounds the engine creates and removes in flight on one node.
+const nodeWorkers = 16
 
 // withResourceReleased journals the node, runs the removal, then gives the workload's usage back under the node lock; the usage stays charged until the workload is gone, and a failed removal or release stays in the journal for repair.
 func (c *Calcium) withResourceReleased(ctx context.Context, logger *log.Fields, node *types.Node, workload *types.Workload, remove func(context.Context) error) error {
@@ -40,7 +40,7 @@ func (c *Calcium) withResourceReleased(ctx context.Context, logger *log.Fields, 
 	return nil
 }
 
-// releaseWorkloads runs release under each workload's lock, node by node with releaseWorkers in flight per node, gives the usage back, reports each outcome, remaps the node afterwards and calls done once every node is through.
+// releaseWorkloads runs release under each workload's lock, node by node with nodeWorkers in flight per node, gives the usage back, reports each outcome, remaps the node afterwards and calls done once every node is through.
 func (c *Calcium) releaseWorkloads(ctx context.Context, logger *log.Fields, IDs []string, release func(context.Context, *types.Node, *types.Workload) error, report func(workloadID string, err error) error, done func()) error {
 	nodeWorkloadGroup, err := c.groupWorkloadsByNode(ctx, IDs)
 	if err != nil {
@@ -63,7 +63,7 @@ func (c *Calcium) releaseWorkloads(ctx context.Context, logger *log.Fields, IDs 
 					return
 				}
 				var releases errgroup.Group
-				releases.SetLimit(releaseWorkers)
+				releases.SetLimit(nodeWorkers)
 				for _, workloadID := range workloadIDs {
 					releases.Go(func() error {
 						defer log.SentryDefer()

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -101,8 +101,8 @@ bookkeeping; core owns node and workload metadata. See [Resource plugins](resour
    - call `rmgr.Alloc` per node for the workload resources and engine params,
    - journal a `create-processing` entry and write the processing counter, so a concurrent deploy
      of the same app/entrypoint sees these workloads before they exist.
-4. **Deploy** (`then`): per node, pull the image unless `ignore_pull`, then create each workload
-   concurrently. For each one: `VirtualizationCreate`, journal `create-workload` with the new ID,
+4. **Deploy** (`then`): per node, pull the image unless `ignore_pull`, then create the workloads
+   with at most 16 in flight per node, the same bound removes use. For each one: `VirtualizationCreate`, journal `create-workload` with the new ID,
    write the workload metadata (decrementing the processing counter in the same transaction),
    copy in any files, run the after-create hooks, start it, inspect it back, and send the message.
    Each workload has its own inner `utils.Txn` whose rollback removes both metadata and instance.


### PR DESCRIPTION
Removes already run at most 16 per node (`releaseWorkers`); creates ran one pool task per workload with no per-node bound, so a 100-workload deploy on one node started 100 containers at once. One constant, `nodeWorkers`, now bounds both directions; the per-create cost is unchanged and the docs say so.

Lane evidence (eru-n2, 8 vCPU, containerd 2.3.5, one deploy call per row, two rounds, arms interleaved):

| core | CNI masq backend | 50 | 100 |
| --- | --- | --- | --- |
| v0.1.4 | iptables | 34–43 s, 50 up | 66 s, 32–34 up (the rest die on the oci-hook's 60 s CNI timeout: `netplugin failed with no error message: signal: killed`) |
| this branch | iptables | 26–32 s, 50 up | 57–62 s, 100 up |
| v0.1.4 | nftables | 5.6 s, 50 up | 9.4–9.8 s, 100 up |
| this branch | nftables | 6.0–6.3 s, 50 up | 11.0–11.2 s, 100 up |

The bridge plugin's `ipMasqBackend: nftables` (quickstart #26) removes the xtables-lock serialization itself; the bound keeps a burst from exceeding the hook timeout on nodes that still masquerade through iptables, and holds node load at 14–24 instead of 34–39 with nftables.

Gates: build, vet, full tests, lint + fmt-check on linux and darwin, asl on both, all green.