### PR TITLE
perf: reuse a registry's digest answer for 30 s

### DIFF
--- a/cluster/calcium/calcium.go
+++ b/cluster/calcium/calcium.go
@@ -36,6 +36,7 @@ type Calcium struct {
 	// serviceAddress is both the key RegisterService publishes and the journal's own prefix
 	serviceAddress string
 	remapped       sync.Map
+	remoteDigests  sync.Map
 }
 
 // New returns a Calcium cluster.

--- a/cluster/calcium/create.go
+++ b/cluster/calcium/create.go
@@ -276,7 +276,7 @@ func (c *Calcium) doGetAndPrepareNode(ctx context.Context, nodename, image strin
 		return nil, err
 	}
 	if !ignorePull {
-		err = pullImage(ctx, node, image)
+		err = c.pullImage(ctx, node, image)
 	}
 
 	return node, err

--- a/cluster/calcium/image.go
+++ b/cluster/calcium/image.go
@@ -23,7 +23,7 @@ func (c *Calcium) CacheImage(ctx context.Context, opts *types.ImageOptions) (cha
 				Nodename: node.Name,
 				Message:  "",
 			}
-			if err := pullImage(ctx, node, image); err != nil {
+			if err := c.pullImage(ctx, node, image); err != nil {
 				logger.Error(ctx, err)
 				m.Success = false
 				m.Message = err.Error()

--- a/cluster/calcium/utils.go
+++ b/cluster/calcium/utils.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"slices"
 	"sync"
+	"time"
 
 	"github.com/cockroachdb/errors"
 
@@ -16,8 +17,17 @@ import (
 	"github.com/projecteru2/core/utils"
 )
 
-// nodeWorkers bounds the engine creates and removes in flight on one node.
-const nodeWorkers = 16
+const (
+	// nodeWorkers bounds the engine creates and removes in flight on one node.
+	nodeWorkers = 16
+	// remoteDigestTTL is how long a registry's answer for a ref serves every node and call before core asks again.
+	remoteDigestTTL = 30 * time.Second
+)
+
+type remoteDigest struct {
+	digest string
+	until  time.Time
+}
 
 // withResourceReleased journals the node, runs the removal, then gives the workload's usage back under the node lock; the usage stays charged until the workload is gone, and a failed removal or release stays in the journal for repair.
 func (c *Calcium) withResourceReleased(ctx context.Context, logger *log.Fields, node *types.Node, workload *types.Workload, remove func(context.Context) error) error {
@@ -85,6 +95,59 @@ func (c *Calcium) invokePoolAsync(f func()) {
 	utils.SentryGo(func() { _ = c.pool.Invoke(f) })
 }
 
+func (c *Calcium) inspectDistribution(ctx context.Context, node *types.Node, image string, digests []string) bool {
+	logger := log.WithFunc("calcium.inspectDistribution")
+	remote, err := c.remoteDigest(ctx, node, image)
+	if err != nil {
+		logger.Error(ctx, err, "get manifest failed")
+		return false
+	}
+
+	if slices.Contains(digests, remote) {
+		logger.Debugf(ctx, "digest matched %s", remote)
+		return true
+	}
+	return false
+}
+
+func (c *Calcium) remoteDigest(ctx context.Context, node *types.Node, image string) (string, error) {
+	if cached, ok := c.remoteDigests.Load(image); ok && time.Now().Before(cached.(remoteDigest).until) {
+		return cached.(remoteDigest).digest, nil
+	}
+	digest, err := node.Engine.ImageRemoteDigest(ctx, image)
+	if err != nil {
+		return "", err
+	}
+	c.remoteDigests.Store(image, remoteDigest{digest: digest, until: time.Now().Add(remoteDigestTTL)})
+	return digest, nil
+}
+
+func (c *Calcium) pullImage(ctx context.Context, node *types.Node, image string) error {
+	logger := log.WithFunc("calcium.pullImage").WithField("node", node.Name).WithField("image", image)
+	if image == "" {
+		return types.ErrNoImage
+	}
+
+	digests, err := node.Engine.ImageLocalDigests(ctx, image)
+	switch {
+	case err != nil:
+		logger.Warnf(ctx, "check image failed: %+v", err)
+	case c.inspectDistribution(ctx, node, image, digests):
+		logger.Debug(ctx, "image cached, skip pulling")
+		return nil
+	}
+
+	logger.Info(ctx, "image not cached, pulling")
+	rc, err := node.Engine.ImagePull(ctx, image, false)
+	defer utils.EnsureReaderClosed(ctx, rc)
+	if err != nil {
+		logger.Errorf(ctx, err, "failed to pull image %s", image)
+		return err
+	}
+	logger.Infof(ctx, "done pulling image %s", image)
+	return nil
+}
+
 func perNode[T any](c *Calcium, nodes []*types.Node, work func(*types.Node, chan<- T)) chan T {
 	ch := make(chan T)
 	utils.SentryGo(func() {
@@ -114,47 +177,6 @@ func removeWorkloadByName(ctx context.Context, node *types.Node, name string) er
 	if err = node.Engine.VirtualizationRemove(ctx, info.ID, true, true); err != nil && !errors.Is(err, types.ErrWorkloadNotExists) {
 		return err
 	}
-	return nil
-}
-
-func inspectDistribution(ctx context.Context, node *types.Node, image string, digests []string) bool {
-	logger := log.WithFunc("calcium.inspectDistribution")
-	remoteDigest, err := node.Engine.ImageRemoteDigest(ctx, image)
-	if err != nil {
-		logger.Error(ctx, err, "get manifest failed")
-		return false
-	}
-
-	if slices.Contains(digests, remoteDigest) {
-		logger.Debugf(ctx, "digest matched %s", remoteDigest)
-		return true
-	}
-	return false
-}
-
-func pullImage(ctx context.Context, node *types.Node, image string) error {
-	logger := log.WithFunc("calcium.pullImage").WithField("node", node.Name).WithField("image", image)
-	if image == "" {
-		return types.ErrNoImage
-	}
-
-	digests, err := node.Engine.ImageLocalDigests(ctx, image)
-	switch {
-	case err != nil:
-		logger.Warnf(ctx, "check image failed: %+v", err)
-	case inspectDistribution(ctx, node, image, digests):
-		logger.Debug(ctx, "image cached, skip pulling")
-		return nil
-	}
-
-	logger.Info(ctx, "image not cached, pulling")
-	rc, err := node.Engine.ImagePull(ctx, image, false)
-	defer utils.EnsureReaderClosed(ctx, rc)
-	if err != nil {
-		logger.Errorf(ctx, err, "failed to pull image %s", image)
-		return err
-	}
-	logger.Infof(ctx, "done pulling image %s", image)
 	return nil
 }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -101,7 +101,8 @@ bookkeeping; core owns node and workload metadata. See [Resource plugins](resour
    - call `rmgr.Alloc` per node for the workload resources and engine params,
    - journal a `create-processing` entry and write the processing counter, so a concurrent deploy
      of the same app/entrypoint sees these workloads before they exist.
-4. **Deploy** (`then`): per node, pull the image unless `ignore_pull`, then create the workloads
+4. **Deploy** (`then`): per node, pull the image unless `ignore_pull` (the registry's digest for a
+   ref is reused for 30 s across nodes and calls, so a burst of deploys asks once), then create the workloads
    with at most 16 in flight per node, the same bound removes use. For each one: `VirtualizationCreate`, journal `create-workload` with the new ID,
    write the workload metadata (decrementing the processing counter in the same transaction),
    copy in any files, run the after-create hooks, start it, inspect it back, and send the message.


### PR DESCRIPTION
Every deploy asked the registry for the ref's digest before deciding whether to pull. On the lane that check is 1.25–1.37 s of a 2.0 s single deploy when the ref resolves to docker.io (2 ms against the local registry, so a private hub pays little). The answer is now remembered per ref for 30 s across nodes and calls, so a burst of deploys resolves once; the docs say so.

Lane evidence (eru-n2, arms interleaved, two rounds, eight sequential single deploys of `nginx:alpine` per arm, cli ms):

| core | deploy 1..8 |
| --- | --- |
| master 26545f9b | 1727 1611 1613 1534 1739 1726 1639 1633 / 1713 1617 1634 1630 1719 1534 1643 1643 |
| this branch | 1705 357 405 406 316 329 427 444 / 1638 345 333 419 336 328 317 381 |

Semantics, measured with two images built through `eru-cli image build` into `eru/probe` and the registry's `v1` tag re-pointed through the registry API between deploys (node pulled A first):

| core | deploy right after the tag moved to B | deploy 35 s later |
| --- | --- | --- |
| master | pulls B, container serves image-b | image-b |
| this branch | keeps A, container serves image-a | pulls B, image-b |

So a tag moved within the window is picked up by the next deploy after it; a digest-pinned ref is never stale. Gates green on linux and darwin.