### PR TITLE
perf: share one lease across orphan status writes

### DIFF
--- a/store/etcdv3/meta/etcd.go
+++ b/store/etcdv3/meta/etcd.go
@@ -60,6 +60,10 @@ type ETCD struct {
 
 	poolMux   sync.Mutex
 	lockPools map[time.Duration]*etcdlock.Pool
+
+	orphanMux   sync.Mutex
+	orphanLease clientv3.LeaseID
+	orphanUntil time.Time
 }
 
 func NewETCD(ctx context.Context, config types.EtcdConfig, embeddedETCD *embedded.Cluster) (*ETCD, error) {
@@ -335,26 +339,40 @@ func (e *ETCD) bindStatusWithoutTTL(ctx context.Context, entityKey, statusKey, s
 		return nil
 	}
 
-	lease, err := e.cliv3.Grant(ctx, common.OrphanStatusTTL)
+	leaseID, err := e.orphanLeaseID(ctx)
 	if err != nil {
 		return err
 	}
 	orphaned, err := e.cliv3.Txn(ctx).
 		If(clientv3.Compare(clientv3.Version(entityKey), "=", 0)).
-		Then(clientv3.OpPut(statusKey, statusValue, clientv3.WithLease(lease.ID))).
+		Then(clientv3.OpPut(statusKey, statusValue, clientv3.WithLease(leaseID))).
 		Else(clientv3.OpPut(statusKey, statusValue)).
 		Commit()
 	if err != nil {
-		e.revokeLease(ctx, lease.ID)
 		return err
 	}
 	if !orphaned.Succeeded {
-		e.revokeLease(ctx, lease.ID)
 		logger.Infof(ctx, "put: key %s value %s", statusKey, statusValue)
 		return nil
 	}
 	logger.Infof(ctx, "put: key %s value %s, leased %ds without %s", statusKey, statusValue, common.OrphanStatusTTL, entityKey)
 	return nil
+}
+
+// orphanLeaseID shares one lease across the orphan status writes of a half-hour window, so a burst of removals costs one Grant instead of one per key.
+func (e *ETCD) orphanLeaseID(ctx context.Context) (clientv3.LeaseID, error) {
+	e.orphanMux.Lock()
+	defer e.orphanMux.Unlock()
+	ttl := time.Duration(common.OrphanStatusTTL) * time.Second
+	if e.orphanLease != 0 && time.Until(e.orphanUntil) > ttl/2 {
+		return e.orphanLease, nil
+	}
+	lease, err := e.cliv3.Grant(ctx, common.OrphanStatusTTL)
+	if err != nil {
+		return 0, err
+	}
+	e.orphanLease, e.orphanUntil = lease.ID, time.Now().Add(ttl)
+	return lease.ID, nil
 }
 
 func (e *ETCD) lockPool(ttl time.Duration) *etcdlock.Pool {

--- a/store/etcdv3/meta/etcd_test.go
+++ b/store/etcdv3/meta/etcd_test.go
@@ -203,8 +203,25 @@ func TestBindStatusOrphanPutYieldsToAnEntityThatAppeared(t *testing.T) {
 
 	etcd.On("Txn", mock.Anything).Return(txn)
 	etcd.On("Grant", mock.Anything, mock.Anything).Return(&clientv3.LeaseGrantResponse{ID: 7}, nil)
-	etcd.On("Revoke", mock.Anything, clientv3.LeaseID(7)).Return(&clientv3.LeaseRevokeResponse{}, nil)
 	require.NoError(t, e.BindStatus(t.Context(), "/entity", "/status", "status", 0))
+}
+
+func TestBindStatusSharesOneLeaseAcrossOrphans(t *testing.T) {
+	e := NewEmbeddedETCD(t)
+	ctx := t.Context()
+
+	require.NoError(t, e.BindStatus(ctx, "/entity/a", "/status/a", "gone", 0))
+	require.NoError(t, e.BindStatus(ctx, "/entity/b", "/status/b", "gone", 0))
+	a, err := e.GetOne(ctx, "/status/a")
+	require.NoError(t, err)
+	b, err := e.GetOne(ctx, "/status/b")
+	require.NoError(t, err)
+	require.NotZero(t, a.Lease)
+	require.Equal(t, a.Lease, b.Lease)
+
+	leases, err := e.cliv3.Leases(ctx)
+	require.NoError(t, err)
+	require.Len(t, leases.Leases, 1)
 }
 
 func TestBindStatusWithZeroTTL(t *testing.T) {


### PR DESCRIPTION
A status reported for a workload core no longer records is written under a one-hour lease so it expires on its own. Each such write granted its own lease; under churn that is one etcd Grant per removed workload. The writes of a half-hour window now share one lease (a fresh one is granted once the current lease has less than half its TTL left), so a burst of removals costs one Grant.

Semantics: an orphan key now expires between 30 and 60 minutes after its write instead of exactly 60; the yield path (an entity that appeared while the orphan put was in flight) no longer revokes anything because the lease is shared. `TestBindStatusOrphanPutYieldsToAnEntityThatAppeared` follows, and `TestBindStatusSharesOneLeaseAcrossOrphans` pins the sharing on the embedded etcd.

Lane evidence (etcd metrics, arms interleaved, two rounds, 50 workloads deployed then batch-removed per cycle): lease grants per cycle 107 → 29–33 (the remaining grants are lock sessions), status keys +50 either way, distinct leases +50 → +1; after a 30-workload cycle the 30 new orphan keys sit on one lease granted 3600 s with 3553 s remaining. e2e-a + e2e-b1 (the status paths) 30/30 on this build. Gates green on linux and darwin.