### PR TITLE
review: style round under the reloaded asl and skill

### DIFF
--- a/client/clientpool.go
+++ b/client/clientpool.go
@@ -71,31 +71,31 @@ func NewCoreRPCClientPool(ctx context.Context, config *PoolConfig) (*Pool, error
 }
 
 // GetClient returns the first alive client, or the first client when none are alive.
-func (c *Pool) GetClient() pb.CoreRPCClient {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+func (p *Pool) GetClient() pb.CoreRPCClient {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 
-	for _, rpc := range c.rpcClients {
+	for _, rpc := range p.rpcClients {
 		if rpc.alive {
 			return rpc.client
 		}
 	}
-	return c.rpcClients[0].client
+	return p.rpcClients[0].client
 }
 
-func (c *Pool) updateClientsStatus(ctx context.Context, timeout time.Duration) {
-	alive := make([]bool, len(c.rpcClients))
+func (p *Pool) updateClientsStatus(ctx context.Context, timeout time.Duration) {
+	alive := make([]bool, len(p.rpcClients))
 	var wg sync.WaitGroup
-	for i, rpc := range c.rpcClients {
+	for i, rpc := range p.rpcClients {
 		wg.Go(func() {
 			alive[i] = checkAlive(ctx, rpc, timeout)
 		})
 	}
 	wg.Wait()
 
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	for i, rpc := range c.rpcClients {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for i, rpc := range p.rpcClients {
 		rpc.alive = alive[i]
 	}
 }

--- a/client/servicediscovery/eru_service_discovery.go
+++ b/client/servicediscovery/eru_service_discovery.go
@@ -34,11 +34,11 @@ func New(endpoint string, authConfig types.AuthConfig) *EruServiceDiscovery {
 }
 
 // Watch streams the core addresses the cluster publishes; the connection it watches over follows them as well.
-func (w *EruServiceDiscovery) Watch(ctx context.Context) (<-chan []string, error) {
-	logger := log.WithFunc("servicediscovery.EruServiceDiscovery.Watch").WithField("endpoint", w.endpoint)
+func (e *EruServiceDiscovery) Watch(ctx context.Context) (<-chan []string, error) {
+	logger := log.WithFunc("servicediscovery.EruServiceDiscovery.Watch").WithField("endpoint", e.endpoint)
 	cores := manual.NewBuilderWithScheme("lb")
-	cores.InitialState(addressState(w.endpoint))
-	cc, err := w.dial(cores)
+	cores.InitialState(addressState(e.endpoint))
+	cc, err := e.dial(cores)
 	if err != nil {
 		logger.Error(ctx, err, "dial")
 		return nil, err
@@ -90,18 +90,18 @@ func (w *EruServiceDiscovery) Watch(ctx context.Context) (<-chan []string, error
 	return ch, nil
 }
 
-func (w *EruServiceDiscovery) dial(cores resolver.Builder) (*grpc.ClientConn, error) {
+func (e *EruServiceDiscovery) dial(cores resolver.Builder) (*grpc.ClientConn, error) {
 	opts := []grpc.DialOption{
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithStreamInterceptor(interceptor.NewStreamRetry(interceptor.RetryOptions{Max: 1})),
 		grpc.WithResolvers(cores),
 	}
 
-	if w.authConfig.Username != "" {
-		opts = append(opts, grpc.WithPerRPCCredentials(auth.NewCredential(w.authConfig)))
+	if e.authConfig.Username != "" {
+		opts = append(opts, grpc.WithPerRPCCredentials(auth.NewCredential(e.authConfig)))
 	}
 
-	return grpc.NewClient("lb:///"+w.endpoint, opts...)
+	return grpc.NewClient("lb:///"+e.endpoint, opts...)
 }
 
 func addressState(endpoints ...string) resolver.State {

--- a/cluster/calcium/node.go
+++ b/cluster/calcium/node.go
@@ -311,9 +311,7 @@ func (c *Calcium) setAllWorkloadsOnNodeDown(ctx context.Context, nodename string
 				return nil
 			}
 
-			if workload.StatusMeta == nil {
-				workload.StatusMeta = &types.StatusMeta{ID: workload.ID}
-			}
+			workload.StatusMeta = cmp.Or(workload.StatusMeta, &types.StatusMeta{ID: workload.ID})
 			workload.StatusMeta.Running = false
 			workload.StatusMeta.Healthy = false
 

--- a/engine/containerd/dockerfile.go
+++ b/engine/containerd/dockerfile.go
@@ -2,6 +2,7 @@ package containerd
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"fmt"
 	"io"
@@ -104,10 +105,7 @@ func preparedSource(ctx context.Context, build *enginetypes.Build, scm coresourc
 	var err error
 	reponame := ""
 	if build.Repo != "" { //nolint:nestif
-		version := build.Version
-		if version == "" {
-			version = "HEAD"
-		}
+		version := cmp.Or(build.Version, "HEAD")
 		reponame, err = utils.GetGitRepoName(build.Repo)
 		if err != nil {
 			return "", err

--- a/engine/containerd/image.go
+++ b/engine/containerd/image.go
@@ -234,7 +234,7 @@ func (e *Engine) imageConfig(ctx context.Context, image client.Image) (*ocispec.
 	return &config.Config, nil
 }
 
-// resolver authenticates every registry request against the configured credentials; its push tracker remembers blobs per digest, not per repository, so it must not outlive one call.
+// resolver is built per call: the docker pusher's tracker remembers blobs per digest, not per repository.
 func (e *Engine) resolver() remotes.Resolver {
 	auths := e.config.Registry.Auths
 	plainHTTP := e.config.Registry.PlainHTTP

--- a/engine/containerd/spec.go
+++ b/engine/containerd/spec.go
@@ -50,8 +50,7 @@ const (
 	// hookBinary runs CNI in the node's netns; core has none.
 	hookBinary  = "/usr/local/bin/eru-agent"
 	hookCommand = "oci-hook"
-	// namespaceAnnotation is how the hook learns its containerd namespace: an OCI
-	// hook is handed the runtime state, never the container's labels.
+	// namespaceAnnotation carries the containerd namespace to the hook, which sees the runtime state and not the labels.
 	namespaceAnnotation = "eru.namespace"
 
 	nofileLimit = 65535

--- a/engine/process/copy.go
+++ b/engine/process/copy.go
@@ -80,7 +80,7 @@ func (e *Engine) VirtualizationCopyFrom(ctx context.Context, ID, path string) (c
 	return nil, 0, 0, 0, errors.Wrapf(coretypes.ErrWorkloadNotExists, "%s not found in workload %s", path, ID)
 }
 
-// hostPaths maps a path inside the workload onto the node's filesystem, most specific first: writing under a mounted overlay is undefined and its upper dir alone misses the bundle.
+// hostPaths returns the host paths of a workload path, most specific first: writing under a mounted overlay is undefined.
 func (e *Engine) hostPaths(ctx context.Context, ID, target string) ([]string, error) {
 	record, mounted, err := e.workloadMeta(ctx, ID)
 	if err != nil {

--- a/engine/sshrunner/ssh.go
+++ b/engine/sshrunner/ssh.go
@@ -350,7 +350,9 @@ func openOnce[T any](ctx context.Context, r *sshRunner, f sshOp[T]) (T, error) {
 	return bounded(ctx, func() (T, error) { return f(client) })
 }
 
-func bounded[T any](ctx context.Context, open func() (T, error)) (T, error) {
+type opener[T any] func() (T, error)
+
+func bounded[T any](ctx context.Context, open opener[T]) (T, error) {
 	type opened struct {
 		v   T
 		err error
@@ -376,7 +378,7 @@ func bounded[T any](ctx context.Context, open func() (T, error)) (T, error) {
 	}
 }
 
-func retryRefused[T any](ctx context.Context, open func() (T, error)) (T, error) {
+func retryRefused[T any](ctx context.Context, open opener[T]) (T, error) {
 	interval := openRetryInterval
 	for attempt := 0; ; attempt++ {
 		res, err := open()

--- a/engine/types/image.go
+++ b/engine/types/image.go
@@ -5,40 +5,6 @@ import (
 	"strings"
 )
 
-// SplitRef separates an image reference from its tag, ignoring a registry port.
-func SplitRef(ref string) (name, tag string) {
-	colon := strings.LastIndex(ref, ":")
-	if colon < 0 || colon < strings.LastIndex(ref, "/") {
-		return ref, ""
-	}
-	return ref[:colon], ref[colon+1:]
-}
-
-// IsURL reports whether the image is a plain download url rather than a registry ref.
-func IsURL(image string) bool {
-	return strings.HasPrefix(image, "http://") || strings.HasPrefix(image, "https://")
-}
-
-// ImageDigest renders the digest form core compares; a cloud image url stands for itself.
-func ImageDigest(image, digest string) string {
-	if IsURL(image) {
-		return image
-	}
-	name, _ := SplitRef(image)
-	return name + "@" + digest
-}
-
-// ParseDescriptor reads the digest out of an OCI descriptor.
-func ParseDescriptor(out string) (string, error) {
-	descriptor := struct {
-		Digest string `json:"digest"`
-	}{}
-	if err := json.Unmarshal([]byte(out), &descriptor); err != nil {
-		return "", err
-	}
-	return descriptor.Digest, nil
-}
-
 // Image is an image's ID and tags.
 type Image struct {
 	ID   string
@@ -76,4 +42,38 @@ type Build struct {
 	Artifacts  map[string]string `yaml:"artifacts,omitempty,flow"`
 	Cache      map[string]string `yaml:"cache,omitempty,flow"`
 	StopSignal string            `yaml:"stop_signal,omitempty,flow"`
+}
+
+// SplitRef separates an image reference from its tag, ignoring a registry port.
+func SplitRef(ref string) (name, tag string) {
+	colon := strings.LastIndex(ref, ":")
+	if colon < 0 || colon < strings.LastIndex(ref, "/") {
+		return ref, ""
+	}
+	return ref[:colon], ref[colon+1:]
+}
+
+// IsURL reports whether the image is a plain download url rather than a registry ref.
+func IsURL(image string) bool {
+	return strings.HasPrefix(image, "http://") || strings.HasPrefix(image, "https://")
+}
+
+// ImageDigest renders the digest form core compares; a cloud image url stands for itself.
+func ImageDigest(image, digest string) string {
+	if IsURL(image) {
+		return image
+	}
+	name, _ := SplitRef(image)
+	return name + "@" + digest
+}
+
+// ParseDescriptor reads the digest out of an OCI descriptor.
+func ParseDescriptor(out string) (string, error) {
+	descriptor := struct {
+		Digest string `json:"digest"`
+	}{}
+	if err := json.Unmarshal([]byte(out), &descriptor); err != nil {
+		return "", err
+	}
+	return descriptor.Digest, nil
 }

--- a/resource/cobalt/call.go
+++ b/resource/cobalt/call.go
@@ -10,7 +10,9 @@ import (
 	"github.com/projecteru2/core/resource/plugins"
 )
 
-func call[T any](ctx context.Context, ps []plugins.Plugin, f func(plugins.Plugin) (T, error)) (map[plugins.Plugin]T, error) {
+type pluginCall[T any] func(plugins.Plugin) (T, error)
+
+func call[T any](ctx context.Context, ps []plugins.Plugin, f pluginCall[T]) (map[plugins.Plugin]T, error) {
 	var wg sync.WaitGroup
 	results := make([]T, len(ps))
 	errs := make([]error, len(ps))

--- a/resource/cobalt/node.go
+++ b/resource/cobalt/node.go
@@ -134,7 +134,6 @@ func (m *Manager) SetNodeResourceUsage(ctx context.Context, nodename string, nod
 
 	return before, after, utils.PCR(ctx,
 		func(_ context.Context) error {
-			// [{"cpu-plugin": {"cpu": 1}}, {"cpu-plugin": {"cpu": 1}}] -> {"cpu-plugin": [{"cpu": 1}, {"cpu": 1}]}
 			for _, workloadResource := range workloadsResource {
 				for plugin, params := range workloadResource {
 					wrksResource[plugin] = append(wrksResource[plugin], params)
@@ -300,7 +299,7 @@ func mergeCapacity(m1, m2 map[string]*plugintypes.NodeDeployCapacity) map[string
 }
 
 // rollbackNodeResource restores every plugin that applied a failed set of the node's resources.
-func rollbackNodeResource[T any](ctx context.Context, ps []plugins.Plugin, restore func(plugins.Plugin) (T, error)) error {
+func rollbackNodeResource[T any](ctx context.Context, ps []plugins.Plugin, restore pluginCall[T]) error {
 	_, err := call(ctx, ps, restore)
 	return err
 }

--- a/resource/cobalt/remap.go
+++ b/resource/cobalt/remap.go
@@ -10,7 +10,7 @@ import (
 	"github.com/projecteru2/core/types"
 )
 
-// Remap returns engine params per workload, format: {"workload-1": {"cpus": ["1-3"]}}; it never changes resource params.
+// Remap returns engine params per workload and never changes resource params.
 func (m *Manager) Remap(ctx context.Context, nodename string, workloads []*types.Workload) (map[string]resourcetypes.Resources, error) {
 	resps, err := call(ctx, m.plugins, func(plugin plugins.Plugin) (*plugintypes.CalculateRemapResponse, error) {
 		name := plugin.Name()

--- a/resource/plugins/cpumem/calculate_test.go
+++ b/resource/plugins/cpumem/calculate_test.go
@@ -19,67 +19,33 @@ func TestCalculateDeploy(t *testing.T) {
 	nodes := generateNodes(ctx, t, cm, 1, 2, 4*units.GB, 100, 0)
 	node := nodes[0]
 
-	req := plugintypes.WorkloadResourceRequest{
-		"cpu-bind":    true,
-		"cpu-request": -1,
+	tests := []struct {
+		name    string
+		node    string
+		count   int
+		req     plugintypes.WorkloadResourceRequest
+		wantErr error
+	}{
+		{"negative cpu", node, 100, plugintypes.WorkloadResourceRequest{"cpu-bind": true, "cpu-request": -1}, types.ErrInvalidCPU},
+		{"unknown node", "xxx", 100, plugintypes.WorkloadResourceRequest{"cpu-bind": true, "cpu-request": 1}, coretypes.ErrInvaildCount},
+		{"fractional bind fits", node, 1, plugintypes.WorkloadResourceRequest{"cpu-bind": true, "cpu-request": 1.1}, nil},
+		{"bind over the cores", node, 1, plugintypes.WorkloadResourceRequest{"cpu-bind": true, "cpu-request": 2.2}, coretypes.ErrInsufficientCapacity},
+		{"bind over the count", node, 3, plugintypes.WorkloadResourceRequest{"cpu-bind": true, "cpu-request": 1}, coretypes.ErrInsufficientCapacity},
+		{"memory only", node, 1, plugintypes.WorkloadResourceRequest{"memory-request": fmt.Sprintf("%v", units.GB)}, nil},
+		{"cpu over the node", node, 1, plugintypes.WorkloadResourceRequest{"memory-request": fmt.Sprintf("%v", units.GB), "cpu-request": 1000}, coretypes.ErrInsufficientCapacity},
+		{"memory over the node", node, 1, plugintypes.WorkloadResourceRequest{"memory-request": fmt.Sprintf("%v", 5*units.GB), "cpu-request": 1}, coretypes.ErrInsufficientCapacity},
+		{"zero memory", node, 1, plugintypes.WorkloadResourceRequest{"memory-request": "0", "cpu-request": 1}, nil},
 	}
-	_, err := cm.CalculateDeploy(ctx, node, 100, req)
-	assert.True(t, errors.Is(err, types.ErrInvalidCPU))
-
-	req = plugintypes.WorkloadResourceRequest{
-		"cpu-bind":    true,
-		"cpu-request": 1,
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := cm.CalculateDeploy(ctx, tt.node, tt.count, tt.req)
+			if tt.wantErr == nil {
+				assert.NoError(t, err)
+				return
+			}
+			assert.ErrorIs(t, err, tt.wantErr)
+		})
 	}
-	_, err = cm.CalculateDeploy(ctx, "xxx", 100, req)
-	assert.True(t, errors.Is(err, coretypes.ErrInvaildCount))
-
-	req = plugintypes.WorkloadResourceRequest{
-		"cpu-bind":    true,
-		"cpu-request": 1.1,
-	}
-	_, err = cm.CalculateDeploy(ctx, node, 1, req)
-	assert.Nil(t, err)
-
-	req = plugintypes.WorkloadResourceRequest{
-		"cpu-bind":    true,
-		"cpu-request": 2.2,
-	}
-	_, err = cm.CalculateDeploy(ctx, node, 1, req)
-	assert.True(t, errors.Is(err, coretypes.ErrInsufficientCapacity))
-
-	req = plugintypes.WorkloadResourceRequest{
-		"cpu-bind":    true,
-		"cpu-request": 1,
-	}
-	_, err = cm.CalculateDeploy(ctx, node, 3, req)
-	assert.True(t, errors.Is(err, coretypes.ErrInsufficientCapacity))
-
-	req = plugintypes.WorkloadResourceRequest{
-		"memory-request": fmt.Sprintf("%v", units.GB),
-	}
-	_, err = cm.CalculateDeploy(ctx, node, 1, req)
-	assert.Nil(t, err)
-
-	req = plugintypes.WorkloadResourceRequest{
-		"memory-request": fmt.Sprintf("%v", units.GB),
-		"cpu-request":    1000,
-	}
-	_, err = cm.CalculateDeploy(ctx, node, 1, req)
-	assert.True(t, errors.Is(err, coretypes.ErrInsufficientCapacity))
-
-	req = plugintypes.WorkloadResourceRequest{
-		"memory-request": fmt.Sprintf("%v", 5*units.GB),
-		"cpu-request":    1,
-	}
-	_, err = cm.CalculateDeploy(ctx, node, 1, req)
-	assert.True(t, errors.Is(err, coretypes.ErrInsufficientCapacity))
-
-	req = plugintypes.WorkloadResourceRequest{
-		"memory-request": "0",
-		"cpu-request":    1,
-	}
-	_, err = cm.CalculateDeploy(ctx, node, 1, req)
-	assert.Nil(t, err)
 
 	resource := plugintypes.NodeResource{
 		"cpu": 4.0,
@@ -101,17 +67,16 @@ func TestCalculateDeploy(t *testing.T) {
 			"3": "1",
 		},
 	}
+	_, err := cm.SetNodeResourceCapacity(ctx, node, resource, nil, false, true)
+	assert.NoError(t, err)
 
-	_, err = cm.SetNodeResourceCapacity(ctx, node, resource, nil, false, true)
-	assert.Nil(t, err)
-
-	req = plugintypes.WorkloadResourceRequest{
+	req := plugintypes.WorkloadResourceRequest{
 		"cpu-bind":    true,
 		"memory":      fmt.Sprintf("%v", units.GB),
 		"cpu-request": 1.3,
 	}
 	r, err := cm.CalculateDeploy(ctx, node, 1, req)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, r.WorkloadsResource)
 }
 
@@ -137,17 +102,10 @@ func TestCalculateRealloc(t *testing.T) {
 			"1": "1",
 		},
 	}
-
 	_, err := cm.SetNodeResourceCapacity(ctx, node, resource, nil, false, true)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
-	origin := plugintypes.WorkloadResource{}
-	req := plugintypes.WorkloadResourceRequest{}
-
-	_, err = cm.CalculateRealloc(ctx, "xxx", origin, req)
-	assert.True(t, errors.Is(err, coretypes.ErrInvaildCount))
-
-	origin = plugintypes.WorkloadResource{
+	origin := plugintypes.WorkloadResource{
 		"cpu_request":    1,
 		"cpu_limit":      1,
 		"memory_request": units.GB,
@@ -156,38 +114,30 @@ func TestCalculateRealloc(t *testing.T) {
 		"numa_memory":    types.NUMAMemory{"0": units.GB},
 		"numa_node":      "0",
 	}
-	req = plugintypes.WorkloadResourceRequest{
-		"keep-cpu-bind": true,
-		"cpu-request":   -3,
+	tests := []struct {
+		name    string
+		node    string
+		origin  plugintypes.WorkloadResource
+		req     plugintypes.WorkloadResourceRequest
+		wantErr error
+	}{
+		{"unknown node", "xxx", plugintypes.WorkloadResource{}, plugintypes.WorkloadResourceRequest{}, coretypes.ErrInvaildCount},
+		{"cpu below zero", node, origin, plugintypes.WorkloadResourceRequest{"keep-cpu-bind": true, "cpu-request": -3}, types.ErrInvalidCPU},
+		{"cpu over the node", node, origin, plugintypes.WorkloadResourceRequest{"keep-cpu-bind": true, "cpu-request": 2}, coretypes.ErrInsufficientResource},
+		{"shrink the bind", node, origin, plugintypes.WorkloadResourceRequest{"keep-cpu-bind": true, "cpu-request": -0.5, "cpu-limit": -0.5}, nil},
+		{"no change", node, origin, plugintypes.WorkloadResourceRequest{}, nil},
+		{"memory over the node", node, origin, plugintypes.WorkloadResourceRequest{"memory-request": fmt.Sprintf("%v", units.PB), "memory-limit": fmt.Sprintf("%v", units.PB)}, coretypes.ErrInsufficientCapacity},
 	}
-	_, err = cm.CalculateRealloc(ctx, node, origin, req)
-	assert.True(t, errors.Is(err, types.ErrInvalidCPU))
-
-	req = plugintypes.WorkloadResourceRequest{
-		"keep-cpu-bind": true,
-		"cpu-request":   2,
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := cm.CalculateRealloc(ctx, tt.node, tt.origin, tt.req)
+			if tt.wantErr == nil {
+				assert.NoError(t, err)
+				return
+			}
+			assert.ErrorIs(t, err, tt.wantErr)
+		})
 	}
-	_, err = cm.CalculateRealloc(ctx, node, origin, req)
-	assert.True(t, errors.Is(err, coretypes.ErrInsufficientResource))
-
-	req = plugintypes.WorkloadResourceRequest{
-		"keep-cpu-bind": true,
-		"cpu-request":   -0.5,
-		"cpu-limit":     -0.5,
-	}
-	_, err = cm.CalculateRealloc(ctx, node, origin, req)
-	assert.Nil(t, err)
-
-	req = plugintypes.WorkloadResourceRequest{}
-	_, err = cm.CalculateRealloc(ctx, node, origin, req)
-	assert.Nil(t, err)
-
-	req = plugintypes.WorkloadResourceRequest{
-		"memory-request": fmt.Sprintf("%v", units.PB),
-		"memory-limit":   fmt.Sprintf("%v", units.PB),
-	}
-	_, err = cm.CalculateRealloc(ctx, node, origin, req)
-	assert.True(t, errors.Is(err, coretypes.ErrInsufficientCapacity))
 }
 
 func TestCalculateRemap(t *testing.T) {

--- a/resource/plugins/cpumem/node.go
+++ b/resource/plugins/cpumem/node.go
@@ -1,6 +1,7 @@
 package cpumem
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -53,9 +54,7 @@ func (p Plugin) AddNode(ctx context.Context, nodename string, resource plugintyp
 			}
 		}
 
-		if req.Memory == 0 {
-			req.Memory = info.MemTotal * rate / 10 // use 80% of real memory
-		}
+		req.Memory = cmp.Or(req.Memory, info.MemTotal*rate/10) // use 80% of real memory
 	}
 
 	nodeResourceInfo := &cpumemtypes.NodeResourceInfo{

--- a/resource/plugins/cpumem/schedule/schedule.go
+++ b/resource/plugins/cpumem/schedule/schedule.go
@@ -187,7 +187,7 @@ func (h *host) getFullCPUPlans(cores []*cpuCore, full int) []types.CPUMap {
 	return utils.Map(plans, func(r ranked) types.CPUMap { return r.plan })
 }
 
-// eachFullCPUPlan visits every whole-core plan as the indexes of its cores; with affinity the cores go in order, otherwise the busiest first.
+// eachFullCPUPlan takes cores in order under affinity and busiest first otherwise.
 func (h *host) eachFullCPUPlan(cores []*cpuCore, full int, visit func(picked []int)) {
 	if h.affinity {
 		pieces := make([]int, len(cores))

--- a/resource/plugins/plugin.go
+++ b/resource/plugins/plugin.go
@@ -14,7 +14,7 @@ const (
 	Decr = false
 )
 
-// ErrVerbNotSupported marks a verb the plugin did not advertise; cobalt leaves the plugin out of that call.
+// ErrVerbNotSupported marks a verb the plugin did not advertise.
 var ErrVerbNotSupported = errors.New("verb not supported by the plugin")
 
 type Plugin interface {
@@ -36,7 +36,7 @@ type Plugin interface {
 
 	SetNodeResourceCapacity(ctx context.Context, nodename string, resource plugintypes.NodeResource, resourceRequest plugintypes.NodeResourceRequest, delta, incr bool) (*plugintypes.SetNodeResourceCapacityResponse, error)
 
-	// GetNodeResourceInfo returns total resource info and available resource info of the node, format: {"cpu": 2}
+	// GetNodeResourceInfo returns the node's total and available resources.
 	GetNodeResourceInfo(ctx context.Context, nodename string, workloadsResource []plugintypes.WorkloadResource) (*plugintypes.GetNodeResourceInfoResponse, error)
 
 	// SetNodeResourceInfo stores a node's capacity and usage as absolute values.

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -463,11 +463,7 @@ func (v *Vibranium) Copy(opts *pb.CopyOptions, stream pb.CoreRPC_CopyServer) err
 				}()
 
 				tw := tar.NewWriter(w)
-				defer func() {
-					if closeErr := tw.Close(); err == nil {
-						err = closeErr
-					}
-				}()
+				defer func() { err = errors.Join(err, tw.Close()) }()
 				header := &tar.Header{
 					Name: filepath.Base(m.Filename),
 					Uid:  m.UID,
@@ -950,7 +946,7 @@ func recvStdin[T any](ctx context.Context, name string, open bool, recv func() (
 			msg, err := recv()
 			if err != nil {
 				if !errors.Is(err, io.EOF) {
-					log.WithFunc("vibranium."+name).Error(ctx, err, "recv command")
+					log.WithFunc("vibranium.recvStdin").WithField("stream", name).Error(ctx, err, "recv command")
 				}
 				return
 			}

--- a/selfmon/selfmon.go
+++ b/selfmon/selfmon.go
@@ -127,7 +127,7 @@ func (n *NodeStatusWatcher) replayDeadJournals(ctx context.Context) {
 
 func (n *NodeStatusWatcher) initNodeStatus(ctx context.Context) {
 	logger := log.WithFunc("selfmon.initNodeStatus")
-	logger.Debug(ctx, "init node status started")
+	logger.Info(ctx, "init node status started")
 
 	var nodes []*types.Node
 	var err error

--- a/source/common/common_test.go
+++ b/source/common/common_test.go
@@ -70,7 +70,7 @@ wBtN56wGIEOHeQAAAAN0aHkBAgMEBQY=
 )
 
 func TestSourceCode(t *testing.T) {
-	privFile, err := os.CreateTemp("", "priv")
+	privFile, err := os.CreateTemp(t.TempDir(), "priv")
 	assert.NoError(t, err)
 	_, err = privFile.WriteString(privkey)
 	assert.NoError(t, err)
@@ -83,8 +83,7 @@ func TestSourceCode(t *testing.T) {
 	assert.NoError(t, err)
 	ctx := t.Context()
 
-	dname, err := os.MkdirTemp("", "source")
-	assert.NoError(t, err)
+	dname := t.TempDir()
 	err = g.SourceCode(ctx, "file:///xxxx", dname, "MASTER", false)
 	assert.Error(t, err)
 	err = g.SourceCode(ctx, "git@xxxx", dname, "MASTER", false)
@@ -109,17 +108,13 @@ func TestSourceCode(t *testing.T) {
 	assert.NoError(t, err)
 	_, err = os.Stat(dotGit)
 	assert.Error(t, err)
-
-	os.Remove(privFile.Name())
-	os.RemoveAll(dname)
 }
 
 func TestArtifact(t *testing.T) {
 	rawString := "test"
 	authValue := "test"
 	data := zipOf(t, map[string]string{"orig.txt": rawString})
-	savedDir, err := os.MkdirTemp("", "saved")
-	assert.NoError(t, err)
+	savedDir := t.TempDir()
 
 	g := &GitScm{}
 	testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -131,7 +126,7 @@ func TestArtifact(t *testing.T) {
 		res.Write(data)
 	}))
 	defer testServer.Close()
-	err = g.Artifact(t.Context(), "invaildurl", savedDir)
+	err := g.Artifact(t.Context(), "invaildurl", savedDir)
 	assert.Error(t, err)
 	err = g.Artifact(t.Context(), testServer.URL, savedDir)
 	assert.Error(t, err)
@@ -145,8 +140,6 @@ func TestArtifact(t *testing.T) {
 	saved, err := os.ReadFile(fname)
 	assert.NoError(t, err)
 	assert.Equal(t, string(saved), rawString)
-
-	os.RemoveAll(savedDir)
 }
 
 func TestArtifactHonoursContextCancellation(t *testing.T) {

--- a/store/common/node.go
+++ b/store/common/node.go
@@ -61,12 +61,14 @@ func (s *Store) RemoveNode(ctx context.Context, node *types.Node) error {
 		return nil
 	}
 
-	err := s.Delete(ctx, []string{
+	if err := s.Delete(ctx, []string{
 		fmt.Sprintf(NodeInfoKey, node.Name),
 		fmt.Sprintf(NodePodKey, node.Podname, node.Name),
-	})
+	}); err != nil {
+		return err
+	}
 	log.WithFunc("store.common.RemoveNode").Infof(ctx, "node (%s, %s, %s) deleted", node.Podname, node.Name, node.Endpoint)
-	return err
+	return nil
 }
 
 func (s *Store) GetNode(ctx context.Context, nodename string) (*types.Node, error) {

--- a/store/etcdv3/meta/etcd.go
+++ b/store/etcdv3/meta/etcd.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"runtime"
 	"slices"
 	"strconv"
 	"sync"
@@ -419,6 +420,7 @@ func (e *ETCD) doBatchOp(ctx context.Context, transactions []ETCDTxn) (*clientv3
 	// indexed slots keep the merged responses in request order, which GetMulti pairs with its keys
 	resps := make([]*clientv3.TxnResponse, len(spans))
 	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(runtime.GOMAXPROCS(0))
 	for i, sp := range spans {
 		g.Go(func() error {
 			conds, thens, elses := []clientv3.Cmp{}, []clientv3.Op{}, []clientv3.Op{}

--- a/store/redis/node_test.go
+++ b/store/redis/node_test.go
@@ -98,7 +98,6 @@ func (s *RediaronTestSuite) TestSetNodeStatus() {
 
 	_, err := s.rediaron.GetOne(s.T().Context(), key)
 	s.NoError(err)
-	time.Sleep(2 * time.Second)
 	s.advance(2 * time.Second)
 	_, err = s.rediaron.GetOne(s.T().Context(), key)
 	s.Error(err)
@@ -123,7 +122,6 @@ func (s *RediaronTestSuite) TestGetNodeStatus() {
 	s.NoError(err)
 	s.Equal(ns.Nodename, node.Name)
 	s.True(ns.Alive)
-	time.Sleep(2 * time.Second)
 	s.advance(2 * time.Second)
 	ns1, err := s.rediaron.GetNodeStatus(s.T().Context(), node.Name)
 	s.Error(err)
@@ -144,7 +142,7 @@ func (s *RediaronTestSuite) TestNodeStatusStream() {
 			}
 			time.Sleep(500 * time.Millisecond)
 			s.NoError(s.rediaron.SetNodeStatus(s.T().Context(), node, 1))
-			triggerMockedKeyspaceNotification(s.rediaron.cli, filepath.Join(common.NodeStatusPrefix, node.Name), actionSet)
+			triggerMockedKeyspaceNotification(ctx, s.rediaron.cli, filepath.Join(common.NodeStatusPrefix, node.Name), actionSet)
 		}
 	}()
 
@@ -152,7 +150,7 @@ func (s *RediaronTestSuite) TestNodeStatusStream() {
 	ch := s.rediaron.NodeStatusStream(ctx)
 	go func() {
 		time.Sleep(1500 * time.Millisecond)
-		triggerMockedKeyspaceNotification(s.rediaron.cli, filepath.Join(common.NodeStatusPrefix, node.Name), actionExpired)
+		triggerMockedKeyspaceNotification(ctx, s.rediaron.cli, filepath.Join(common.NodeStatusPrefix, node.Name), actionExpired)
 		time.Sleep(500 * time.Millisecond)
 		cancel()
 	}()

--- a/store/redis/pod_test.go
+++ b/store/redis/pod_test.go
@@ -13,7 +13,7 @@ func (s *RediaronTestSuite) TestPod() {
 	s.Equal(pod.Name, podname)
 
 	_, err = s.rediaron.AddPod(ctx, podname, "CPU")
-	s.Equal(err, ErrAlreadyExists)
+	s.ErrorIs(err, ErrAlreadyExists)
 
 	pod2, err := s.rediaron.GetPod(ctx, podname)
 	s.NoError(err)

--- a/store/redis/rediaron_test.go
+++ b/store/redis/rediaron_test.go
@@ -83,13 +83,13 @@ func (s *RediaronTestSuite) TestKeyNotify() {
 
 	time.Sleep(time.Second)
 	s.rediaron.cli.Set(s.T().Context(), "aaa", 1, 0)
-	triggerMockedKeyspaceNotification(s.rediaron.cli, "aaa", actionSet)
+	triggerMockedKeyspaceNotification(ctx, s.rediaron.cli, "aaa", actionSet)
 	s.rediaron.cli.Set(s.T().Context(), "aab", 1, 0)
-	triggerMockedKeyspaceNotification(s.rediaron.cli, "aab", actionSet)
+	triggerMockedKeyspaceNotification(ctx, s.rediaron.cli, "aab", actionSet)
 	s.rediaron.cli.Set(s.T().Context(), "bab", 1, 0)
-	triggerMockedKeyspaceNotification(s.rediaron.cli, "bab", actionSet)
+	triggerMockedKeyspaceNotification(ctx, s.rediaron.cli, "bab", actionSet)
 	s.rediaron.cli.Del(s.T().Context(), "aaa")
-	triggerMockedKeyspaceNotification(s.rediaron.cli, "aaa", actionDel)
+	triggerMockedKeyspaceNotification(ctx, s.rediaron.cli, "aaa", actionDel)
 
 	messages := []*KNotifyMessage{}
 	for m := range ch {
@@ -112,7 +112,7 @@ func (s *RediaronTestSuite) TestKeyNotifyCancellationUnblocksPendingMessage() {
 		return err == nil && count > 0
 	}, time.Second, 10*time.Millisecond)
 
-	triggerMockedKeyspaceNotification(s.rediaron.cli, "aaa", actionSet)
+	triggerMockedKeyspaceNotification(ctx, s.rediaron.cli, "aaa", actionSet)
 	time.Sleep(50 * time.Millisecond)
 	cancel()
 	s.Require().Eventually(func() bool {
@@ -224,9 +224,9 @@ func (s *RediaronTestSuite) TestWatchSkipsTTLRefreshes() {
 		return err == nil && count > 0
 	}, time.Second, 10*time.Millisecond)
 
-	triggerMockedKeyspaceNotification(s.rediaron.cli, "aaa", "expire")
-	triggerMockedKeyspaceNotification(s.rediaron.cli, "aab", actionSet)
-	triggerMockedKeyspaceNotification(s.rediaron.cli, "aaa", actionExpired)
+	triggerMockedKeyspaceNotification(ctx, s.rediaron.cli, "aaa", "expire")
+	triggerMockedKeyspaceNotification(ctx, s.rediaron.cli, "aab", actionSet)
+	triggerMockedKeyspaceNotification(ctx, s.rediaron.cli, "aaa", actionExpired)
 	time.Sleep(50 * time.Millisecond)
 	cancel()
 	<-done
@@ -263,9 +263,9 @@ func (s *RediaronTestSuite) advance(d time.Duration) {
 	time.Sleep(d + 500*time.Millisecond)
 }
 
-func triggerMockedKeyspaceNotification(cli *redis.Client, key, action string) {
+func triggerMockedKeyspaceNotification(ctx context.Context, cli *redis.Client, key, action string) {
 	channel := fmt.Sprintf(keyNotifyPrefix, 0, key)
-	cli.Publish(context.Background(), channel, action).Result()
+	cli.Publish(ctx, channel, action).Result()
 }
 
 func testRedis(t testing.TB) (*redis.Client, *miniredis.Miniredis) {

--- a/store/redis/service_test.go
+++ b/store/redis/service_test.go
@@ -46,7 +46,7 @@ func (s *RediaronTestSuite) TestServiceStatusStream() {
 	_, _, err = m.RegisterService(ctx, "127.0.0.1:5002", time.Second)
 	s.NoError(err)
 	time.Sleep(500 * time.Millisecond)
-	triggerMockedKeyspaceNotification(s.rediaron.cli, fmt.Sprintf(common.ServiceStatusKey, "127.0.0.1:5002"), actionSet)
+	triggerMockedKeyspaceNotification(ctx, s.rediaron.cli, fmt.Sprintf(common.ServiceStatusKey, "127.0.0.1:5002"), actionSet)
 
 	endpoints := <-ch
 	slices.Sort(endpoints)
@@ -54,7 +54,7 @@ func (s *RediaronTestSuite) TestServiceStatusStream() {
 
 	unregisterService1()
 	time.Sleep(500 * time.Millisecond)
-	triggerMockedKeyspaceNotification(s.rediaron.cli, fmt.Sprintf(common.ServiceStatusKey, "127.0.0.1:5001"), actionDel)
+	triggerMockedKeyspaceNotification(ctx, s.rediaron.cli, fmt.Sprintf(common.ServiceStatusKey, "127.0.0.1:5001"), actionDel)
 
 	s.advance(time.Second)
 	s.Equal(<-ch, []string{"127.0.0.1:5002"})

--- a/strategy/average.go
+++ b/strategy/average.go
@@ -14,9 +14,7 @@ import (
 // AveragePlan puts need workloads on each of limit nodes; need is per node, limit 0 means every node.
 func AveragePlan(_ context.Context, infos []Info, need, _, limit int) (map[string]int, error) {
 	scheduleInfosLength := len(infos)
-	if limit == 0 {
-		limit = scheduleInfosLength
-	}
+	limit = cmp.Or(limit, scheduleInfosLength)
 	if scheduleInfosLength < limit {
 		return nil, errors.Wrapf(types.ErrInsufficientResource, "node len %d < limit, cannot alloc an average node plan", scheduleInfosLength)
 	}

--- a/strategy/drained_test.go
+++ b/strategy/drained_test.go
@@ -9,35 +9,34 @@ import (
 func TestDrainedPlan(t *testing.T) {
 	nodes := genNodesByCapCount([]int{10, 9, 10, 8}, []int{2, 3, 5, 7})
 
-	r, err := DrainedPlan(t.Context(), nodes, 1, 100, 0)
-	assert.NoError(t, err)
-	assert.ElementsMatch(t, []int{2, 3, 5, 8}, getFinalStatus(r, nodes))
+	tests := []struct {
+		name    string
+		need    int
+		total   int
+		wantErr bool
+		want    []int
+	}{
+		{name: "need=1", need: 1, total: 100, want: []int{2, 3, 5, 8}},
+		{name: "need=2,total=1", need: 2, total: 1, wantErr: true},
+		{name: "need=2", need: 2, total: 100, want: []int{2, 3, 5, 9}},
+		{name: "need=3", need: 3, total: 100, want: []int{2, 3, 5, 10}},
+		{name: "need=10", need: 10, total: 100, want: []int{2, 5, 5, 15}},
+		{name: "need=25", need: 25, total: 100, want: []int{10, 12, 5, 15}},
+		{name: "need=29", need: 29, total: 100, want: []int{12, 12, 7, 15}},
+		{name: "need=37", need: 37, total: 100, want: []int{12, 12, 15, 15}},
+	}
 
-	r, err = DrainedPlan(t.Context(), nodes, 2, 1, 0)
-	assert.Error(t, err)
-
-	r, err = DrainedPlan(t.Context(), nodes, 2, 100, 0)
-	assert.NoError(t, err)
-	assert.ElementsMatch(t, []int{2, 3, 5, 9}, getFinalStatus(r, nodes))
-
-	r, err = DrainedPlan(t.Context(), nodes, 3, 100, 0)
-	assert.ElementsMatch(t, []int{2, 3, 5, 10}, getFinalStatus(r, nodes))
-
-	r, err = DrainedPlan(t.Context(), nodes, 10, 100, 0)
-	assert.NoError(t, err)
-	assert.ElementsMatch(t, []int{2, 5, 5, 15}, getFinalStatus(r, nodes))
-
-	r, err = DrainedPlan(t.Context(), nodes, 25, 100, 0)
-	assert.NoError(t, err)
-	assert.ElementsMatch(t, []int{10, 12, 5, 15}, getFinalStatus(r, nodes))
-
-	r, err = DrainedPlan(t.Context(), nodes, 29, 100, 0)
-	assert.NoError(t, err)
-	assert.ElementsMatch(t, []int{12, 12, 7, 15}, getFinalStatus(r, nodes))
-
-	r, err = DrainedPlan(t.Context(), nodes, 37, 100, 0)
-	assert.NoError(t, err)
-	assert.ElementsMatch(t, []int{12, 12, 15, 15}, getFinalStatus(r, nodes))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, err := DrainedPlan(t.Context(), nodes, tt.need, tt.total, 0)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, tt.want, getFinalStatus(r, nodes))
+		})
+	}
 }
 
 func TestDrainedPlanOrdersByCapacityThenUsage(t *testing.T) {

--- a/strategy/fill.go
+++ b/strategy/fill.go
@@ -13,9 +13,7 @@ import (
 // FillPlan tops every node up to need workloads; need is a per-node ceiling, limit 0 means every node.
 func FillPlan(_ context.Context, infos []Info, need, _, limit int) (_ map[string]int, err error) {
 	scheduleInfosLength := len(infos)
-	if limit == 0 {
-		limit = scheduleInfosLength
-	}
+	limit = cmp.Or(limit, scheduleInfosLength)
 	if scheduleInfosLength < limit {
 		return nil, errors.Wrapf(types.ErrInsufficientResource, "node len %d cannot alloc a fill node plan", scheduleInfosLength)
 	}

--- a/types/config.go
+++ b/types/config.go
@@ -73,7 +73,7 @@ type GRPCConfig struct {
 }
 
 type GitConfig struct {
-	SCMType      string        `yaml:"scm_type"` // source code manager type [gitlab/github]
+	SCMType      string        `yaml:"scm_type"`
 	PrivateKey   string        `yaml:"private_key"`
 	Token        string        `yaml:"token"`
 	CloneTimeout time.Duration `yaml:"clone_timeout" default:"300s"`

--- a/types/options.go
+++ b/types/options.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"cmp"
 	"fmt"
 	"io"
 	"slices"
@@ -184,9 +185,7 @@ func (o *ReplaceOptions) Validate() error {
 
 // Normalize defaults Count to 1.
 func (o *ReplaceOptions) Normalize() {
-	if o.Count == 0 {
-		o.Count = 1
-	}
+	o.Count = cmp.Or(o.Count, 1)
 }
 
 type AddNodeOptions struct {

--- a/utils/transaction.go
+++ b/utils/transaction.go
@@ -37,7 +37,7 @@ func Txn(ctx context.Context, cond, then contextFunc, rollback rollbackFunc, ttl
 		defer rollBackCancel()
 		failureByCond := condErr != nil
 		if err := rollback(rollbackCtx, failureByCond); err != nil {
-			logger.Warnf(ctx, "txn failed but rollback also failed: %+v", err)
+			logger.Error(ctx, err, "txn failed, rollback also failed")
 			return
 		}
 		settled = true


### PR DESCRIPTION
Whole-repo style round under the reloaded asl (rules commit 2b26bf9: `cmpor`, `forwarder`, `labelenum` join the gate) and the reloaded /code skill. Three commits:

1. `review: fold zero-value fallbacks into cmp.Or` — the six sites the new `cmpor` analyzer gates.
2. `review: standalone funcs below the type block` — layout only, `engine/types/image.go`.
3. `review: style round under the reloaded asl and skill` — what 15 readers (369 files read in full, every finding adjudicated against the source) surfaced and adjudication kept: cobalt's plugin call and rollback share one named generic func type, as do sshrunner's openers; comments over the one-fact budget trimmed and an enumerating field comment dropped; `RemoveNode` logs the deletion only when it happened, the txn rollback failure is an Error with its cause, `recvStdin` names itself and carries the stream as a field, the tar writer close joins into the copy error; `doBatchOp` bounds its span fan-out at GOMAXPROCS; receivers derive from their types; tests use `t.TempDir`, drop redundant sleeps before `advance`, check a sentinel with `ErrorIs`, pass ctx to the keyspace helper, and the cpumem and drained-plan cases are table-driven.

Adjudication kept (recorded in the hygiene ledger, not changed): the `logger.Error(ctx, err)` log-and-return idiom, WHY godocs on engine methods, the helium stress sleeps, `Error` on corrupted store entries, the wire-key comment, the API-named cluster methods, `omitempty` on the map-typed resource fields, the producer-method placement asl's contiguity gate governs.

Gates: build, vet, full tests, lint + fmt-check on linux and darwin, asl gate analyzers on both, all green; comment lines over the round −2.