### PR TITLE
review: post-merge round over the batch, with a fix for the plural node read

### DIFF
--- a/cluster/calcium/control.go
+++ b/cluster/calcium/control.go
@@ -11,10 +11,18 @@ import (
 	"github.com/projecteru2/core/utils"
 )
 
+type controlHandler func(context.Context, *types.Workload, bool) ([]*bytes.Buffer, error)
+
 func (c *Calcium) ControlWorkload(ctx context.Context, IDs []string, typ string, force bool) (chan *types.ControlWorkloadMessage, error) {
-	switch typ {
-	case cluster.WorkloadStop, cluster.WorkloadStart, cluster.WorkloadRestart, cluster.WorkloadSuspend, cluster.WorkloadResume:
-	default:
+	handlers := map[string]controlHandler{
+		cluster.WorkloadStop:    c.doStopWorkload,
+		cluster.WorkloadStart:   c.doStartWorkload,
+		cluster.WorkloadRestart: c.doRestartWorkload,
+		cluster.WorkloadSuspend: c.doSuspendWorkload,
+		cluster.WorkloadResume:  c.doResumeWorkload,
+	}
+	handle, ok := handlers[typ]
+	if !ok {
 		return nil, types.ErrInvaildControlType
 	}
 
@@ -30,32 +38,9 @@ func (c *Calcium) ControlWorkload(ctx context.Context, IDs []string, typ string,
 			_ = c.pool.Invoke(func() {
 				defer wg.Done()
 				var message []*bytes.Buffer
-				err := c.withWorkloadLocked(ctx, ID, false, func(ctx context.Context, workload *types.Workload) error {
-					var err error
-					switch typ {
-					case cluster.WorkloadStop:
-						message, err = c.doStopWorkload(ctx, workload, force)
-						return err
-					case cluster.WorkloadStart:
-						message, err = c.doStartWorkload(ctx, workload, force)
-						return err
-					case cluster.WorkloadRestart:
-						message, err = c.doStopWorkload(ctx, workload, force)
-						if err != nil {
-							return err
-						}
-						var startHook []*bytes.Buffer
-						startHook, err = c.doStartWorkload(ctx, workload, force)
-						message = append(message, startHook...)
-						return err
-					case cluster.WorkloadSuspend:
-						message, err = c.doSuspendWorkload(ctx, workload, force)
-						return err
-					case cluster.WorkloadResume:
-						message, err = c.doResumeWorkload(ctx, workload, force)
-						return err
-					}
-					return types.ErrInvaildControlType
+				err := c.withWorkloadLocked(ctx, ID, false, func(ctx context.Context, workload *types.Workload) (err error) {
+					message, err = handle(ctx, workload, force)
+					return err
 				})
 				if err == nil {
 					logger.Infof(ctx, "workload %s %s", ID, typ)
@@ -83,6 +68,15 @@ func (c *Calcium) doStartWorkload(ctx context.Context, workload *types.Workload,
 		message, err = c.doHook(ctx, workload, workload.Hook.AfterStart, force)
 	}
 	return message, err
+}
+
+func (c *Calcium) doRestartWorkload(ctx context.Context, workload *types.Workload, force bool) ([]*bytes.Buffer, error) {
+	message, err := c.doStopWorkload(ctx, workload, force)
+	if err != nil {
+		return message, err
+	}
+	startHook, err := c.doStartWorkload(ctx, workload, force)
+	return append(message, startHook...), err
 }
 
 func (c *Calcium) doStopWorkload(ctx context.Context, workload *types.Workload, force bool) (message []*bytes.Buffer, err error) {

--- a/cluster/calcium/status.go
+++ b/cluster/calcium/status.go
@@ -60,8 +60,7 @@ func (c *Calcium) SetWorkloadsStatus(ctx context.Context, statusMetas []*types.S
 		}
 	}
 
-	r := make([]*types.StatusMeta, len(statusMetas))
-	for idx, statusMeta := range statusMetas {
+	for _, statusMeta := range statusMetas {
 		if workload, ok := workloads[statusMeta.ID]; ok {
 			appname, entrypoint, _, err := utils.ParseWorkloadName(workload.Name)
 			if err != nil {
@@ -72,7 +71,6 @@ func (c *Calcium) SetWorkloadsStatus(ctx context.Context, statusMetas []*types.S
 			statusMeta.Nodename = workload.Nodename
 			statusMeta.Entrypoint = entrypoint
 		}
-		r[idx] = statusMeta
 	}
 
 	var writes errgroup.Group
@@ -84,7 +82,7 @@ func (c *Calcium) SetWorkloadsStatus(ctx context.Context, statusMetas []*types.S
 		logger.Error(ctx, err)
 		return nil, err
 	}
-	return r, nil
+	return statusMetas, nil
 }
 
 func (c *Calcium) WorkloadStatusStream(ctx context.Context, appname, entrypoint, nodename string, labels map[string]string) chan *types.WorkloadStatus {

--- a/engine/cocoon/copy.go
+++ b/engine/cocoon/copy.go
@@ -4,7 +4,6 @@ import (
 	"archive/tar"
 	"context"
 	"io"
-	"strings"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -38,7 +37,8 @@ func (e *Engine) VirtualizationCopyChunkTo(ctx context.Context, ID, target strin
 	if err = running.Stdin().Close(); err != nil {
 		return err
 	}
-	return exited(argv, running)
+	_, err = sshrunner.Exited(argv, running)
+	return err
 }
 
 func (e *Engine) VirtualizationCopyFrom(ctx context.Context, ID, path string) (content []byte, uid, gid int, mode int64, err error) {
@@ -57,14 +57,4 @@ func (e *Engine) VirtualizationCopyFrom(ctx context.Context, ID, path string) (c
 	}
 	content, err = io.ReadAll(archive)
 	return content, header.Uid, header.Gid, header.Mode, err
-}
-
-// exited reports a non-zero guest exit with what the command said on stderr.
-func exited(argv []string, running sshrunner.Session) error {
-	stderr, _ := io.ReadAll(running.Stderr())
-	code, err := running.Wait()
-	if err != nil {
-		return err
-	}
-	return sshrunner.ExitError(argv, &sshrunner.Result{Stderr: strings.TrimSpace(string(stderr)), Code: code})
 }

--- a/engine/containerd/copy.go
+++ b/engine/containerd/copy.go
@@ -73,12 +73,9 @@ func (e *Engine) VirtualizationCopyFrom(ctx context.Context, ID, path string) (c
 	if readErr == nil {
 		content, readErr = io.ReadAll(reader)
 	}
-	res, err := exited(running)
+	res, err := sshrunner.Exited(argv, running)
 	if err != nil {
-		return nil, 0, 0, 0, err
-	}
-	if err = sshrunner.ExitError(argv, res); err != nil {
-		if missingPath(res) {
+		if res != nil && missingPath(res) {
 			return nil, 0, 0, 0, errors.Wrapf(coretypes.ErrWorkloadNotExists, "%s not found in workload %s", path, ID)
 		}
 		return nil, 0, 0, 0, err
@@ -124,18 +121,6 @@ func (e *Engine) snapshotArgv(ID, snapshotKey, target string) []string {
 		ctrBinary, e.socket, e.namespace, snapshotKey,
 		filepath.Join(workloadDir(ID), snapshotMount), filepath.Dir(target),
 	)
-}
-
-func exited(running sshrunner.Session) (*sshrunner.Result, error) {
-	stderr, err := io.ReadAll(running.Stderr())
-	if err != nil {
-		return nil, err
-	}
-	code, err := running.Wait()
-	if err != nil {
-		return nil, err
-	}
-	return &sshrunner.Result{Stderr: string(stderr), Code: code}, nil
 }
 
 func missingPath(res *sshrunner.Result) bool {

--- a/engine/sshrunner/utils.go
+++ b/engine/sshrunner/utils.go
@@ -84,16 +84,21 @@ func Stream(ctx context.Context, runner Runner, argv ...string) (*Result, error)
 	defer func() {
 		_ = running.Close()
 	}()
+	return Exited(argv, running)
+}
+
+// Exited drains a started session and reports a non-zero exit as an error.
+func Exited(argv []string, running Session) (*Result, error) {
 	var out, errOut []byte
 	var readers errgroup.Group
 	readers.Go(func() (err error) { out, err = io.ReadAll(running.Stdout()); return err })
 	readers.Go(func() (err error) { errOut, err = io.ReadAll(running.Stderr()); return err })
-	if readErr := readers.Wait(); readErr != nil {
-		return nil, readErr
+	if err := readers.Wait(); err != nil {
+		return nil, err
 	}
-	code, waitErr := running.Wait()
-	if waitErr != nil {
-		return nil, waitErr
+	code, err := running.Wait()
+	if err != nil {
+		return nil, err
 	}
 	res := &Result{Stdout: string(out), Stderr: string(errOut), Code: code}
 	return res, ExitError(argv, res)

--- a/resource/cobalt/cobalt.go
+++ b/resource/cobalt/cobalt.go
@@ -44,7 +44,8 @@ func (m *Manager) LoadPlugins(ctx context.Context, store store.Store) error {
 		return err
 	}
 	for _, file := range pluginFiles {
-		if _, ok := cache[filepath.Base(file)]; ok {
+		name := filepath.Base(file)
+		if _, ok := cache[name]; ok {
 			continue
 		}
 		logger.Infof(ctx, "load binary plugin: %+v", file)
@@ -52,7 +53,7 @@ func (m *Manager) LoadPlugins(ctx context.Context, store store.Store) error {
 		if err != nil {
 			return err
 		}
-		cache[b.Name()] = struct{}{}
+		cache[name] = struct{}{}
 		m.AddPlugins(b)
 	}
 	return nil

--- a/resource/cobalt/node.go
+++ b/resource/cobalt/node.go
@@ -126,20 +126,23 @@ func (m *Manager) GetNodeResourceInfo(ctx context.Context, nodename string, work
 }
 
 func (m *Manager) GetNodesResourceInfo(ctx context.Context, nodenames []string) (map[string]*types.NodeResourceInfo, error) {
+	infos := make(map[string]*types.NodeResourceInfo, len(nodenames))
+	if len(nodenames) == 0 {
+		return infos, nil
+	}
 	resps, err := call(ctx, m.whitelisted, func(plugin plugins.Plugin) (*plugintypes.GetNodesResourceInfoResponse, error) {
 		return plugin.GetNodesResourceInfo(ctx, nodenames)
 	})
 
-	infos := make(map[string]*types.NodeResourceInfo, len(nodenames))
-	for _, nodename := range nodenames {
-		infos[nodename] = &types.NodeResourceInfo{Capacity: resourcetypes.Resources{}, Usage: resourcetypes.Resources{}}
-	}
 	for plugin, resp := range resps {
 		for nodename, info := range resp.NodeResourceInfoMap {
-			if node, ok := infos[nodename]; ok {
-				node.Capacity[plugin.Name()] = info.Capacity
-				node.Usage[plugin.Name()] = info.Usage
+			node, ok := infos[nodename]
+			if !ok {
+				node = &types.NodeResourceInfo{Capacity: resourcetypes.Resources{}, Usage: resourcetypes.Resources{}}
+				infos[nodename] = node
 			}
+			node.Capacity[plugin.Name()] = info.Capacity
+			node.Usage[plugin.Name()] = info.Usage
 		}
 	}
 	return infos, err

--- a/resource/cobalt/node.go
+++ b/resource/cobalt/node.go
@@ -187,7 +187,6 @@ func (m *Manager) SetNodeResourceUsage(ctx context.Context, nodename string, nod
 	)
 }
 
-// GetNodesDeployCapacity returns, under the caller's node locks, the nodes meeting every plugin's requirements and their total capacity.
 func (m *Manager) GetNodesDeployCapacity(ctx context.Context, nodenames []string, opts resourcetypes.Resources) (map[string]*plugintypes.NodeDeployCapacity, int, error) {
 	var resp map[string]*plugintypes.NodeDeployCapacity
 
@@ -216,7 +215,6 @@ func (m *Manager) GetNodesDeployCapacity(ctx context.Context, nodenames []string
 	return resp, total, nil
 }
 
-// SetNodeResourceCapacity updates node capacity from resource options rather than resource args.
 func (m *Manager) SetNodeResourceCapacity(ctx context.Context, nodename string, nodeResource, nodeResourceRequest resourcetypes.Resources, delta, incr bool) (resourcetypes.Resources, resourcetypes.Resources, error) {
 	logger := log.WithFunc("resource.cobalt.SetNodeResourceCapacity").WithField("node", nodename)
 
@@ -321,7 +319,6 @@ func mergeCapacity(m1, m2 map[string]*plugintypes.NodeDeployCapacity) map[string
 	return m1
 }
 
-// rollbackNodeResource restores every plugin that applied a failed set of the node's resources.
 func rollbackNodeResource[T any](ctx context.Context, ps []plugins.Plugin, restore pluginCall[T]) error {
 	_, err := call(ctx, ps, restore)
 	return err

--- a/resource/plugins/binary/node.go
+++ b/resource/plugins/binary/node.go
@@ -2,11 +2,12 @@ package binary
 
 import (
 	"context"
-	"slices"
 
+	"github.com/cockroachdb/errors"
 	"golang.org/x/sync/errgroup"
 
 	enginetypes "github.com/projecteru2/core/engine/types"
+	"github.com/projecteru2/core/resource/plugins"
 	binarytypes "github.com/projecteru2/core/resource/plugins/binary/types"
 	plugintypes "github.com/projecteru2/core/resource/plugins/types"
 )
@@ -59,8 +60,9 @@ func (p Plugin) GetNodeResourceInfo(ctx context.Context, nodename string, worklo
 
 func (p Plugin) GetNodesResourceInfo(ctx context.Context, nodenames []string) (*plugintypes.GetNodesResourceInfoResponse, error) {
 	resp := &plugintypes.GetNodesResourceInfoResponse{}
-	if slices.Contains(p.verbs, GetNodesResourceInfoCommand) {
-		return resp, p.call(ctx, GetNodesResourceInfoCommand, &binarytypes.GetNodesResourceInfoRequest{Nodenames: nodenames}, resp)
+	err := p.call(ctx, GetNodesResourceInfoCommand, &binarytypes.GetNodesResourceInfoRequest{Nodenames: nodenames}, resp)
+	if !errors.Is(err, plugins.ErrVerbNotSupported) {
+		return resp, err
 	}
 
 	infos := make([]*plugintypes.GetNodeResourceInfoResponse, len(nodenames))

--- a/resource/plugins/binary/types/node.go
+++ b/resource/plugins/binary/types/node.go
@@ -21,11 +21,11 @@ type GetNodesDeployCapacityRequest struct {
 }
 
 type SetNodeResourceCapacityRequest struct {
-	Nodename        string                   `json:"nodename"`
-	Resource        plugintypes.NodeResource `json:"resource"`
-	ResourceRequest plugintypes.NodeResource `json:"resource_request"`
-	Delta           bool                     `json:"delta"`
-	Incr            bool                     `json:"incr"`
+	Nodename        string                          `json:"nodename"`
+	Resource        plugintypes.NodeResource        `json:"resource"`
+	ResourceRequest plugintypes.NodeResourceRequest `json:"resource_request"`
+	Delta           bool                            `json:"delta"`
+	Incr            bool                            `json:"incr"`
 }
 
 type GetNodeResourceInfoRequest struct {

--- a/resource/plugins/cpumem/node.go
+++ b/resource/plugins/cpumem/node.go
@@ -112,28 +112,24 @@ func (p Plugin) GetNodesDeployCapacity(ctx context.Context, nodenames []string, 
 	}
 
 	nodesDeployCapacityMap := make(map[string]*plugintypes.NodeDeployCapacity, len(nodenames))
-	if !req.CPUBind {
-		for nodename, nodeResourceInfo := range nodesResourceInfos {
-			if nodeDeployCapacity := p.doGetNodeDeployCapacity(nodeResourceInfo, req); nodeDeployCapacity.Capacity > 0 {
-				nodesDeployCapacityMap[nodename] = nodeDeployCapacity
-			}
-		}
-	} else {
-		var mu sync.Mutex
-		var planners errgroup.Group
-		planners.SetLimit(runtime.GOMAXPROCS(0))
-		for nodename, nodeResourceInfo := range nodesResourceInfos {
-			planners.Go(func() error {
-				if nodeDeployCapacity := p.doGetNodeDeployCapacity(nodeResourceInfo, req); nodeDeployCapacity.Capacity > 0 {
-					mu.Lock()
-					nodesDeployCapacityMap[nodename] = nodeDeployCapacity
-					mu.Unlock()
-				}
-				return nil
-			})
-		}
-		_ = planners.Wait()
+	planners := 1
+	if req.CPUBind {
+		planners = runtime.GOMAXPROCS(0)
 	}
+	var mu sync.Mutex
+	var g errgroup.Group
+	g.SetLimit(planners)
+	for nodename, nodeResourceInfo := range nodesResourceInfos {
+		g.Go(func() error {
+			if nodeDeployCapacity := p.doGetNodeDeployCapacity(nodeResourceInfo, req); nodeDeployCapacity.Capacity > 0 {
+				mu.Lock()
+				nodesDeployCapacityMap[nodename] = nodeDeployCapacity
+				mu.Unlock()
+			}
+			return nil
+		})
+	}
+	_ = g.Wait()
 
 	total := 0
 	for _, nodeDeployCapacity := range nodesDeployCapacityMap {

--- a/resource/plugins/cpumem/node.go
+++ b/resource/plugins/cpumem/node.go
@@ -199,18 +199,22 @@ func (p Plugin) GetNodeResourceInfo(ctx context.Context, nodename string, worklo
 }
 
 func (p Plugin) GetNodesResourceInfo(ctx context.Context, nodenames []string) (*plugintypes.GetNodesResourceInfoResponse, error) {
-	infos, err := p.doGetNodesResourceInfo(ctx, nodenames)
+	keys := utils.Map(nodenames, func(nodename string) string { return fmt.Sprintf(nodeResourceInfoKey, nodename) })
+	data, err := p.store.GetMulti(ctx, keys)
+	if p.store.NotFound(err) {
+		data, err = p.getKnown(ctx, keys)
+	}
 	if err != nil {
 		return nil, err
 	}
 
-	resp := &plugintypes.GetNodesResourceInfoResponse{NodeResourceInfoMap: make(map[string]*plugintypes.NodeResourceInfo, len(infos))}
-	for nodename, info := range infos {
-		nodeInfo := &plugintypes.NodeResourceInfo{}
-		if err := resourcetypes.Decode(map[string]any{fieldCapacity: info.Capacity, fieldUsage: info.Usage}, nodeInfo); err != nil {
+	resp := &plugintypes.GetNodesResourceInfoResponse{NodeResourceInfoMap: make(map[string]*plugintypes.NodeResourceInfo, len(data))}
+	for key, value := range data {
+		info := &plugintypes.NodeResourceInfo{}
+		if err := json.Unmarshal([]byte(value), info); err != nil {
 			return nil, err
 		}
-		resp.NodeResourceInfoMap[nodename] = nodeInfo
+		resp.NodeResourceInfoMap[utils.Tail(key)] = info
 	}
 	return resp, nil
 }
@@ -356,6 +360,18 @@ func (p Plugin) doGetNodeResourceInfo(ctx context.Context, nodename string) (*cp
 		return nil, err
 	}
 	return resp[nodename], nil
+}
+
+func (p Plugin) getKnown(ctx context.Context, keys []string) (map[string]string, error) {
+	data := make(map[string]string, len(keys))
+	for _, key := range keys {
+		one, err := p.store.GetMulti(ctx, []string{key})
+		if err != nil && !p.store.NotFound(err) {
+			return nil, err
+		}
+		maps.Copy(data, one)
+	}
+	return data, nil
 }
 
 func (p Plugin) doGetNodesResourceInfo(ctx context.Context, nodenames []string) (map[string]*cpumemtypes.NodeResourceInfo, error) {

--- a/resource/plugins/cpumem/node_test.go
+++ b/resource/plugins/cpumem/node_test.go
@@ -72,7 +72,7 @@ func TestGetNodesResourceInfo(t *testing.T) {
 	cm := initCPUMEM(t)
 	nodes := generateNodes(ctx, t, cm, 2, 2, 4*units.GB, 100, 0)
 
-	resp, err := cm.GetNodesResourceInfo(ctx, nodes)
+	resp, err := cm.GetNodesResourceInfo(ctx, append(nodes, "never-added"))
 	assert.NoError(t, err)
 	assert.Len(t, resp.NodeResourceInfoMap, 2)
 	for _, node := range nodes {

--- a/resource/plugins/cpumem/node_test.go
+++ b/resource/plugins/cpumem/node_test.go
@@ -95,36 +95,28 @@ func TestGetNodesDeployCapacityWithCPUBind(t *testing.T) {
 	_, err := cm.GetNodesDeployCapacity(ctx, []string{"xxx"}, req)
 	assert.True(t, errors.Is(err, coretypes.ErrInvaildCount))
 
-	r, err := cm.GetNodesDeployCapacity(ctx, nodes, req)
-	assert.Nil(t, err)
-	assert.True(t, r.Total >= 1)
-
-	req = plugintypes.WorkloadResourceRequest{
-		"cpu-bind":       true,
-		"cpu-request":    2,
-		"memory-request": "1",
+	tests := []struct {
+		name       string
+		cpuRequest any
+		check      func(t *testing.T, total int)
+	}{
+		{"half core request", 0.5, func(t *testing.T, total int) { assert.True(t, total >= 1) }},
+		{"two core request", 2, func(t *testing.T, total int) { assert.True(t, total < 3) }},
+		{"three core request", 3, func(t *testing.T, total int) { assert.True(t, total < 2) }},
+		{"one core request", 1, func(t *testing.T, total int) { assert.True(t, total < 5) }},
 	}
-	r, err = cm.GetNodesDeployCapacity(ctx, nodes, req)
-	assert.Nil(t, err)
-	assert.True(t, r.Total < 3)
-
-	req = plugintypes.WorkloadResourceRequest{
-		"cpu-bind":       true,
-		"cpu-request":    3,
-		"memory-request": "1",
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := plugintypes.WorkloadResourceRequest{
+				"cpu-bind":       true,
+				"cpu-request":    tt.cpuRequest,
+				"memory-request": "1",
+			}
+			r, err := cm.GetNodesDeployCapacity(ctx, nodes, req)
+			assert.Nil(t, err)
+			tt.check(t, r.Total)
+		})
 	}
-	r, err = cm.GetNodesDeployCapacity(ctx, nodes, req)
-	assert.Nil(t, err)
-	assert.True(t, r.Total < 2)
-
-	req = plugintypes.WorkloadResourceRequest{
-		"cpu-bind":       true,
-		"cpu-request":    1,
-		"memory-request": "1",
-	}
-	r, err = cm.GetNodesDeployCapacity(ctx, nodes, req)
-	assert.Nil(t, err)
-	assert.True(t, r.Total < 5)
 
 	nodes = generateNodes(ctx, t, cm, 1, 4, 12*units.GB, 100, 10)
 	nodes = append(nodes, generateNodes(ctx, t, cm, 1, 14, 12*units.GB, 100, 11)...)
@@ -137,7 +129,7 @@ func TestGetNodesDeployCapacityWithCPUBind(t *testing.T) {
 		"cpu-request":    1.7,
 		"memory-request": "1",
 	}
-	r, err = cm.GetNodesDeployCapacity(ctx, nodes, req)
+	r, err := cm.GetNodesDeployCapacity(ctx, nodes, req)
 	assert.Nil(t, err)
 	assert.Equal(t, r.Total, 28)
 }
@@ -212,36 +204,23 @@ func TestGetNodesDeployCapacityWithMemory(t *testing.T) {
 	_, err := cm.GetNodesDeployCapacity(ctx, nodes, req)
 	assert.True(t, errors.Is(err, types.ErrInvalidMemory))
 
-	req = plugintypes.WorkloadResourceRequest{
-		"cpu-request":    1,
-		"memory-request": fmt.Sprintf("%v", 512*units.MB),
+	tests := []struct {
+		name string
+		req  plugintypes.WorkloadResourceRequest
+		want int
+	}{
+		{"cpu and memory request", plugintypes.WorkloadResourceRequest{"cpu-request": 1, "memory-request": fmt.Sprintf("%v", 512*units.MB)}, 16},
+		{"memory request only", plugintypes.WorkloadResourceRequest{"memory-request": fmt.Sprintf("%v", 512*units.MB)}, 16},
+		{"cpu request exceeds capacity", plugintypes.WorkloadResourceRequest{"cpu-request": 3, "memory-request": fmt.Sprintf("%v", 512*units.MB)}, 0},
+		{"cpu request only", plugintypes.WorkloadResourceRequest{"cpu-request": 1}, math.MaxInt},
 	}
-
-	r, err := cm.GetNodesDeployCapacity(ctx, nodes, req)
-	assert.Nil(t, err)
-	assert.Equal(t, r.Total, 16)
-
-	req = plugintypes.WorkloadResourceRequest{
-		"memory-request": fmt.Sprintf("%v", 512*units.MB),
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, err := cm.GetNodesDeployCapacity(ctx, nodes, tt.req)
+			assert.Nil(t, err)
+			assert.Equal(t, r.Total, tt.want)
+		})
 	}
-	r, err = cm.GetNodesDeployCapacity(ctx, nodes, req)
-	assert.Nil(t, err)
-	assert.Equal(t, r.Total, 16)
-
-	req = plugintypes.WorkloadResourceRequest{
-		"cpu-request":    3,
-		"memory-request": fmt.Sprintf("%v", 512*units.MB),
-	}
-	r, err = cm.GetNodesDeployCapacity(ctx, nodes, req)
-	assert.Nil(t, err)
-	assert.Equal(t, r.Total, 0)
-
-	req = plugintypes.WorkloadResourceRequest{
-		"cpu-request": 1,
-	}
-	r, err = cm.GetNodesDeployCapacity(ctx, nodes, req)
-	assert.Nil(t, err)
-	assert.Equal(t, r.Total, math.MaxInt)
 }
 
 func TestSetNodeResourceCapacity(t *testing.T) {
@@ -291,36 +270,78 @@ func TestSetNodeResourceCapacity(t *testing.T) {
 		"memory": fmt.Sprintf("%v", 2*units.GB),
 	}
 
-	r, err := cm.SetNodeResourceCapacity(ctx, node, nodeResource, nil, true, true)
-	assert.Nil(t, err)
-	assert.Len(t, r.After["cpu_map"], 4)
-
-	r, err = cm.SetNodeResourceCapacity(ctx, node, nodeResource, nil, true, false)
-	assert.Nil(t, err)
-	assert.Len(t, r.After["cpu_map"], 2)
-	assert.Len(t, r.After["numa_memory"], 2)
-	assert.Len(t, r.After["numa"], 4)
-
-	r, err = cm.SetNodeResourceCapacity(ctx, node, nil, nodeResourceRequest, true, true)
-	assert.Nil(t, err)
-	assert.Len(t, r.After["cpu_map"], 4)
-	assert.Len(t, r.After["numa_memory"], 2)
-	assert.Len(t, r.After["numa"], 4)
-
-	r, err = cm.SetNodeResourceCapacity(ctx, node, nil, nodeResourceRequest, true, false)
-	assert.Nil(t, err)
-	assert.Len(t, r.After["cpu_map"], 2)
-	assert.Len(t, r.After["numa_memory"], 2)
-	assert.Len(t, r.After["numa"], 4)
-
-	r, err = cm.SetNodeResourceCapacity(ctx, node, nil, noChangeRequest, false, true)
-	assert.Nil(t, err)
-	assert.Len(t, r.After["cpu_map"], 4)
-
-	r, err = cm.SetNodeResourceCapacity(ctx, node, newNodeResource, nil, false, false)
-	assert.Nil(t, err)
-	assert.Len(t, r.After["cpu_map"], 2)
-	assert.Len(t, r.After["numa"], 0)
+	tests := []struct {
+		name     string
+		resource plugintypes.NodeResource
+		request  plugintypes.NodeResourceRequest
+		delta    bool
+		incr     bool
+		check    func(t *testing.T, after plugintypes.NodeResource)
+	}{
+		{
+			name:     "resource delta incr",
+			resource: nodeResource,
+			delta:    true,
+			incr:     true,
+			check: func(t *testing.T, after plugintypes.NodeResource) {
+				assert.Len(t, after["cpu_map"], 4)
+			},
+		},
+		{
+			name:     "resource delta decr",
+			resource: nodeResource,
+			delta:    true,
+			check: func(t *testing.T, after plugintypes.NodeResource) {
+				assert.Len(t, after["cpu_map"], 2)
+				assert.Len(t, after["numa_memory"], 2)
+				assert.Len(t, after["numa"], 4)
+			},
+		},
+		{
+			name:    "request delta incr",
+			request: nodeResourceRequest,
+			delta:   true,
+			incr:    true,
+			check: func(t *testing.T, after plugintypes.NodeResource) {
+				assert.Len(t, after["cpu_map"], 4)
+				assert.Len(t, after["numa_memory"], 2)
+				assert.Len(t, after["numa"], 4)
+			},
+		},
+		{
+			name:    "request delta decr",
+			request: nodeResourceRequest,
+			delta:   true,
+			check: func(t *testing.T, after plugintypes.NodeResource) {
+				assert.Len(t, after["cpu_map"], 2)
+				assert.Len(t, after["numa_memory"], 2)
+				assert.Len(t, after["numa"], 4)
+			},
+		},
+		{
+			name:    "request no delta incr",
+			request: noChangeRequest,
+			incr:    true,
+			check: func(t *testing.T, after plugintypes.NodeResource) {
+				assert.Len(t, after["cpu_map"], 4)
+			},
+		},
+		{
+			name:     "resource no delta decr",
+			resource: newNodeResource,
+			check: func(t *testing.T, after plugintypes.NodeResource) {
+				assert.Len(t, after["cpu_map"], 2)
+				assert.Len(t, after["numa"], 0)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, err := cm.SetNodeResourceCapacity(ctx, node, tt.resource, tt.request, tt.delta, tt.incr)
+			assert.Nil(t, err)
+			tt.check(t, r.After)
+		})
+	}
 }
 
 func TestGetAndFixNodeResourceInfo(t *testing.T) {
@@ -416,47 +437,98 @@ func TestSetNodeResourceUsage(t *testing.T) {
 		},
 	}
 
-	r, err := cm.SetNodeResourceUsage(ctx, node, nodeResource, nil, nil, true, true)
-	assert.Nil(t, err)
-	assert.Len(t, r.After["cpu_map"], 2)
-
-	r, err = cm.SetNodeResourceUsage(ctx, node, nodeResource, nil, nil, true, false)
-	assert.Nil(t, err)
-	assert.Len(t, r.After["cpu_map"], 2)
-	assert.Equal(t, r.After["cpu"], 0.0)
-	assert.Equal(t, r.After["memory"], 0.0)
-
-	r, err = cm.SetNodeResourceUsage(ctx, node, nil, nodeResourceRequest, nil, true, true)
-	assert.Nil(t, err)
-	assert.Len(t, r.After["cpu_map"], 2)
-
-	r, err = cm.SetNodeResourceUsage(ctx, node, nil, nodeResourceRequest, nil, true, false)
-	assert.Nil(t, err)
-	assert.Len(t, r.After["cpu_map"], 2)
-	assert.Equal(t, r.After["cpu"], 0.0)
-	assert.Equal(t, r.After["memory"], 0.0)
-
-	r, err = cm.SetNodeResourceUsage(ctx, node, nil, nil, workloadsResource, true, true)
-	assert.Nil(t, err)
-	assert.Len(t, r.After["cpu_map"], 2)
-
-	r, err = cm.SetNodeResourceUsage(ctx, node, nil, nil, workloadsResource, true, false)
-	assert.Nil(t, err)
-	assert.Len(t, r.After["cpu_map"], 2)
-	assert.Equal(t, r.After["cpu"], 0.0)
-	assert.Equal(t, r.After["memory"], 0.0)
-
-	r, err = cm.SetNodeResourceUsage(ctx, node, nil, nil, nil, true, false)
-	assert.Nil(t, err)
-	assert.Len(t, r.After["cpu_map"], 2)
-	assert.Equal(t, r.After["cpu"], 0.0)
-	assert.Equal(t, r.After["memory"], 0.0)
-
-	r, err = cm.SetNodeResourceUsage(ctx, node, nil, nodeResourceRequest, nil, false, false)
-	assert.Nil(t, err)
-	assert.Len(t, r.After["cpu_map"], 2)
-	assert.Equal(t, r.After["cpu"], 2.0)
-	assert.Equal(t, r.After["memory"], float64(2*units.GB))
+	tests := []struct {
+		name              string
+		resource          plugintypes.NodeResource
+		resourceRequest   plugintypes.NodeResourceRequest
+		workloadsResource []plugintypes.WorkloadResource
+		delta             bool
+		incr              bool
+		check             func(t *testing.T, after plugintypes.NodeResource)
+	}{
+		{
+			name:     "resource delta incr",
+			resource: nodeResource,
+			delta:    true,
+			incr:     true,
+			check: func(t *testing.T, after plugintypes.NodeResource) {
+				assert.Len(t, after["cpu_map"], 2)
+			},
+		},
+		{
+			name:     "resource delta decr",
+			resource: nodeResource,
+			delta:    true,
+			check: func(t *testing.T, after plugintypes.NodeResource) {
+				assert.Len(t, after["cpu_map"], 2)
+				assert.Equal(t, after["cpu"], 0.0)
+				assert.Equal(t, after["memory"], 0.0)
+			},
+		},
+		{
+			name:            "request delta incr",
+			resourceRequest: nodeResourceRequest,
+			delta:           true,
+			incr:            true,
+			check: func(t *testing.T, after plugintypes.NodeResource) {
+				assert.Len(t, after["cpu_map"], 2)
+			},
+		},
+		{
+			name:            "request delta decr",
+			resourceRequest: nodeResourceRequest,
+			delta:           true,
+			check: func(t *testing.T, after plugintypes.NodeResource) {
+				assert.Len(t, after["cpu_map"], 2)
+				assert.Equal(t, after["cpu"], 0.0)
+				assert.Equal(t, after["memory"], 0.0)
+			},
+		},
+		{
+			name:              "workloads delta incr",
+			workloadsResource: workloadsResource,
+			delta:             true,
+			incr:              true,
+			check: func(t *testing.T, after plugintypes.NodeResource) {
+				assert.Len(t, after["cpu_map"], 2)
+			},
+		},
+		{
+			name:              "workloads delta decr",
+			workloadsResource: workloadsResource,
+			delta:             true,
+			check: func(t *testing.T, after plugintypes.NodeResource) {
+				assert.Len(t, after["cpu_map"], 2)
+				assert.Equal(t, after["cpu"], 0.0)
+				assert.Equal(t, after["memory"], 0.0)
+			},
+		},
+		{
+			name:  "no input delta decr",
+			delta: true,
+			check: func(t *testing.T, after plugintypes.NodeResource) {
+				assert.Len(t, after["cpu_map"], 2)
+				assert.Equal(t, after["cpu"], 0.0)
+				assert.Equal(t, after["memory"], 0.0)
+			},
+		},
+		{
+			name:            "request no delta",
+			resourceRequest: nodeResourceRequest,
+			check: func(t *testing.T, after plugintypes.NodeResource) {
+				assert.Len(t, after["cpu_map"], 2)
+				assert.Equal(t, after["cpu"], 2.0)
+				assert.Equal(t, after["memory"], float64(2*units.GB))
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, err := cm.SetNodeResourceUsage(ctx, node, tt.resource, tt.resourceRequest, tt.workloadsResource, tt.delta, tt.incr)
+			assert.Nil(t, err)
+			tt.check(t, r.After)
+		})
+	}
 }
 
 func TestGetMostIdleNode(t *testing.T) {

--- a/resource/plugins/plugin.go
+++ b/resource/plugins/plugin.go
@@ -39,7 +39,7 @@ type Plugin interface {
 	// GetNodeResourceInfo returns the node's total and available resources.
 	GetNodeResourceInfo(ctx context.Context, nodename string, workloadsResource []plugintypes.WorkloadResource) (*plugintypes.GetNodeResourceInfoResponse, error)
 
-	// GetNodesResourceInfo returns the capacity and usage of many nodes in one call; a node the plugin never saw is left out.
+	// GetNodesResourceInfo returns the capacity and usage of many nodes in one call; a node the plugin never saw is left out or empty.
 	GetNodesResourceInfo(ctx context.Context, nodenames []string) (*plugintypes.GetNodesResourceInfoResponse, error)
 
 	// SetNodeResourceInfo stores a node's capacity and usage as absolute values.

--- a/resource/plugins/types/node.go
+++ b/resource/plugins/types/node.go
@@ -19,9 +19,9 @@ type NodeDeployCapacity struct {
 	Capacity int `json:"capacity"`
 	// Usage is the used fraction of the node's total, 0..1
 	Usage float64 `json:"usage"`
-	// Rate proportion of requested resources to total
+	// Rate is the proportion of requested resources to the total
 	Rate float64 `json:"rate"`
-	// Weight used for weighted average
+	// Weight is the share of this plugin in the weighted average
 	Weight float64 `json:"weight"`
 }
 

--- a/strategy/fill.go
+++ b/strategy/fill.go
@@ -20,16 +20,15 @@ func FillPlan(_ context.Context, infos []Info, need, _, limit int) (map[string]i
 	slices.SortFunc(infos, func(a, b Info) int {
 		return cmp.Or(cmp.Compare(b.Count, a.Count), cmp.Compare(b.Capacity, a.Capacity))
 	})
-	deployMap, toDeploy, remain := make(map[string]int), 0, limit
+	deployMap, remain := make(map[string]int), limit
 	for _, info := range infos {
 		if info.Count+info.Capacity >= need {
-			if deploy := max(need-info.Count, 0); deploy > 0 {
+			if deploy := need - info.Count; deploy > 0 {
 				deployMap[info.Nodename] = deploy
-				toDeploy += deploy
 			}
 			remain--
 			if remain == 0 {
-				if toDeploy == 0 {
+				if len(deployMap) == 0 {
 					return deployMap, types.ErrAlreadyFilled
 				}
 				return deployMap, nil


### PR DESCRIPTION
## Fix (own commit, regression test in `TestGetNodesResourceInfo`)

`cpumem` read the requested nodes with one strict `GetMulti`, so a node whose record was gone (reachable after a crash between the plugin's and the store's `RemoveNode`) failed the whole listing's cpumem column; the read now falls back to one lookup per key and leaves the missing node out, which the interface already promised. Cobalt no longer seeds an entry for every requested node, so a node no plugin knows stays untouched instead of reading as zero, and it asks no plugin at all for an empty list, which spawned every binary plugin only to log an error on an empty or filtered pod.

## Review

The four `/simplify` lenses over the whole batch since the last style round, plus a style and a judge read of every file the batch changed (16 + 12 files, read in full). Applied:

- `ControlWorkload` dispatches through one verb table instead of an entry guard and a switch that repeated the list with a dead arm.
- `SetWorkloadsStatus` returns the metas it was given instead of an element-wise copy.
- cpumem plans capacity through one bounded loop (limit 1 unless `CPUBind`) instead of two copies of the loop, and decodes the plural read straight from the stored blob (one JSON pass instead of three, on every listing).
- `FillPlan` tests the map it builds instead of a running sum; the plugin cache is keyed once; the binary client leaves the verb check to `call`.
- The two engines' identical session drains become `sshrunner.Exited`, which `Stream` now shares.
- Binary request types name `NodeResourceRequest` where they carry one; three restating comments go, two field docs become sentences (comment delta +4 −7); the four repeated cpumem node tests are tables.

Rejected, with the reason recorded in the round ledger: `nodeErr` in realloc (the shadow form fails govet, the gate caught it once); `byLockOrder`'s prefix rank (derived from the same format that builds the keys); the single-include branch in `filterNodes` (20+ calcium tests pin `GetNode`); the fallback fan-out bound of 16 (lane A/B at 50 nodes: 619 vs 623 ms against the unbounded old path).

## Lines

Production −14 net, tests +72 net (the tables carry subtest names).

## Evidence

Gate on the branch: build, vet, full tests, `make lint`, `make fmt-check` and `asl` on both GOOS green.
