### PR TITLE
perf: list nodes for the metrics scrape without their resource info

### DIFF
--- a/cluster/calcium/node.go
+++ b/cluster/calcium/node.go
@@ -142,9 +142,11 @@ func (c *Calcium) ListPodNodes(ctx context.Context, opts *types.ListNodesOptions
 		logger.Error(ctx, err)
 		return nil, err
 	}
-	infos, err := c.rmgr.GetNodesResourceInfo(ctx, utils.Map(nodes, func(node *types.Node) string { return node.Name }))
-	if err != nil {
-		logger.Error(ctx, err, "failed to get nodes resource info")
+	var infos map[string]*types.NodeResourceInfo
+	if !opts.WithoutResourceInfo {
+		if infos, err = c.rmgr.GetNodesResourceInfo(ctx, utils.Map(nodes, func(node *types.Node) string { return node.Name })); err != nil {
+			logger.Error(ctx, err, "failed to get nodes resource info")
+		}
 	}
 	return perNode(c, nodes, func(node *types.Node, ch chan<- *types.Node) {
 		if info, ok := infos[node.Name]; ok {

--- a/cluster/calcium/node_test.go
+++ b/cluster/calcium/node_test.go
@@ -174,6 +174,13 @@ func TestListPodNodes(t *testing.T) {
 	}
 	assert.Equal(t, map[string]any{name1: 8, name2: nil}, listed)
 	rmgr.AssertExpectations(t)
+
+	opts.WithoutResourceInfo = true
+	ns, err = c.ListPodNodes(ctx, opts)
+	assert.NoError(t, err)
+	for range ns {
+	}
+	rmgr.AssertNumberOfCalls(t, "GetNodesResourceInfo", 2)
 	store.AssertExpectations(t)
 }
 

--- a/metrics/handler.go
+++ b/metrics/handler.go
@@ -20,7 +20,7 @@ func (m *Metrics) ResourceMiddleware(ctx context.Context, cluster cluster.Cluste
 			refreshed := scrapes.DoChan("refresh", func() (any, error) {
 				refreshCtx, cancel := context.WithTimeout(ctx, m.refreshTimeout)
 				defer cancel()
-				nodeCh, err := cluster.ListPodNodes(refreshCtx, &types.ListNodesOptions{All: true})
+				nodeCh, err := cluster.ListPodNodes(refreshCtx, &types.ListNodesOptions{All: true, WithoutResourceInfo: true})
 				if err != nil {
 					logger.Error(refreshCtx, err, "failed to list nodes")
 					return nil, err

--- a/metrics/handler_test.go
+++ b/metrics/handler_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestResourceMiddlewareRefreshesEveryNodeInOneCall(t *testing.T) {
 	cluster := &clustermocks.Cluster{}
-	cluster.On("ListPodNodes", mock.Anything, mock.Anything).Return(twoNodes(), nil).Once()
+	cluster.On("ListPodNodes", mock.Anything, mock.MatchedBy(func(opts *types.ListNodesOptions) bool { return opts.All && opts.WithoutResourceInfo })).Return(twoNodes(), nil).Once()
 	rmgr := &resourcemocks.Manager{}
 	rmgr.On("GetNodesMetrics", mock.Anything, mock.MatchedBy(func(nodes []*types.Node) bool { return len(nodes) == 2 })).Return(nil, nil).Once()
 

--- a/types/options.go
+++ b/types/options.go
@@ -34,10 +34,11 @@ type ListWorkloadsOptions struct {
 }
 
 type ListNodesOptions struct {
-	Podname  string
-	Labels   map[string]string
-	All      bool
-	CallInfo bool
+	Podname             string
+	Labels              map[string]string
+	All                 bool
+	CallInfo            bool
+	WithoutResourceInfo bool
 }
 
 type TriOptions int


### PR DESCRIPTION
## What

`ListNodesOptions` gains `WithoutResourceInfo`; `ListPodNodes` skips the plugin fan-out when it is set, and the metrics middleware lists with it. The scrape only needs each node's name and pod: the plugins read their own stores in `GetNodesMetrics`.

## Why

Listing with resource info asked every plugin for every node on each scrape and discarded the answer: two plugin processes per scrape with the plural verb, one per node per plugin without it.

## Evidence

`TestListPodNodes` pins that the manager is not called with the option set; `TestResourceMiddlewareRefreshesEveryNodeInOneCall` pins that the middleware passes it. Gate on the branch: build, vet, full tests, `make lint`, `make fmt-check` and `asl` on both GOOS green; comment delta +0 −0; production +11 −5.
