### PR TITLE
cut: drop the add-node response's usage

### DIFF
--- a/resource/plugins/cpumem/node.go
+++ b/resource/plugins/cpumem/node.go
@@ -81,10 +81,7 @@ func (p Plugin) AddNode(ctx context.Context, nodename string, resource plugintyp
 	}
 
 	resp := &plugintypes.AddNodeResponse{}
-	return resp, resourcetypes.Decode(map[string]any{
-		fieldCapacity: nodeResourceInfo.Capacity,
-		fieldUsage:    nodeResourceInfo.Usage,
-	}, resp)
+	return resp, resourcetypes.Decode(map[string]any{fieldCapacity: nodeResourceInfo.Capacity}, resp)
 }
 
 func (p Plugin) RemoveNode(ctx context.Context, nodename string) (*plugintypes.RemoveNodeResponse, error) {

--- a/resource/plugins/types/node.go
+++ b/resource/plugins/types/node.go
@@ -10,7 +10,6 @@ type NodeResource = resourcetypes.RawParams
 
 type AddNodeResponse struct {
 	Capacity NodeResource `json:"capacity"`
-	Usage    NodeResource `json:"usage"`
 }
 
 type RemoveNodeResponse struct{}


### PR DESCRIPTION
## What

`AddNodeResponse` loses its `Usage` field; cpumem stops filling it.

## Why

The field came with the 2023 plugin protocol as the pair of `capacity`, but cobalt reads only the capacity of a fresh node (`resource/cobalt/node.go`), calcium stores only that, and nothing ever sent a usage other than zero. A binary plugin that still emits `usage` is decoded without it, so plugin binaries built before this change keep working; resource-extend's matching PR stops sending it.

## Evidence

Gate on the branch: build, vet, full tests, `make lint`, `make fmt-check` and `asl` on both GOOS green; comment delta +0 −0; production −4.
