### PR TITLE
cut: drop the exec-level privileged flag no engine reads

### DIFF
--- a/cluster/calcium/hook.go
+++ b/cluster/calcium/hook.go
@@ -10,7 +10,7 @@ import (
 func (c *Calcium) doHook(ctx context.Context, workload *types.Workload, cmds []string, force bool) ([]*bytes.Buffer, error) {
 	outputs := []*bytes.Buffer{}
 	for _, cmd := range cmds {
-		output, err := c.executeInside(ctx, workload.Engine, workload.ID, cmd, workload.User, workload.Env, workload.Privileged)
+		output, err := c.executeInside(ctx, workload.Engine, workload.ID, cmd, workload.User, workload.Env)
 		if err != nil {
 			outputs = append(outputs, bytes.NewBufferString(err.Error()))
 			if workload.Hook.Force && !force {

--- a/cluster/calcium/stream.go
+++ b/cluster/calcium/stream.go
@@ -31,13 +31,12 @@ type window struct {
 	Width  uint `json:"Col"`
 }
 
-func (c *Calcium) executeInside(ctx context.Context, client engine.API, ID, cmd, user string, env []string, privileged bool) ([]byte, error) {
+func (c *Calcium) executeInside(ctx context.Context, client engine.API, ID, cmd, user string, env []string) ([]byte, error) {
 	cmds := utils.MakeCommandLineArgs(cmd)
 	execConfig := &enginetypes.ExecConfig{
-		User:       user,
-		Cmd:        cmds,
-		Privileged: privileged,
-		Env:        env,
+		User: user,
+		Cmd:  cmds,
+		Env:  env,
 	}
 	b := []byte{}
 	execID, stdout, stderr, _, err := client.Execute(ctx, ID, execConfig)

--- a/engine/types/exec.go
+++ b/engine/types/exec.go
@@ -3,7 +3,6 @@ package types
 // ExecConfig mirrors the exec subset of docker's api/types Config.
 type ExecConfig struct {
 	User        string
-	Privileged  bool
 	Tty         bool
 	AttachStdin bool
 	Env         []string


### PR DESCRIPTION
## What

`ExecConfig.Privileged` was docker's per-exec privilege switch (`docker exec --privileged`). Every engine now runs an exec inside the workload's own task, whose privilege was fixed at create time from the same `Entrypoint.Privileged`, and none of them read the exec flag. The field and the `privileged` parameter of `executeInside` are gone; the container-level `VirtualizationCreateOptions.Privileged` is untouched (containerd's `withPrivileged`, the process engine's create).

Stacked on #743 because both touch `engine/types/exec.go` and the exec literal in `stream.go`; it will be rebased onto master and retargeted once #743 merges.

## Evidence

Gate on the branch: build, vet, full tests, `make lint`, `make fmt-check` and `asl` on both GOOS green; comment delta +0 −0.
