### PR TITLE
fix: read nodes after taking their locks

### DIFF
--- a/cluster/calcium/lock.go
+++ b/cluster/calcium/lock.go
@@ -110,15 +110,15 @@ func (c *Calcium) withNodesLocked(ctx context.Context, nodeFilter *types.NodeFil
 		logger.Debugf(ctx, "keys %+v unlocked", lockKeys)
 	}()
 
-	ns, err := c.filterNodes(ctx, nodeFilter)
+	named, err := c.filterNodes(ctx, nodeFilter)
 	if err != nil {
 		return err
 	}
-	for _, n := range ns {
-		nodes[n.Name] = n
+	if len(named) == 0 {
+		return f(ctx, nodes)
 	}
 
-	keys := keysOf(ns)
+	keys := keysOf(named)
 	slices.SortFunc(keys, byLockOrder)
 	var lock lock.DistributedLock
 	for _, key := range slices.Compact(keys) {
@@ -129,6 +129,16 @@ func (c *Calcium) withNodesLocked(ctx context.Context, nodeFilter *types.NodeFil
 		logger.Debugf(ctx, "key %s locked", key)
 		locks[key] = lock
 		lockKeys = append(lockKeys, key)
+	}
+
+	ns, err := c.filterNodes(ctx, nodeFilter)
+	if err != nil {
+		return err
+	}
+	for _, n := range ns {
+		if slices.ContainsFunc(named, func(m *types.Node) bool { return m.Name == n.Name }) {
+			nodes[n.Name] = n
+		}
 	}
 	return f(ctx, nodes)
 }

--- a/cluster/calcium/lock_test.go
+++ b/cluster/calcium/lock_test.go
@@ -130,6 +130,53 @@ func TestWithWorkloadLockedSkipsTheLockWhenIgnored(t *testing.T) {
 	store.AssertNotCalled(t, "CreateLock", mock.Anything, mock.Anything)
 }
 
+func TestWithNodesLockedReadsAfterLock(t *testing.T) {
+	c := NewTestCluster()
+	store := c.store.(*storemocks.Store)
+	lock := &lockmocks.DistributedLock{}
+	node := &types.Node{NodeMeta: types.NodeMeta{Name: "n1", Podname: "p"}, Available: true}
+
+	named := store.On("GetNode", mock.Anything, "n1").Return(node, nil).Once()
+	locked := lock.On("Lock", mock.Anything).Return(context.Background(), nil).Once()
+	gone := store.On("GetNode", mock.Anything, "n1").Return(nil, types.ErrNodeNotExists).Once()
+	store.On("CreateLock", "cnode_op_p_n1", mock.Anything).Return(lock, nil).Once()
+	lock.On("Unlock", mock.Anything).Return(nil).Once()
+	mock.InOrder(named, locked, gone)
+
+	called := false
+	err := c.withNodeOperationLocked(t.Context(), "n1", func(context.Context, *types.Node) error {
+		called = true
+		return nil
+	})
+	assert.ErrorIs(t, err, types.ErrNodeNotExists)
+	assert.False(t, called)
+	store.AssertExpectations(t)
+	lock.AssertExpectations(t)
+}
+
+func TestWithNodesLockedHandsOverOnlyTheNodesItNamed(t *testing.T) {
+	c := NewTestCluster()
+	store := c.store.(*storemocks.Store)
+	lock := &lockmocks.DistributedLock{}
+	n1 := &types.Node{NodeMeta: types.NodeMeta{Name: "n1", Podname: "p"}, Available: true}
+	n2 := &types.Node{NodeMeta: types.NodeMeta{Name: "n2", Podname: "p"}, Available: true}
+
+	store.On("GetNodesByPod", mock.Anything, mock.Anything, mock.Anything).Return([]*types.Node{n1}, nil).Once()
+	store.On("GetNodesByPod", mock.Anything, mock.Anything, mock.Anything).Return([]*types.Node{n1, n2}, nil).Once()
+	store.On("CreateLock", "plock_p", mock.Anything).Return(lock, nil).Once()
+	lock.On("Lock", mock.Anything).Return(context.Background(), nil).Once()
+	lock.On("Unlock", mock.Anything).Return(nil).Once()
+
+	err := c.withPodLocked(t.Context(), "p", func(_ context.Context, nodes map[string]*types.Node) error {
+		assert.Len(t, nodes, 1)
+		assert.Contains(t, nodes, "n1")
+		return nil
+	})
+	assert.NoError(t, err)
+	store.AssertExpectations(t)
+	lock.AssertExpectations(t)
+}
+
 func TestWithNodesPlanLocked(t *testing.T) {
 	c := NewTestCluster()
 	ctx := t.Context()

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -54,7 +54,10 @@ The package splits by concern — `create.go`, `realloc.go`, `remove.go`, `disso
 - `lock.go` — `withWorkloadLocked`, `withNodesPlanLocked`, `withPodLocked`,
   `withNodeOperationLocked`. Locks are taken in sorted order, pod locks before node locks, and
   released in reverse; lock keys are `clock_<id>` for a workload, `plock_<pod>` for a pod and
-  `cnode_op_<pod>_<node>` for a node operation.
+  `cnode_op_<pod>_<node>` for a node operation. A workload or node is read again after its
+  lock is taken, so an operation that waited on the lock works on what the previous holder
+  wrote, never on the snapshot it queued with; a node that appeared meanwhile is not handed
+  over, because no lock was named after it.
 - `utils.Txn` — the if/then/rollback shape used everywhere a resource change and a metadata
   change must agree. `rollback` runs on either failure and is told which stage failed;
   `utils.PCR` is the variant that skips it when the `if` failed.


### PR DESCRIPTION
The node counterpart of #739. `withNodesLocked` read the nodes, took the locks named after them and handed the pre-lock snapshot to `f`, so an operation that waited on a node lock worked on what it had queued with. Concretely, `SetNode` writes its snapshot back with a plain Put (`UpdateNodes`), so a `RemoveNode` that ran meanwhile was undone and the node came back.

The nodes are now read again once the locks are held, and only the nodes the locks were named after are handed over: a node that appeared in between holds no lock of ours. Nothing is re-read when the filter named no node. Two tests pin it: a node removed while the caller waited yields `ErrNodeNotExists` and `f` never runs (mock order CreateLock → Lock → second read); a node that appears only in the post-lock listing is not handed over. The architecture doc says what both lock helpers now guarantee.

Hot path: one extra node read per locked node operation (deploy plan, SetNode, RemoveNode, remap), none on the remove RPC path. Lane A/B (master ab77eb38 vs this branch, arms interleaved, two rounds, eight sequential calls each): single deploy median 1.80 s → 1.78 s, single remove 136–291 ms both, `node set` 38 → 40 ms.

Gates: build, vet, full tests, lint + fmt-check on linux and darwin (0 issues), asl on both, comments +0 −0; the only local test failure was the known macOS first-exec flake in `resource/plugins/binary`, which this branch does not touch and which passes on rerun.