### PR TITLE
fix: read workloads after taking their lock

### DIFF
--- a/cluster/calcium/dissociate_test.go
+++ b/cluster/calcium/dissociate_test.go
@@ -42,7 +42,6 @@ func TestDissociateWorkload(t *testing.T) {
 		}
 
 		store.On("GetWorkloads", mock.Anything, mock.Anything).Return([]*types.Workload{c1}, nil)
-		store.On("GetWorkload", mock.Anything, mock.Anything).Return(c1, nil)
 		rmgr.On("GetNodeResourceInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 			nil, nil, nil, nil,
 		)
@@ -56,6 +55,7 @@ func TestDissociateWorkload(t *testing.T) {
 		store.AssertExpectations(t)
 
 		store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
+		store.On("GetWorkload", mock.Anything, mock.Anything).Return(c1, nil)
 		rmgr.On("SetNodeResourceUsage", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 			resourcetypes.Resources{},
 			resourcetypes.Resources{},

--- a/cluster/calcium/lock.go
+++ b/cluster/calcium/lock.go
@@ -54,25 +54,25 @@ func (c *Calcium) doUnlockAll(ctx context.Context, locks map[string]lock.Distrib
 }
 
 func (c *Calcium) withWorkloadLocked(ctx context.Context, ID string, ignoreLock bool, f workloadHandler) error {
+	if !ignoreLock {
+		logger := log.WithFunc("calcium.withWorkloadLocked")
+		lock, lockCtx, err := c.doLock(ctx, fmt.Sprintf(cluster.WorkloadLock, ID), c.config.LockTimeout)
+		if err != nil {
+			return err
+		}
+		ctx = lockCtx
+		logger.Debugf(ctx, "workload %s locked", ID)
+		defer func() {
+			if err := c.doUnlock(context.WithoutCancel(ctx), lock, ID); err != nil {
+				logger.Errorf(ctx, err, "failed to unlock workload %s", ID)
+			}
+		}()
+	}
+
 	workload, err := c.store.GetWorkload(ctx, ID)
 	if err != nil {
 		return err
 	}
-	if ignoreLock {
-		return f(ctx, workload)
-	}
-
-	logger := log.WithFunc("calcium.withWorkloadLocked")
-	lock, ctx, err := c.doLock(ctx, fmt.Sprintf(cluster.WorkloadLock, workload.ID), c.config.LockTimeout)
-	if err != nil {
-		return err
-	}
-	logger.Debugf(ctx, "workload %s locked", workload.ID)
-	defer func() {
-		if err := c.doUnlock(context.WithoutCancel(ctx), lock, workload.ID); err != nil {
-			logger.Errorf(ctx, err, "failed to unlock workload %s", workload.ID)
-		}
-	}()
 	return f(ctx, workload)
 }
 

--- a/cluster/calcium/lock_test.go
+++ b/cluster/calcium/lock_test.go
@@ -74,7 +74,6 @@ func TestWithWorkloadLocked(t *testing.T) {
 	store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
 	lock.On("Unlock", mock.Anything).Return(nil)
 	lock.On("Lock", mock.Anything).Return(t.Context(), types.ErrMockError).Once()
-	store.On("GetWorkload", mock.Anything, mock.Anything).Return(&types.Workload{}, nil).Once()
 	err := c.withWorkloadLocked(ctx, "c1", false, func(ctx context.Context, workload *types.Workload) error { return nil })
 	assert.Error(t, err)
 	lock.On("Lock", mock.Anything).Return(context.Background(), nil)
@@ -92,6 +91,30 @@ func TestWithWorkloadLocked(t *testing.T) {
 		return nil
 	})
 	assert.NoError(t, err)
+	store.AssertExpectations(t)
+	lock.AssertExpectations(t)
+}
+
+func TestWithWorkloadLockedReadsAfterLock(t *testing.T) {
+	c := NewTestCluster()
+	store := c.store.(*storemocks.Store)
+	lock := &lockmocks.DistributedLock{}
+
+	created := store.On("CreateLock", "clock_c1", mock.Anything).Return(lock, nil).Once()
+	locked := lock.On("Lock", mock.Anything).Return(context.Background(), nil).Once()
+	read := store.On("GetWorkload", mock.Anything, "c1").Return(nil, types.ErrWorkloadNotExists).Once()
+	lock.On("Unlock", mock.Anything).Return(nil).Once()
+	mock.InOrder(created, locked, read)
+
+	called := false
+	err := c.withWorkloadLocked(t.Context(), "c1", false, func(context.Context, *types.Workload) error {
+		called = true
+		return nil
+	})
+	assert.ErrorIs(t, err, types.ErrWorkloadNotExists)
+	assert.False(t, called)
+	store.AssertExpectations(t)
+	lock.AssertExpectations(t)
 }
 
 func TestWithWorkloadLockedSkipsTheLockWhenIgnored(t *testing.T) {

--- a/cluster/calcium/replace_test.go
+++ b/cluster/calcium/replace_test.go
@@ -59,6 +59,7 @@ func TestReplaceWorkload(t *testing.T) {
 	store.AssertExpectations(t)
 
 	store.On("ListWorkloads", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]*types.Workload{workload}, nil)
+	store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
 	store.On("GetWorkload", mock.Anything, mock.Anything).Return(nil, types.ErrMockError).Once()
 	ch, err := c.ReplaceWorkload(ctx, opts)
 	assert.NoError(t, err)
@@ -68,7 +69,6 @@ func TestReplaceWorkload(t *testing.T) {
 	store.AssertExpectations(t)
 
 	store.On("GetWorkload", mock.Anything, mock.Anything).Return(workload, nil).Once()
-	store.On("CreateLock", mock.Anything, mock.Anything).Return(lock, nil)
 	opts.Podname = "wtf"
 	ch, err = c.ReplaceWorkload(ctx, opts)
 	assert.NoError(t, err)


### PR DESCRIPTION
## Summary

- acquire the existing workload lock by requested ID before loading the workload
- make overlapping same-ID operations re-read state after serialization instead of using a stale snapshot
- keep the ignore-lock path and concurrency across different workload IDs unchanged

No separate dedupe state is added; the existing per-workload distributed lock is the deduplication boundary.

## Validation

- regression test fails on origin/master when applied alone because GetWorkload runs before Lock
- GOWORK=off go test -race -timeout 600s -count=1 ./...
- GOWORK=off GOOSES="linux darwin" make lint
- GOWORK=off GOOSES="linux darwin" make vet
- GOWORK=off GOOS=linux make fmt-check
- GOWORK=off GOOS=darwin make fmt-check
- asl ./... on darwin and linux
- GOWORK=off make build