### PR TITLE
feat: read every node's resources in one plugin call when listing

### DIFF
--- a/cluster/calcium/node.go
+++ b/cluster/calcium/node.go
@@ -142,9 +142,13 @@ func (c *Calcium) ListPodNodes(ctx context.Context, opts *types.ListNodesOptions
 		logger.Error(ctx, err)
 		return nil, err
 	}
+	infos, err := c.rmgr.GetNodesResourceInfo(ctx, utils.Map(nodes, func(node *types.Node) string { return node.Name }))
+	if err != nil {
+		logger.Error(ctx, err, "failed to get nodes resource info")
+	}
 	return perNode(c, nodes, func(node *types.Node, ch chan<- *types.Node) {
-		if err := c.refreshResourceInfo(ctx, node); err != nil {
-			logger.Errorf(ctx, err, "failed to get node %s resource info", node.Name)
+		if info, ok := infos[node.Name]; ok {
+			node.ResourceInfo = *info
 		}
 		if opts.CallInfo {
 			if err := node.Info(ctx); err != nil {

--- a/cluster/calcium/node_test.go
+++ b/cluster/calcium/node_test.go
@@ -152,7 +152,7 @@ func TestListPodNodes(t *testing.T) {
 	}
 	store.On("GetNodesByPod", mock.Anything, mock.Anything, mock.Anything).Return(nodes, nil)
 	rmgr := c.rmgr.(*resourcemocks.Manager)
-	rmgr.On("GetNodeResourceInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil, nil, types.ErrMockError)
+	rmgr.On("GetNodesResourceInfo", mock.Anything, []string{name1, name2}).Return(nil, types.ErrMockError).Once()
 	opts.CallInfo = true
 
 	ns, err := c.ListPodNodes(ctx, opts)
@@ -162,6 +162,17 @@ func TestListPodNodes(t *testing.T) {
 		cnt++
 	}
 	assert.Equal(t, cnt, 2)
+
+	rmgr.On("GetNodesResourceInfo", mock.Anything, []string{name1, name2}).Return(map[string]*types.NodeResourceInfo{
+		name1: {Capacity: resourcetypes.Resources{"cpumem": resourcetypes.RawParams{"cpu": 8}}},
+	}, nil).Once()
+	ns, err = c.ListPodNodes(ctx, opts)
+	assert.NoError(t, err)
+	listed := map[string]any{}
+	for node := range ns {
+		listed[node.Name] = node.ResourceInfo.Capacity["cpumem"]["cpu"]
+	}
+	assert.Equal(t, map[string]any{name1: 8, name2: nil}, listed)
 	rmgr.AssertExpectations(t)
 	store.AssertExpectations(t)
 }

--- a/docs/resource-plugins.md
+++ b/docs/resource-plugins.md
@@ -111,6 +111,7 @@ The contract is a subcommand plus JSON:
 | `get-nodes-deploy-capacity` | `GetNodesDeployCapacity` |
 | `set-node-resource-capacity` | `SetNodeResourceCapacity` |
 | `get-node-resource-info` | `GetNodeResourceInfo` |
+| `get-nodes-resource-info` | `GetNodesResourceInfo` |
 | `set-node-resource-info` | `SetNodeResourceInfo` |
 | `set-node-resource-usage` | `SetNodeResourceUsage` |
 | `get-most-idle-node` | `GetMostIdleNode` |
@@ -121,6 +122,10 @@ The contract is a subcommand plus JSON:
 Response shapes are the JSON encodings of the types in `resource/plugins/types/`, e.g.
 `calculate-deploy` returns `{"engines_params": [...], "workloads_resource": [...]}` and
 `get-nodes-deploy-capacity` returns `{"nodes_deploy_capacity_map": {...}, "total": n}`.
+`get-nodes-resource-info` takes `{"nodenames": [...]}` and returns
+`{"node_resource_info_map": {"<node>": {"capacity": {...}, "usage": {...}}, ...}}`; core lists nodes
+through it and falls back to one `get-node-resource-info` call per node for a plugin that does not
+advertise it.
 `get-metrics` takes every node in one call, `{"nodes": [{"podname": ..., "nodename": ...}, ...]}`,
 and returns the metrics of all of them.
 

--- a/resource/cobalt/node.go
+++ b/resource/cobalt/node.go
@@ -125,6 +125,26 @@ func (m *Manager) GetNodeResourceInfo(ctx context.Context, nodename string, work
 	return m.getNodeResourceInfo(ctx, nodename, m.whitelisted, workloads, fix)
 }
 
+func (m *Manager) GetNodesResourceInfo(ctx context.Context, nodenames []string) (map[string]*types.NodeResourceInfo, error) {
+	resps, err := call(ctx, m.whitelisted, func(plugin plugins.Plugin) (*plugintypes.GetNodesResourceInfoResponse, error) {
+		return plugin.GetNodesResourceInfo(ctx, nodenames)
+	})
+
+	infos := make(map[string]*types.NodeResourceInfo, len(nodenames))
+	for _, nodename := range nodenames {
+		infos[nodename] = &types.NodeResourceInfo{Capacity: resourcetypes.Resources{}, Usage: resourcetypes.Resources{}}
+	}
+	for plugin, resp := range resps {
+		for nodename, info := range resp.NodeResourceInfoMap {
+			if node, ok := infos[nodename]; ok {
+				node.Capacity[plugin.Name()] = info.Capacity
+				node.Usage[plugin.Name()] = info.Usage
+			}
+		}
+	}
+	return infos, err
+}
+
 func (m *Manager) SetNodeResourceUsage(ctx context.Context, nodename string, nodeResource, nodeResourceRequest resourcetypes.Resources, workloadsResource []resourcetypes.Resources, delta, incr bool) (resourcetypes.Resources, resourcetypes.Resources, error) {
 	logger := log.WithFunc("resource.cobalt.SetNodeResourceUsage").WithField("node", nodename)
 	wrksResource := map[string][]resourcetypes.RawParams{}

--- a/resource/cobalt/node_test.go
+++ b/resource/cobalt/node_test.go
@@ -107,10 +107,53 @@ func TestSetNodeResourceCapacityReturnsSuccessfulChange(t *testing.T) {
 	assert.Equal(t, afterResource, after["cpumem"])
 }
 
+func TestGetNodesResourceInfoMergesEveryPlugin(t *testing.T) {
+	m := New(coretypes.Config{})
+	m.AddPlugins(
+		newResourceInfoPlugin(t, "cpumem", map[string]*plugintypes.NodeResourceInfo{
+			"n1": {Capacity: plugintypes.NodeResource{"cpu": 8}, Usage: plugintypes.NodeResource{"cpu": 1}},
+			"n2": {Capacity: plugintypes.NodeResource{"cpu": 4}, Usage: plugintypes.NodeResource{"cpu": 0}},
+		}),
+		newResourceInfoPlugin(t, "storage", map[string]*plugintypes.NodeResourceInfo{
+			"n1": {Capacity: plugintypes.NodeResource{"storage": 100}, Usage: plugintypes.NodeResource{"storage": 10}},
+		}),
+	)
+
+	infos, err := m.GetNodesResourceInfo(t.Context(), []string{"n1", "n2"})
+	assert.NoError(t, err)
+	assert.Equal(t, plugintypes.NodeResource{"cpu": 8}, infos["n1"].Capacity["cpumem"])
+	assert.Equal(t, plugintypes.NodeResource{"storage": 10}, infos["n1"].Usage["storage"])
+	assert.Equal(t, plugintypes.NodeResource{"cpu": 4}, infos["n2"].Capacity["cpumem"])
+	assert.NotContains(t, infos["n2"].Capacity, "storage")
+}
+
+func TestGetNodesResourceInfoKeepsTheHealthyPlugins(t *testing.T) {
+	m := New(coretypes.Config{})
+	broken := pluginmocks.NewPlugin(t)
+	broken.On("Name").Return("gpu").Maybe()
+	broken.On("GetNodesResourceInfo", mock.Anything, mock.Anything).Return(nil, coretypes.ErrMockError)
+	m.AddPlugins(
+		newResourceInfoPlugin(t, "cpumem", map[string]*plugintypes.NodeResourceInfo{"n1": {Capacity: plugintypes.NodeResource{"cpu": 8}}}),
+		broken,
+	)
+
+	infos, err := m.GetNodesResourceInfo(t.Context(), []string{"n1"})
+	assert.ErrorIs(t, err, coretypes.ErrMockError)
+	assert.Equal(t, plugintypes.NodeResource{"cpu": 8}, infos["n1"].Capacity["cpumem"])
+}
+
 func newCapacityPlugin(t *testing.T, name string, capacities map[string]*plugintypes.NodeDeployCapacity) *pluginmocks.Plugin {
 	p := pluginmocks.NewPlugin(t)
 	p.On("Name").Return(name).Maybe()
 	resp := &plugintypes.GetNodesDeployCapacityResponse{NodeDeployCapacityMap: capacities}
 	p.On("GetNodesDeployCapacity", mock.Anything, mock.Anything, mock.Anything).Return(resp, nil)
+	return p
+}
+
+func newResourceInfoPlugin(t *testing.T, name string, infos map[string]*plugintypes.NodeResourceInfo) *pluginmocks.Plugin {
+	p := pluginmocks.NewPlugin(t)
+	p.On("Name").Return(name).Maybe()
+	resp := &plugintypes.GetNodesResourceInfoResponse{NodeResourceInfoMap: infos}
+	p.On("GetNodesResourceInfo", mock.Anything, mock.Anything).Return(resp, nil)
 	return p
 }

--- a/resource/manager.go
+++ b/resource/manager.go
@@ -17,6 +17,7 @@ type Manager interface {
 	SetNodeResourceCapacity(context.Context, string, resourcetypes.Resources, resourcetypes.Resources, bool, bool) (resourcetypes.Resources, resourcetypes.Resources, error)
 	SetNodeResourceUsage(context.Context, string, resourcetypes.Resources, resourcetypes.Resources, []resourcetypes.Resources, bool, bool) (resourcetypes.Resources, resourcetypes.Resources, error)
 	GetNodeResourceInfo(context.Context, string, []*types.Workload, bool) (resourcetypes.Resources, resourcetypes.Resources, []string, error)
+	GetNodesResourceInfo(context.Context, []string) (map[string]*types.NodeResourceInfo, error)
 	GetMostIdleNode(context.Context, []string) (string, error)
 
 	Alloc(context.Context, string, int, resourcetypes.Resources) ([]resourcetypes.Resources, []resourcetypes.Resources, error)

--- a/resource/mocks/Manager.go
+++ b/resource/mocks/Manager.go
@@ -581,6 +581,74 @@ func (_c *Manager_GetNodesMetrics_Call) RunAndReturn(run func(context1 context.C
 	return _c
 }
 
+// GetNodesResourceInfo provides a mock function for the type Manager
+func (_mock *Manager) GetNodesResourceInfo(context1 context.Context, strings []string) (map[string]*types2.NodeResourceInfo, error) {
+	ret := _mock.Called(context1, strings)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetNodesResourceInfo")
+	}
+
+	var r0 map[string]*types2.NodeResourceInfo
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) (map[string]*types2.NodeResourceInfo, error)); ok {
+		return returnFunc(context1, strings)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) map[string]*types2.NodeResourceInfo); ok {
+		r0 = returnFunc(context1, strings)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]*types2.NodeResourceInfo)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, []string) error); ok {
+		r1 = returnFunc(context1, strings)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Manager_GetNodesResourceInfo_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetNodesResourceInfo'
+type Manager_GetNodesResourceInfo_Call struct {
+	*mock.Call
+}
+
+// GetNodesResourceInfo is a helper method to define mock.On call
+//   - context1 context.Context
+//   - strings []string
+func (_e *Manager_Expecter) GetNodesResourceInfo(context1 any, strings any) *Manager_GetNodesResourceInfo_Call {
+	return &Manager_GetNodesResourceInfo_Call{Call: _e.mock.On("GetNodesResourceInfo", context1, strings)}
+}
+
+func (_c *Manager_GetNodesResourceInfo_Call) Run(run func(context1 context.Context, strings []string)) *Manager_GetNodesResourceInfo_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []string
+		if args[1] != nil {
+			arg1 = args[1].([]string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *Manager_GetNodesResourceInfo_Call) Return(stringToNodeResourceInfo map[string]*types2.NodeResourceInfo, err error) *Manager_GetNodesResourceInfo_Call {
+	_c.Call.Return(stringToNodeResourceInfo, err)
+	return _c
+}
+
+func (_c *Manager_GetNodesResourceInfo_Call) RunAndReturn(run func(context1 context.Context, strings []string) (map[string]*types2.NodeResourceInfo, error)) *Manager_GetNodesResourceInfo_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Realloc provides a mock function for the type Manager
 func (_mock *Manager) Realloc(context1 context.Context, s string, resources types.Resources, resources1 types.Resources) (types.Resources, types.Resources, types.Resources, error) {
 	ret := _mock.Called(context1, s, resources, resources1)

--- a/resource/plugins/binary/call_test.go
+++ b/resource/plugins/binary/call_test.go
@@ -14,16 +14,31 @@ import (
 	coretypes "github.com/projecteru2/core/types"
 )
 
-const fakePlugin = `#!/bin/sh
+const (
+	fakePlugin = `#!/bin/sh
 case "$1" in
 verbs) echo '["remove-node", "get-metrics"]' ;;
 remove-node) echo 'a log line' >&2; echo '{}' ;;
 get-metrics) cat >&2 ;;
 esac
 `
+	perNodePlugin = `#!/bin/sh
+case "$1" in
+verbs) echo '["get-node-resource-info"]' ;;
+get-node-resource-info) n=$(sed 's/.*"nodename":"\([^"]*\)".*/\1/'); echo "{\"capacity\":{\"node\":\"$n\"},\"usage\":{}}" ;;
+esac
+`
+	batchPlugin = `#!/bin/sh
+case "$1" in
+verbs) echo '["get-node-resource-info", "get-nodes-resource-info"]' ;;
+get-node-resource-info) echo 'the singular verb was called' >&2; exit 1 ;;
+get-nodes-resource-info) cat >/dev/null; echo '{"node_resource_info_map":{"n1":{"capacity":{"cpu":1},"usage":{}},"n2":{"capacity":{"cpu":2},"usage":{}}}}' ;;
+esac
+`
+)
 
 func TestCallSpawnsOnlyAdvertisedVerbs(t *testing.T) {
-	p := newFakePlugin(t)
+	p := newFakePlugin(t, fakePlugin)
 	_, err := p.RemoveNode(t.Context(), "n1")
 	assert.NoError(t, err)
 
@@ -32,9 +47,25 @@ func TestCallSpawnsOnlyAdvertisedVerbs(t *testing.T) {
 }
 
 func TestCallRejectsAnEmptyResponse(t *testing.T) {
-	p := newFakePlugin(t)
+	p := newFakePlugin(t, fakePlugin)
 	_, err := p.GetMetrics(t.Context(), []plugintypes.NodeRef{{Podname: "p", Nodename: "n1"}})
 	assert.ErrorContains(t, err, "no response")
+}
+
+func TestGetNodesResourceInfoUsesThePluralVerb(t *testing.T) {
+	p := newFakePlugin(t, batchPlugin)
+	resp, err := p.GetNodesResourceInfo(t.Context(), []string{"n1", "n2"})
+	require.NoError(t, err)
+	assert.Len(t, resp.NodeResourceInfoMap, 2)
+	assert.EqualValues(t, 2, resp.NodeResourceInfoMap["n2"].Capacity["cpu"])
+}
+
+func TestGetNodesResourceInfoFallsBackToOneCallPerNode(t *testing.T) {
+	p := newFakePlugin(t, perNodePlugin)
+	resp, err := p.GetNodesResourceInfo(t.Context(), []string{"n1", "n2"})
+	require.NoError(t, err)
+	assert.Equal(t, "n1", resp.NodeResourceInfoMap["n1"].Capacity["node"])
+	assert.Equal(t, "n2", resp.NodeResourceInfoMap["n2"].Capacity["node"])
 }
 
 func TestNewPluginNeedsTheVerbList(t *testing.T) {
@@ -46,10 +77,10 @@ func TestNewPluginNeedsTheVerbList(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func newFakePlugin(t *testing.T) *Plugin {
+func newFakePlugin(t *testing.T, script string) *Plugin {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "resource-fake")
-	require.NoError(t, os.WriteFile(path, []byte(fakePlugin), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(script), 0o755))
 	p, err := NewPlugin(t.Context(), path, pluginConfig(dir))
 	require.NoError(t, err)
 	return p

--- a/resource/plugins/binary/commands.go
+++ b/resource/plugins/binary/commands.go
@@ -14,8 +14,9 @@ const (
 
 	SetNodeResourceCapacityCommand = "set-node-resource-capacity"
 
-	GetNodeResourceInfoCommand = "get-node-resource-info"
-	SetNodeResourceInfoCommand = "set-node-resource-info"
+	GetNodeResourceInfoCommand  = "get-node-resource-info"
+	GetNodesResourceInfoCommand = "get-nodes-resource-info"
+	SetNodeResourceInfoCommand  = "set-node-resource-info"
 
 	SetNodeResourceUsageCommand = "set-node-resource-usage"
 

--- a/resource/plugins/binary/node.go
+++ b/resource/plugins/binary/node.go
@@ -2,11 +2,16 @@ package binary
 
 import (
 	"context"
+	"slices"
+
+	"golang.org/x/sync/errgroup"
 
 	enginetypes "github.com/projecteru2/core/engine/types"
 	binarytypes "github.com/projecteru2/core/resource/plugins/binary/types"
 	plugintypes "github.com/projecteru2/core/resource/plugins/types"
 )
+
+const fallbackFanout = 16
 
 func (p Plugin) AddNode(ctx context.Context, nodename string, resource plugintypes.NodeResourceRequest, info *enginetypes.Info) (*plugintypes.AddNodeResponse, error) {
 	req := &binarytypes.AddNodeRequest{
@@ -50,6 +55,32 @@ func (p Plugin) SetNodeResourceCapacity(ctx context.Context, nodename string, re
 
 func (p Plugin) GetNodeResourceInfo(ctx context.Context, nodename string, workloadsResource []plugintypes.WorkloadResource) (*plugintypes.GetNodeResourceInfoResponse, error) {
 	return p.doGetNodeResourceInfo(ctx, nodename, workloadsResource, GetNodeResourceInfoCommand)
+}
+
+func (p Plugin) GetNodesResourceInfo(ctx context.Context, nodenames []string) (*plugintypes.GetNodesResourceInfoResponse, error) {
+	resp := &plugintypes.GetNodesResourceInfoResponse{}
+	if slices.Contains(p.verbs, GetNodesResourceInfoCommand) {
+		return resp, p.call(ctx, GetNodesResourceInfoCommand, &binarytypes.GetNodesResourceInfoRequest{Nodenames: nodenames}, resp)
+	}
+
+	infos := make([]*plugintypes.GetNodeResourceInfoResponse, len(nodenames))
+	var g errgroup.Group
+	g.SetLimit(fallbackFanout)
+	for i, nodename := range nodenames {
+		g.Go(func() error {
+			var err error
+			infos[i], err = p.GetNodeResourceInfo(ctx, nodename, nil)
+			return err
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+	resp.NodeResourceInfoMap = make(map[string]*plugintypes.NodeResourceInfo, len(nodenames))
+	for i, nodename := range nodenames {
+		resp.NodeResourceInfoMap[nodename] = &plugintypes.NodeResourceInfo{Capacity: infos[i].Capacity, Usage: infos[i].Usage}
+	}
+	return resp, nil
 }
 
 func (p Plugin) SetNodeResourceInfo(ctx context.Context, nodename string, capacity, usage plugintypes.NodeResource) (*plugintypes.SetNodeResourceInfoResponse, error) {

--- a/resource/plugins/binary/types/node.go
+++ b/resource/plugins/binary/types/node.go
@@ -33,6 +33,10 @@ type GetNodeResourceInfoRequest struct {
 	WorkloadsResource []plugintypes.WorkloadResource `json:"workloads_resource"`
 }
 
+type GetNodesResourceInfoRequest struct {
+	Nodenames []string `json:"nodenames"`
+}
+
 type SetNodeResourceInfoRequest struct {
 	Nodename string                   `json:"nodename"`
 	Capacity plugintypes.NodeResource `json:"capacity"`

--- a/resource/plugins/cpumem/node.go
+++ b/resource/plugins/cpumem/node.go
@@ -198,6 +198,23 @@ func (p Plugin) GetNodeResourceInfo(ctx context.Context, nodename string, worklo
 	}, resp)
 }
 
+func (p Plugin) GetNodesResourceInfo(ctx context.Context, nodenames []string) (*plugintypes.GetNodesResourceInfoResponse, error) {
+	infos, err := p.doGetNodesResourceInfo(ctx, nodenames)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := &plugintypes.GetNodesResourceInfoResponse{NodeResourceInfoMap: make(map[string]*plugintypes.NodeResourceInfo, len(infos))}
+	for nodename, info := range infos {
+		nodeInfo := &plugintypes.NodeResourceInfo{}
+		if err := resourcetypes.Decode(map[string]any{fieldCapacity: info.Capacity, fieldUsage: info.Usage}, nodeInfo); err != nil {
+			return nil, err
+		}
+		resp.NodeResourceInfoMap[nodename] = nodeInfo
+	}
+	return resp, nil
+}
+
 func (p Plugin) SetNodeResourceInfo(ctx context.Context, nodename string, capacity, usage plugintypes.NodeResource) (*plugintypes.SetNodeResourceInfoResponse, error) {
 	capacityResource := &cpumemtypes.NodeResource{}
 	usageResource := &cpumemtypes.NodeResource{}

--- a/resource/plugins/cpumem/node_test.go
+++ b/resource/plugins/cpumem/node_test.go
@@ -67,6 +67,20 @@ func TestRemoveNode(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestGetNodesResourceInfo(t *testing.T) {
+	ctx := t.Context()
+	cm := initCPUMEM(t)
+	nodes := generateNodes(ctx, t, cm, 2, 2, 4*units.GB, 100, 0)
+
+	resp, err := cm.GetNodesResourceInfo(ctx, nodes)
+	assert.NoError(t, err)
+	assert.Len(t, resp.NodeResourceInfoMap, 2)
+	for _, node := range nodes {
+		assert.EqualValues(t, 2, resp.NodeResourceInfoMap[node].Capacity["cpu"])
+		assert.EqualValues(t, 0, resp.NodeResourceInfoMap[node].Usage["cpu"])
+	}
+}
+
 func TestGetNodesDeployCapacityWithCPUBind(t *testing.T) {
 	ctx := t.Context()
 	cm := initCPUMEM(t)

--- a/resource/plugins/mocks/Plugin.go
+++ b/resource/plugins/mocks/Plugin.go
@@ -773,6 +773,74 @@ func (_c *Plugin_GetNodesDeployCapacity_Call) RunAndReturn(run func(ctx context.
 	return _c
 }
 
+// GetNodesResourceInfo provides a mock function for the type Plugin
+func (_mock *Plugin) GetNodesResourceInfo(ctx context.Context, nodenames []string) (*types.GetNodesResourceInfoResponse, error) {
+	ret := _mock.Called(ctx, nodenames)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetNodesResourceInfo")
+	}
+
+	var r0 *types.GetNodesResourceInfoResponse
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) (*types.GetNodesResourceInfoResponse, error)); ok {
+		return returnFunc(ctx, nodenames)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) *types.GetNodesResourceInfoResponse); ok {
+		r0 = returnFunc(ctx, nodenames)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*types.GetNodesResourceInfoResponse)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, []string) error); ok {
+		r1 = returnFunc(ctx, nodenames)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// Plugin_GetNodesResourceInfo_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetNodesResourceInfo'
+type Plugin_GetNodesResourceInfo_Call struct {
+	*mock.Call
+}
+
+// GetNodesResourceInfo is a helper method to define mock.On call
+//   - ctx context.Context
+//   - nodenames []string
+func (_e *Plugin_Expecter) GetNodesResourceInfo(ctx any, nodenames any) *Plugin_GetNodesResourceInfo_Call {
+	return &Plugin_GetNodesResourceInfo_Call{Call: _e.mock.On("GetNodesResourceInfo", ctx, nodenames)}
+}
+
+func (_c *Plugin_GetNodesResourceInfo_Call) Run(run func(ctx context.Context, nodenames []string)) *Plugin_GetNodesResourceInfo_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []string
+		if args[1] != nil {
+			arg1 = args[1].([]string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *Plugin_GetNodesResourceInfo_Call) Return(getNodesResourceInfoResponse *types.GetNodesResourceInfoResponse, err error) *Plugin_GetNodesResourceInfo_Call {
+	_c.Call.Return(getNodesResourceInfoResponse, err)
+	return _c
+}
+
+func (_c *Plugin_GetNodesResourceInfo_Call) RunAndReturn(run func(ctx context.Context, nodenames []string) (*types.GetNodesResourceInfoResponse, error)) *Plugin_GetNodesResourceInfo_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Name provides a mock function for the type Plugin
 func (_mock *Plugin) Name() string {
 	ret := _mock.Called()

--- a/resource/plugins/plugin.go
+++ b/resource/plugins/plugin.go
@@ -39,6 +39,9 @@ type Plugin interface {
 	// GetNodeResourceInfo returns the node's total and available resources.
 	GetNodeResourceInfo(ctx context.Context, nodename string, workloadsResource []plugintypes.WorkloadResource) (*plugintypes.GetNodeResourceInfoResponse, error)
 
+	// GetNodesResourceInfo returns the capacity and usage of many nodes in one call; a node the plugin never saw is left out.
+	GetNodesResourceInfo(ctx context.Context, nodenames []string) (*plugintypes.GetNodesResourceInfoResponse, error)
+
 	// SetNodeResourceInfo stores a node's capacity and usage as absolute values.
 	SetNodeResourceInfo(ctx context.Context, nodename string, capacity, usage plugintypes.NodeResource) (*plugintypes.SetNodeResourceInfoResponse, error)
 

--- a/resource/plugins/types/node.go
+++ b/resource/plugins/types/node.go
@@ -41,6 +41,15 @@ type GetNodeResourceInfoResponse struct {
 	Diffs    []string     `json:"diffs"`
 }
 
+type NodeResourceInfo struct {
+	Capacity NodeResource `json:"capacity"`
+	Usage    NodeResource `json:"usage"`
+}
+
+type GetNodesResourceInfoResponse struct {
+	NodeResourceInfoMap map[string]*NodeResourceInfo `json:"node_resource_info_map"`
+}
+
 type SetNodeResourceInfoResponse struct{}
 
 type SetNodeResourceUsageResponse struct {


### PR DESCRIPTION
## What

Listing nodes asked every resource plugin for every node: one process per node per binary plugin, so `pod nodes` on a cluster with N nodes and two binary plugins spawned 2N processes. This adds a plural verb to the plugin protocol and lists through it.

- `resource/plugins`: `Plugin.GetNodesResourceInfo(ctx, nodenames)` returns `{node_resource_info_map: {<node>: {capacity, usage}}}`; a node the plugin never saw is left out.
- `resource/plugins/binary`: the client sends `get-nodes-resource-info` when the plugin advertised it in `verbs`, and otherwise falls back to one `get-node-resource-info` call per node (bounded fan-out), so plugin binaries that predate the verb keep working unchanged.
- `resource/plugins/cpumem`: one `GetMulti` over the node keys.
- `resource/cobalt`: `Manager.GetNodesResourceInfo` merges the plugins' maps per node; a failing plugin is logged and left out, the other plugins' data is kept.
- `cluster/calcium`: `ListPodNodes` asks once for all nodes before it streams them. The per-node diffs the old path computed against an empty workload set were never sent (`pb.Node` carries no diffs), so the listing output is unchanged.
- `docs/resource-plugins.md`: the verb, its shapes, and the fallback.

Single-node paths (`node get`, `node set`, `node resource`) keep the singular verb with workloads and diffs.

## Hot-path cost

Off the deploy/remove path. The list path goes from 2N plugin processes to 2 (or stays at 2N with old plugin binaries).

Lane A/B, `eru-cli pod nodes test --filter all`, 3 rounds × 8 runs per arm, arms interleaved, on the same host; A = this branch's base + plugins v0.1.4, B = this branch + plugins v0.1.4 (fallback), C = this branch + resource-extend's matching branch:

| nodes | A median | B median | C median |
| --- | --- | --- | --- |
| 1 | 32 ms | 33 ms | 34 ms |
| 50 (49 `mock://`) | 623 ms | 619 ms | 42 ms |

B equals A, so the fallback costs nothing; C is the verb.

## Lines

Production +90 net (a new verb in the client, the plugin, the manager and the listing; no other mechanism), tests +99 net; mocks regenerated.

## Evidence

Gate on the branch: build, vet, full tests, `make lint`, `make fmt-check` and `asl` on both GOOS green. Tests: the binary client's plural and fallback paths against fake plugin scripts, cobalt's merge and partial-failure cases, cpumem's batch read, the listing with and without resource info.

Stacked on #743 (it changes files #743 touches); resource-extend's side is the matching PR there.

